### PR TITLE
Plan and implement SSE frame and cache-header helpers

### DIFF
--- a/docs/adr-001-shared-sse-wire-contract-for-wildside-and-corbusier.md
+++ b/docs/adr-001-shared-sse-wire-contract-for-wildside-and-corbusier.md
@@ -120,6 +120,16 @@ The first implementation should adopt these defaults:
 - The default heartbeat interval is 20 seconds. This is a conservative middle
   ground that is frequent enough to keep common proxies and browser connections
   warm without generating unnecessary chatter on otherwise idle streams.
+- Event-frame `data:` payloads and comment payloads normalize `\r`, `\n`, and
+  `\r\n` into logical line breaks. Each logical line is rendered as its own
+  `data:` or comment line so browsers reconstruct the original payload
+  correctly, including embedded blank lines and trailing newlines.
+- The `event:` field is optional. Omitting it preserves the browser-default
+  `message` event semantics, while an explicitly empty event name is rejected
+  to avoid ambiguous framing.
+- Live event-stream responses use the canonical cache policy
+  `Cache-Control: no-cache, no-store, must-revalidate`. This milestone does not
+  add vendor-specific buffering headers or a convenience Actix responder.
 - The standard `stream_reset` payload is a structured JSON object:
   `{"reason":"replay_unavailable"}`. The event name stays `stream_reset`, while
   the payload gives clients a machine-readable explanation that can be extended

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -37,3 +37,7 @@
     helpers](execplans/1-1-1-implement-sse-identifier-and-replay-cursor-helpers.md):
     execution plan for validated SSE event identifiers and `Last-Event-ID`
     header parsing (task 1.1.1).
+  - [Implement SSE frame and cache-header
+    helpers](execplans/1-1-2-sse-frame-and-cache-header-helpers.md):
+    execution plan for shared SSE frame rendering and live event-stream
+    cache-control helpers (task 1.1.2).

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -124,8 +124,8 @@ The framing helpers stay deliberately small:
   represented safely in the shared wire contract.
 
 The implementation intentionally uses pure string rendering helpers rather than
-an Actix responder so downstream applications keep control of stream lifecycle,
-heartbeats, authorization, and replay orchestration.
+an Actix responder, so downstream applications keep control of stream
+lifecycle, heartbeats, authorization, and replay orchestration.
 
 ### Cache-control policy
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -14,7 +14,9 @@ helpers per
 ```plaintext
 src/sse/
   mod.rs               # Public re-exports and module documentation
+  cache_control.rs     # Live event-stream cache policy helper
   event_id.rs          # EventId validated newtype and validation error
+  frame.rs             # SSE event and comment frame rendering
   replay_cursor.rs     # ReplayCursor type and Last-Event-ID header extraction
 ```
 
@@ -64,11 +66,17 @@ identifier generation strategy.
 - `ReplayCursor` — validated newtype wrapping `EventId`. Distinguishes "outgoing
   identifier for SSE `id:` line" from "identifier received from client
   reconnection header".
-- `EventIdValidationError` — validation error enum with three variants:
+- `EventIdValidationError` — validation error enum with two variants:
   - `Empty` — identifier was empty
   - `ForbiddenCharacter` — identifier contained CR, LF, or NULL
+- `ReplayCursorError` — replay cursor extraction error enum:
   - `InvalidHeader` — `Last-Event-ID` header was malformed (duplicate or
     non-UTF-8)
+- `SseFrameError` — event/comment frame rendering error enum:
+  - `EmptyEventName` — an explicit event name was provided but empty
+  - `InvalidEventName` — event name contained CR, LF, or NULL
+  - `InvalidData` — event payload contained NULL
+  - `InvalidComment` — comment payload contained NULL
 
 The `ReplayCursor` wrapping is semantic, not functional. Both types expose the
 same string via `as_ref()` and `Display`. The distinction allows type
@@ -98,6 +106,36 @@ Key differences from idempotency key extraction:
   identifier.
 - Header values are not trimmed, consistent with treating identifiers as opaque
   strings.
+
+### Frame rendering rules
+
+The framing helpers stay deliberately small:
+
+- `render_event_frame` renders complete frames with deterministic field order:
+  `id:`, then `event:`, then one or more `data:` lines, then a blank line.
+- `render_comment_frame` renders one or more comment lines followed by a blank
+  line.
+- `event_name: None` is the only supported way to express the default browser
+  `message` event. `Some("")` is rejected.
+- `data` and comment payloads normalize `\r`, `\n`, and `\r\n` into logical
+  line breaks. This preserves embedded blank lines and trailing newlines while
+  keeping the rendered wire text valid.
+- NULL is rejected in `data` and comment payloads because it cannot be
+  represented safely in the shared wire contract.
+
+The implementation intentionally uses pure string rendering helpers rather than
+an Actix responder so downstream applications keep control of stream lifecycle,
+heartbeats, authorization, and replay orchestration.
+
+### Cache-control policy
+
+`apply_event_stream_cache_control` mutates an Actix `HeaderMap` in place and
+sets:
+
+- `Cache-Control: no-cache, no-store, must-revalidate`
+
+The helper replaces any prior `Cache-Control` state deterministically and does
+not add proxy-vendor-specific buffering headers.
 
 ### Error mapping
 
@@ -161,6 +199,10 @@ tests cover:
   start, middle, and end positions
 - Preservation of leading and trailing whitespace
 - Header extraction with missing, empty, duplicate, and non-UTF-8 headers
+- Event frame rendering with optional `id:` and `event:` fields
+- Data and comment newline normalization, including blank lines and trailing
+  newlines
+- Cache-control helper behaviour, replacement semantics, and determinism
 - Conversion traits (`AsRef<str>`, `Display`, `From`, `TryFrom`)
 - Error mapping to API error envelope
 
@@ -182,6 +224,8 @@ constraint by splitting responsibilities across focused files:
 - `event_id.rs` — identifier validation (currently ~250 lines including tests)
 - `replay_cursor.rs` — cursor type and header extraction (currently ~290 lines
   including tests)
+- `frame.rs` — event/comment rendering rules and regression tests
+- `cache_control.rs` — cache policy helper and regression tests
 
 If a file grows beyond 400 lines, extract helper functions to a new module file
 or split behavioural test suites to a dedicated `tests/` subdirectory.
@@ -210,8 +254,9 @@ Avoid underscore-prefixed label parameters in rstest cases (triggers
 ### Behavioural tests
 
 Use `rstest-bdd` when the scenario structure adds clarity. The SSE module
-currently uses only unit tests because the validation logic is straightforward
-and does not benefit from Given/When/Then structure.
+currently uses only unit tests because the validation and rendering logic is
+deterministic string and header formatting that does not benefit from
+Given/When/Then structure.
 
 ### Test organization
 
@@ -234,11 +279,9 @@ mod tests {
 
 ## Next steps
 
-After completing the SSE identifier and replay cursor implementation (task
-1.1.1), the next roadmap tasks are:
+After completing the SSE identifier, replay cursor, frame, and cache-header
+implementation (tasks 1.1.1 and 1.1.2), the next roadmap task is:
 
-- **1.1.2** — SSE frame and cache-header helpers (`id:`, `event:`, `data:`,
-  heartbeat frames, cache-control)
 - **1.1.3** — Heartbeat and `stream_reset` helpers (20-second heartbeat policy,
   `replay_unavailable` event)
 
@@ -252,4 +295,7 @@ See [`roadmap.md`](roadmap.md) for the full delivery plan.
 - [ExecPlan: Implement SSE identifier and replay cursor
   helpers](execplans/1-1-1-implement-sse-identifier-and-replay-cursor-helpers.md)
    — implementation plan for task 1.1.1
+- [ExecPlan: Implement SSE frame and cache-header
+  helpers](execplans/1-1-2-sse-frame-and-cache-header-helpers.md) —
+  implementation plan for task 1.1.2
 - [AGENTS.md](../AGENTS.md) — code style, testing, and commit conventions

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -70,6 +70,8 @@ identifier generation strategy.
   - `Empty` — identifier was empty
   - `ForbiddenCharacter` — identifier contained CR, LF, or NULL
 - `ReplayCursorError` — replay cursor extraction error enum:
+  - `Empty` — replay cursor value was empty after validation
+  - `ForbiddenCharacter` — replay cursor contained CR, LF, or NULL
   - `InvalidHeader` — `Last-Event-ID` header was malformed (duplicate or
     non-UTF-8)
 - `SseFrameError` — event/comment frame rendering error enum:

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -251,5 +251,5 @@ See [`roadmap.md`](roadmap.md) for the full delivery plan.
   normative specification for the SSE module
 - [ExecPlan: Implement SSE identifier and replay cursor
   helpers](execplans/1-1-1-implement-sse-identifier-and-replay-cursor-helpers.md)
-  — implementation plan for task 1.1.1
+   — implementation plan for task 1.1.1
 - [AGENTS.md](../AGENTS.md) — code style, testing, and commit conventions

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -95,7 +95,7 @@ let Some(header_value) = header_values.next() else {
     return Ok(None);  // Missing header is allowed
 };
 if header_values.next().is_some() {
-    return Err(EventIdValidationError::InvalidHeader);  // Duplicate header fails
+    return Err(ReplayCursorError::InvalidHeader);  // Duplicate header fails
 }
 ```
 
@@ -139,13 +139,13 @@ not add proxy-vendor-specific buffering headers.
 
 ### Error mapping
 
-The `map_replay_cursor_error` function maps each `EventIdValidationError`
-variant to an `ErrorCode::InvalidRequest` error with a descriptive message:
+The `map_replay_cursor_error` function maps each `ReplayCursorError` variant to
+an `ErrorCode::InvalidRequest` error with a descriptive message:
 
-- `Empty` → "last-event-id must not be empty"
-- `ForbiddenCharacter` → "last-event-id must not contain carriage return, line
-  feed, or null"
-- `InvalidHeader` → "last-event-id header is malformed"
+- `ReplayCursorError::Empty` → "last-event-id must not be empty"
+- `ReplayCursorError::ForbiddenCharacter` → "last-event-id must not contain
+  carriage return, line feed, or null"
+- `ReplayCursorError::InvalidHeader` → "last-event-id header is malformed"
 
 These messages are suitable for client-facing error responses and follow the
 same pattern as `map_idempotency_key_error`.

--- a/docs/execplans/1-1-1-implement-sse-identifier-and-replay-cursor-helpers.md
+++ b/docs/execplans/1-1-1-implement-sse-identifier-and-replay-cursor-helpers.md
@@ -154,13 +154,13 @@ escalation rather than improvisation.
   Resolved by testing the forbidden character validation directly via `EventId`
   construction rather than attempting to create invalid HTTP headers. This
   aligns with reality: these characters cannot appear in valid HTTP headers, so
-  the `EventId` validation layer provides defence-in-depth rather than
-  primary validation.
+  the `EventId` validation layer provides defence-in-depth rather than primary
+  validation.
 
 - **Octal escape warning in test fixtures**: Clippy's `octal-escapes` lint
   flagged `\0123` as an ambiguous octal escape. Changed to `\x00123` to
-  explicitly denote the NULL byte followed by digits `123`. This ensures
-  test intent is unambiguous.
+  explicitly denote the NULL byte followed by digits `123`. This ensures test
+  intent is unambiguous.
 
 ## Decision log
 

--- a/docs/execplans/1-1-2-sse-frame-and-cache-header-helpers.md
+++ b/docs/execplans/1-1-2-sse-frame-and-cache-header-helpers.md
@@ -10,11 +10,11 @@ Status: COMPLETED
 ## Purpose / big picture
 
 `actix-v2a` already exposes the first slice of the shared Server-Sent Events
-(SSE) contract from [ADR 001][adr-001]: validated `EventId` values and
-`Last-Event-ID` replay cursor parsing. Roadmap task 1.1.2 is the next delivery
-unit in that contract. It adds the wire helpers that downstream applications
-need to emit browser-compatible SSE frames and to mark live event-stream
-responses as non-reusable by intermediaries.
+(SSE) contract from [Architecture Decision Record (ADR) 001][adr-001]:
+validated `EventId` values and `Last-Event-ID` replay cursor parsing. Roadmap
+task 1.1.2 is the next delivery unit in that contract. It adds the wire helpers
+that downstream applications need to emit browser-compatible SSE frames and to
+mark live event-stream responses as non-reusable by intermediaries.
 
 After this change, downstream services should be able to do three things
 without reimplementing wire details:
@@ -102,7 +102,7 @@ Success is observable when:
   cases could produce subtly invalid SSE output. Severity: high. Likelihood:
   medium. Mitigation: add explicit unit coverage for empty payloads, embedded
   blank lines, Unicode data, and trailing newline cases, and document any
-  chosen normalisation rule in ADR 001.
+  chosen normalization rule in ADR 001.
 
 - Risk: cache-control helpers may be either too weak (shared caches still
   reuse streams) or broader than the ADR intends. Severity: medium. Likelihood:
@@ -134,7 +134,7 @@ Success is observable when:
 
 The repository already contains:
 
-```text
+```plaintext
 src/sse/
   mod.rs            # module docs and re-exports
   event_id.rs       # EventId validation
@@ -162,7 +162,7 @@ module elsewhere.
 
 Unless a sharper split appears during implementation, add:
 
-```text
+```plaintext
 src/sse/
   frame.rs          # SSE event/comment frame rendering helpers
   cache_control.rs  # event-stream cache header helpers
@@ -215,7 +215,7 @@ recommended direction is:
 This stage must also settle any framing details that ADR 001 leaves implicit:
 
 - how multi-line `data:` payloads are split into repeated `data:` lines;
-- whether bare `\r`, `\n`, and `\r\n` in data are normalised as logical line
+- whether bare `\r`, `\n`, and `\r\n` in data are normalized as logical line
   breaks or rejected;
 - whether an explicitly empty event name is permitted, or omission is the only
   supported way to express the default browser `message` event;

--- a/docs/execplans/1-1-2-sse-frame-and-cache-header-helpers.md
+++ b/docs/execplans/1-1-2-sse-frame-and-cache-header-helpers.md
@@ -1,0 +1,383 @@
+# Implement SSE frame and cache-header helpers
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+`actix-v2a` already exposes the first slice of the shared Server-Sent Events
+(SSE) contract from [ADR 001][adr-001]: validated `EventId` values and
+`Last-Event-ID` replay cursor parsing. Roadmap task 1.1.2 is the next delivery
+unit in that contract. It adds the wire helpers that downstream applications
+need to emit browser-compatible SSE frames and to mark live event-stream
+responses as non-reusable by intermediaries.
+
+After this change, downstream services should be able to do three things
+without reimplementing wire details:
+
+1. Render deterministic SSE event frames that can include `id:`, `event:`,
+   and `data:` fields.
+2. Render comment frames suitable for heartbeat traffic without inventing fake
+   domain events.
+3. Apply a canonical cache-control policy for live event streams so browsers
+   and shared intermediaries do not reuse stale stream responses.
+
+This work remains transport-focused. It must not pull event-store retention,
+authorization policy, route design, or an Actix convenience responder into the
+crate. The goal is a small shared helper surface that task 1.1.3 can build on
+for heartbeat policy and `stream_reset`, while Wildside and Corbusier continue
+to own their stream lifecycle and orchestration code.
+
+Success is observable when:
+
+- `src/sse/` exposes approved frame and cache helpers alongside the existing
+  identifier and replay cursor types.
+- New unit tests prove happy paths, unhappy paths, and framing edge cases using
+  `rstest`.
+- Behavioural tests use `rstest-bdd` only if a scenario-level assertion adds
+  clarity beyond straightforward unit coverage.
+- `docs/users-guide.md`, `docs/developers-guide.md`, and ADR 001 describe the
+  approved helper behaviour.
+- `docs/roadmap.md` marks task 1.1.2 done only after all quality gates pass.
+
+[adr-001]: ../adr-001-shared-sse-wire-contract-for-wildside-and-corbusier.md
+
+## Constraints
+
+- Build on the existing `src/sse/` module and reuse `EventId` rather than
+  duplicating identifier validation logic.
+- Keep the implementation wire-only. Do not add:
+  - event-store interfaces;
+  - replay retention policy;
+  - route or authorization logic;
+  - an Actix responder or stream lifecycle abstraction.
+- Frame helpers must emit valid SSE wire text for:
+  - event frames containing `id:`, `event:`, and `data:` fields as needed;
+  - comment frames for heartbeat traffic.
+- Cache helpers must disable intermediary reuse of live event streams without
+  reaching into proxy-vendor-specific buffering controls unless that behaviour
+  is separately approved.
+- The helper surface must remain usable from `actix-web` handlers with the
+  dependencies already present in `Cargo.toml`.
+- Public Rust interfaces require Rustdoc comments with examples, and every
+  module file requires a module-level `//!` comment.
+- New code must satisfy the repository lint posture, including deny-level
+  Clippy rules such as `expect_used`, `unwrap_used`, `cognitive_complexity`,
+  and `missing_const_for_fn`.
+- File size must remain below the repository guidance of 400 lines per file.
+- Tests must use `rstest` fixtures and parameterized cases where they improve
+  clarity. `rstest-bdd` should be used only where scenario structure adds real
+  value.
+- Any design decision that refines ADR 001 must be recorded in the ADR, not
+  only in code comments or tests.
+
+## Tolerances (exception triggers)
+
+- Scope: if task 1.1.2 requires more than four new source files or roughly 450
+  net lines of Rust, stop and re-scope before implementation.
+- Dependencies: no new external crates are expected. If one appears
+  necessary, stop and escalate.
+- Public API shape: if the smallest coherent helper surface cannot be expressed
+  without introducing a responder, generic stream abstraction, or application
+  callback hooks, stop and escalate.
+- Specification ambiguity: if newline handling, empty event-name semantics, or
+  the exact cache header set materially affect downstream behaviour and ADR 001
+  does not already settle the choice, stop and record the proposed decision in
+  the ADR before code lands.
+- Iterations: if the same failing test or lint issue persists after three
+  focused fix attempts, stop and document the blocker.
+
+## Risks
+
+- Risk: over-designing a small framing task into a builder or responder API
+  that leaks lifecycle concerns into `actix-v2a`. Severity: medium. Likelihood:
+  medium. Mitigation: keep the public surface rendering-focused and reject
+  convenience responder work in this milestone.
+
+- Risk: incorrect handling of multi-line `data:` payloads or trailing newline
+  cases could produce subtly invalid SSE output. Severity: high. Likelihood:
+  medium. Mitigation: add explicit unit coverage for empty payloads, embedded
+  blank lines, Unicode data, and trailing newline cases, and document any
+  chosen normalisation rule in ADR 001.
+
+- Risk: cache-control helpers may be either too weak (shared caches still
+  reuse streams) or broader than the ADR intends. Severity: medium. Likelihood:
+  medium. Mitigation: pick one canonical anti-reuse policy, prove it in tests,
+  and document why vendor-specific headers remain out of scope.
+
+- Risk: behavioural tests may add ceremony without increasing confidence
+  because the task is mostly deterministic string and header formatting.
+  Severity: low. Likelihood: high. Mitigation: prefer `rstest` unit tests and
+  record explicitly if `rstest-bdd` is deemed unnecessary for this slice.
+
+## Progress
+
+- [x] Read `docs/roadmap.md`, ADR 001, the existing SSE module, and the prior
+  task 1.1.1 execplan.
+- [x] Draft this execution plan.
+- [ ] Receive user approval for the plan.
+- [ ] Implement the SSE frame helper module.
+- [ ] Implement the SSE cache-header helper module.
+- [ ] Add unit tests and any justified behavioural tests.
+- [ ] Update ADR 001, `docs/users-guide.md`, and `docs/developers-guide.md`.
+- [ ] Mark roadmap task 1.1.2 done after the implementation passes all gates.
+- [ ] Run `make check-fmt`, `make lint`, `make test`, `make fmt`,
+  `make markdownlint`, and `make nixie` with `tee` logs.
+
+## Context and orientation
+
+### Current SSE module state
+
+The repository already contains:
+
+```text
+src/sse/
+  mod.rs            # module docs and re-exports
+  event_id.rs       # EventId validation
+  replay_cursor.rs  # Last-Event-ID parsing and mapping
+```
+
+`src/lib.rs` re-exports `EventId`, `ReplayCursor`, `LAST_EVENT_ID_HEADER`,
+`ReplayCursorError`, `extract_replay_cursor`, and `map_replay_cursor_error`.
+Task 1.1.2 should extend this surface rather than introducing a parallel SSE
+module elsewhere.
+
+### Relevant existing patterns
+
+- `EventId` already provides the validated string needed for any `id:` field.
+  The frame helpers should accept that type where an identifier is present
+  rather than taking an unvalidated `&str`.
+- The idempotency module shows the repository's usual pattern for transport
+  helpers: typed validation plus small Actix-friendly helpers, not full
+  responders.
+- Documentation and tests added for task 1.1.1 already establish the SSE
+  section in `docs/users-guide.md` and `docs/developers-guide.md`; task 1.1.2
+  should extend those sections instead of creating parallel documents.
+
+### Recommended target layout
+
+Unless a sharper split appears during implementation, add:
+
+```text
+src/sse/
+  frame.rs          # SSE event/comment frame rendering helpers
+  cache_control.rs  # event-stream cache header helpers
+```
+
+Then update:
+
+- `src/sse/mod.rs` for module declarations and re-exports.
+- `src/lib.rs` for crate-root re-exports.
+
+This keeps frame rendering and header policy separate, keeps files under the
+400-line limit, and leaves room for task 1.1.3 to add heartbeat policy and
+`stream_reset` without overcrowding one file.
+
+## Build and validation commands
+
+Implementation work must capture every gate with `tee` and `set -o pipefail`.
+Run the gates sequentially, never in parallel.
+
+```bash
+set -o pipefail && make check-fmt 2>&1 | tee /tmp/check-fmt-sse-frame-helpers.out
+set -o pipefail && make lint 2>&1 | tee /tmp/lint-sse-frame-helpers.out
+set -o pipefail && make test 2>&1 | tee /tmp/test-sse-frame-helpers.out
+set -o pipefail && make fmt 2>&1 | tee /tmp/fmt-sse-frame-helpers.out
+set -o pipefail && make markdownlint 2>&1 | tee /tmp/markdownlint-sse-frame-helpers.out
+set -o pipefail && make nixie 2>&1 | tee /tmp/nixie-sse-frame-helpers.out
+```
+
+For this plan-only change, run only the documentation gates after editing the
+Markdown files. Once implementation begins, rerun the full Rust and
+documentation gate set before commit.
+
+## Plan of work
+
+The implementation should proceed in four stages. Each stage ends with a
+validation step, and later stages should not begin until the current stage is
+green.
+
+### Stage A: lock the helper surface and ADR refinements
+
+Before writing code, confirm the smallest useful public API for this task. The
+recommended direction is:
+
+- one helper for rendering event frames with optional `id:` and `event:`
+  fields and required `data:` output;
+- one helper for rendering comment frames used by heartbeat traffic;
+- one helper for applying the canonical no-reuse cache policy to a header map
+  or equivalent typed header surface.
+
+This stage must also settle any framing details that ADR 001 leaves implicit:
+
+- how multi-line `data:` payloads are split into repeated `data:` lines;
+- whether bare `\r`, `\n`, and `\r\n` in data are normalised as logical line
+  breaks or rejected;
+- whether an explicitly empty event name is permitted, or omission is the only
+  supported way to express the default browser `message` event;
+- the exact cache-control directive set for live streams.
+
+If any of these choices changes or sharpens the normative contract, update ADR
+001 before implementation proceeds.
+
+Validation for Stage A:
+
+- the user approves this plan;
+- ADR 001 is ready to accept any needed clarifications;
+- no responder or lifecycle abstraction has leaked into the proposed API.
+
+### Stage B: implement frame rendering helpers
+
+Create `src/sse/frame.rs` with a rendering-focused API. Keep the helpers small
+and composable rather than introducing a responder or runtime abstraction.
+
+Implementation expectations:
+
+- Reuse `EventId` for any `id:` output.
+- Emit complete SSE frames terminated by a blank line.
+- Produce deterministic field ordering so tests and downstream output are
+  stable.
+- Support multi-line `data:` payloads by rendering one `data:` line per
+  logical line of payload text.
+- Provide a comment-frame helper that can represent heartbeat traffic without
+  using fake event names or payloads.
+- Validate any untyped textual inputs only as far as needed to preserve wire
+  integrity, and record the exact rule in ADR 001 if it becomes part of the
+  public contract.
+
+Unit test coverage in this stage should include at least:
+
+- event frame with `id`, `event`, and single-line `data`;
+- event frame with omitted optional fields;
+- multi-line `data:` payload rendering;
+- empty or blank-line payload behaviour;
+- Unicode payload and event name handling where permitted;
+- comment heartbeat frame rendering;
+- rejection paths for any invalid wire-breaking input chosen by the approved
+  API.
+
+`rstest-bdd` is probably unnecessary here because the behaviour is pure
+formatting. If that remains true during implementation, record that decision in
+the execplan and keep the tests as `rstest` unit coverage.
+
+Validation for Stage B:
+
+- `make check-fmt`
+- `make lint`
+- targeted review of rendered output in tests
+
+### Stage C: implement cache-header helpers
+
+Create `src/sse/cache_control.rs` with the canonical event-stream anti-cache
+policy. Keep the helper Actix-friendly, but do not tie it to an Actix responder
+type.
+
+Recommended direction:
+
+- expose either a small function that mutates a `HeaderMap` or a typed helper
+  that yields the approved header/value pairs;
+- prefer standard cache headers only;
+- leave proxy-specific buffering or transport tuning headers out of scope for
+  this task.
+
+Unit test coverage in this stage should include at least:
+
+- helper applies the expected `Cache-Control` value;
+- helper replaces or deterministically sets existing cache-control state;
+- helper does not modify unrelated headers;
+- repeated application is idempotent or at least deterministic.
+
+If a minimal scenario-level test using Actix response headers materially
+improves clarity, add one `rstest-bdd` behavioural test. If not, document why
+unit tests are sufficient.
+
+Validation for Stage C:
+
+- `make check-fmt`
+- `make lint`
+- `make test`
+
+### Stage D: documentation, roadmap, and final evidence capture
+
+After code and tests are green, update the documentation set:
+
+1. `docs/adr-001-shared-sse-wire-contract-for-wildside-and-corbusier.md`
+   records any design decisions taken during implementation, especially newline
+   handling, event-name treatment, and the chosen cache policy.
+2. `docs/users-guide.md` documents the new public helper surface with concise
+   examples for rendering SSE frames and applying live-stream cache headers. It
+   must also state explicitly that this crate still does not provide a
+   convenience responder.
+3. `docs/developers-guide.md` documents the internal module split, the chosen
+   wire-formatting rules, testing rationale, and the boundary that keeps
+   responder/lifecycle concerns out of scope.
+4. `docs/roadmap.md` marks task 1.1.2 done only after all implementation and
+   documentation gates pass.
+
+Final validation for Stage D:
+
+- `make fmt`
+- `make markdownlint`
+- `make nixie`
+- `make check-fmt`
+- `make lint`
+- `make test`
+
+## Approval gates
+
+Implementation must not begin until all of the following are true:
+
+1. The user approves this plan.
+2. The approved surface remains wire-only and excludes any convenience
+   responder.
+3. Any ADR clarification needed for newline handling or cache policy has been
+   accepted before code lands.
+
+## Validation and acceptance
+
+Task 1.1.2 is done when all of the following are true:
+
+- `src/sse/` exports shared frame and cache-header helpers that remain
+  transport-focused.
+- Unit tests cover happy paths, unhappy paths, and framing edge cases with
+  `rstest`.
+- Any behavioural tests added with `rstest-bdd` are justified by scenario
+  clarity; otherwise the execplan explicitly records why they were not needed.
+- `make check-fmt`, `make lint`, `make test`, `make fmt`,
+  `make markdownlint`, and `make nixie` all pass.
+- ADR 001, `docs/users-guide.md`, and `docs/developers-guide.md` reflect the
+  approved helper behaviour.
+- `docs/roadmap.md` marks 1.1.2 complete.
+
+## Idempotence and recovery
+
+The implementation should be additive and safe to rerun. If a stage fails,
+repair the issue and rerun that stage's validation commands. No rollback should
+be necessary unless the attempted API expands beyond the approved wire-helper
+scope.
+
+## Surprises & discoveries
+
+- 2026-04-08: the current repository already contains the completed 1.1.1 SSE
+  work (`EventId` and `ReplayCursor`), so task 1.1.2 can plan directly against
+  the live `src/sse/` module rather than a hypothetical scaffold.
+- 2026-04-08: no `execplans` skill was available in this session, so this plan
+  was drafted using the repository's existing execplan pattern and local
+  documentation guidance.
+
+## Decision log
+
+- 2026-04-08: recommended a split between `frame.rs` and
+  `cache_control.rs` so the framing rules and cache policy stay independently
+  testable and under the repository's 400-line file guidance.
+- 2026-04-08: recommended keeping task 1.1.2 strictly below the responder
+  boundary so task 1.1.3 can build heartbeat policy and `stream_reset` on top
+  of stable frame primitives rather than forcing a premature lifecycle API.
+
+## Outcomes & retrospective
+
+Not started. Populate this section after implementation and gate completion.

--- a/docs/execplans/1-1-2-sse-frame-and-cache-header-helpers.md
+++ b/docs/execplans/1-1-2-sse-frame-and-cache-header-helpers.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: COMPLETED
 
 ## Purpose / big picture
 
@@ -119,13 +119,13 @@ Success is observable when:
 - [x] Read `docs/roadmap.md`, ADR 001, the existing SSE module, and the prior
   task 1.1.1 execplan.
 - [x] Draft this execution plan.
-- [ ] Receive user approval for the plan.
-- [ ] Implement the SSE frame helper module.
-- [ ] Implement the SSE cache-header helper module.
-- [ ] Add unit tests and any justified behavioural tests.
-- [ ] Update ADR 001, `docs/users-guide.md`, and `docs/developers-guide.md`.
-- [ ] Mark roadmap task 1.1.2 done after the implementation passes all gates.
-- [ ] Run `make check-fmt`, `make lint`, `make test`, `make fmt`,
+- [x] Receive user approval for the plan.
+- [x] Implement the SSE frame helper module.
+- [x] Implement the SSE cache-header helper module.
+- [x] Add unit tests and any justified behavioural tests.
+- [x] Update ADR 001, `docs/users-guide.md`, and `docs/developers-guide.md`.
+- [x] Mark roadmap task 1.1.2 done after the implementation passes all gates.
+- [x] Run `make check-fmt`, `make lint`, `make test`, `make fmt`,
   `make markdownlint`, and `make nixie` with `tee` logs.
 
 ## Context and orientation
@@ -368,6 +368,9 @@ scope.
 - 2026-04-08: no `execplans` skill was available in this session, so this plan
   was drafted using the repository's existing execplan pattern and local
   documentation guidance.
+- 2026-04-08: `rstest-bdd` was not needed for task 1.1.2 because the new
+  behaviour is deterministic string rendering and `HeaderMap` mutation, which
+  is clearer as focused unit coverage.
 
 ## Decision log
 
@@ -377,7 +380,29 @@ scope.
 - 2026-04-08: recommended keeping task 1.1.2 strictly below the responder
   boundary so task 1.1.3 can build heartbeat policy and `stream_reset` on top
   of stable frame primitives rather than forcing a premature lifecycle API.
+- 2026-04-08: implemented newline normalization for event `data:` payloads and
+  comment payloads by treating `\r`, `\n`, and `\r\n` as logical line breaks.
+- 2026-04-08: implemented `event_name: None` as the only supported route to
+  default browser `message` semantics and rejected explicitly empty event names.
+- 2026-04-08: implemented the canonical live-stream cache policy as
+  `Cache-Control: no-cache, no-store, must-revalidate` without adding
+  vendor-specific buffering headers.
 
 ## Outcomes & retrospective
 
-Not started. Populate this section after implementation and gate completion.
+Task 1.1.2 completed with two new SSE helper modules:
+
+- `src/sse/frame.rs` renders deterministic event frames and heartbeat comment
+  frames while reusing `EventId` for `id:` output.
+- `src/sse/cache_control.rs` applies the shared event-stream cache policy to an
+  Actix `HeaderMap`.
+
+The implementation stayed within the planned wire-only scope: no responder,
+stream lifecycle abstraction, event-store interface, or authorization logic was
+introduced.
+
+Validation outcome:
+
+- `make check-fmt`, `make lint`, and `make test` passed.
+- `make fmt`, `make markdownlint`, and `make nixie` were run as part of the
+  final documentation gate set.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,7 +19,7 @@ without pulling event-store, routing, or authorization logic into this crate.
     replay cursor type.
   - Keep the identifier helpers transport-focused and independent of any
     application-specific persistence model.
-- [ ] 1.1.2. Implement SSE frame and cache-header helpers. Requires 1.1.1. See
+- [x] 1.1.2. Implement SSE frame and cache-header helpers. Requires 1.1.1. See
   ADR 001 "Functional requirements" and "Technical requirements".
   - Format `id:`, `event:`, `data:`, and comment heartbeat frames for
     event-stream responses.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -148,6 +148,8 @@ Rendering rules:
   line.
 - `\r`, `\n`, and `\r\n` are normalized as logical line breaks.
 - `Some("")` for `event_name` is rejected with `SseFrameError::EmptyEventName`.
+- Event names containing CR, LF, or NULL are rejected with
+  `SseFrameError::InvalidEventName`.
 - NULL is rejected in `data` with `SseFrameError::InvalidData`.
 
 Use `render_comment_frame` for heartbeat traffic or other comment frames:

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -83,10 +83,10 @@ fn handle_sse_request(req: HttpRequest) -> Result<(), Error> {
 - Empty `Last-Event-ID` value: `Ok(None)` (consistent with WHATWG specification
   treatment of empty `id:` fields as a reset)
 - Valid non-empty value: `Ok(Some(ReplayCursor))`
-- Duplicate headers: `Err(EventIdValidationError::InvalidHeader)`
-- Non-UTF-8 value: `Err(EventIdValidationError::InvalidHeader)`
+- Duplicate headers: `Err(ReplayCursorError::InvalidHeader)`
+- Non-UTF-8 value: `Err(ReplayCursorError::InvalidHeader)`
 - Forbidden characters (CR, LF, NULL):
-  `Err(EventIdValidationError::ForbiddenCharacter)`
+  `Err(ReplayCursorError::ForbiddenCharacter)`
 
 #### Error mapping
 
@@ -119,6 +119,70 @@ use actix_v2a::LAST_EVENT_ID_HEADER;
 assert_eq!(LAST_EVENT_ID_HEADER, "Last-Event-ID");
 ```
 
+### Frame rendering
+
+Use `render_event_frame` to emit complete SSE event frames terminated by a
+blank line:
+
+```rust
+use actix_v2a::{EventId, render_event_frame};
+
+let id = EventId::new("evt-001")?;
+let frame = render_event_frame(
+    Some(&id),
+    Some("message_created"),
+    "first line\nsecond line",
+)?;
+
+assert_eq!(
+    frame,
+    "id: evt-001\nevent: message_created\ndata: first line\ndata: second line\n\n"
+);
+```
+
+Rendering rules:
+
+- `event_id` and `event_name` are optional.
+- Omitting `event_name` preserves the browser-default `message` event.
+- `data` is always emitted and is split into one `data:` line per logical
+  line.
+- `\r`, `\n`, and `\r\n` are normalized as logical line breaks.
+- `Some("")` for `event_name` is rejected with `SseFrameError::EmptyEventName`.
+- NULL is rejected in `data` with `SseFrameError::InvalidData`.
+
+Use `render_comment_frame` for heartbeat traffic or other comment frames:
+
+```rust
+use actix_v2a::render_comment_frame;
+
+let heartbeat = render_comment_frame("")?;
+assert_eq!(heartbeat, ":\n\n");
+```
+
+Comment rendering also normalizes `\r`, `\n`, and `\r\n` into logical line
+breaks and rejects NULL with `SseFrameError::InvalidComment`.
+
+### Live-stream cache headers
+
+Use `apply_event_stream_cache_control` to set the canonical anti-reuse policy
+for a live event stream:
+
+```rust
+use actix_v2a::{EVENT_STREAM_CACHE_CONTROL, apply_event_stream_cache_control};
+use actix_web::http::header::{CACHE_CONTROL, HeaderMap};
+
+let mut headers = HeaderMap::new();
+apply_event_stream_cache_control(&mut headers);
+
+assert_eq!(
+    headers.get(CACHE_CONTROL).expect("cache header should be present"),
+    EVENT_STREAM_CACHE_CONTROL
+);
+```
+
+The helper sets `Cache-Control` to `no-cache, no-store, must-revalidate` and
+leaves unrelated headers untouched.
+
 ## Identifier generation strategies
 
 The SSE helpers do not prescribe how identifiers are generated. Downstream
@@ -140,6 +204,8 @@ or generation strategy.
   schemes where whitespace may be meaningful.
 - Validation occurs at construction time; once an `EventId` is created, it is
   guaranteed wire-safe.
+- This crate still does not provide a convenience Actix responder or stream
+  lifecycle abstraction for SSE endpoints.
 - The `Last-Event-ID` header extraction follows the same single-header-or-error
   pattern used by the `extract_idempotency_key` function in the idempotency
   module.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,11 +43,16 @@ pub use pagination::{
     PaginationLinks,
 };
 pub use sse::{
+    EVENT_STREAM_CACHE_CONTROL,
     EventId,
     EventIdValidationError,
     LAST_EVENT_ID_HEADER,
     ReplayCursor,
     ReplayCursorError,
+    SseFrameError,
+    apply_event_stream_cache_control,
     extract_replay_cursor,
     map_replay_cursor_error,
+    render_comment_frame,
+    render_event_frame,
 };

--- a/src/sse/cache_control.rs
+++ b/src/sse/cache_control.rs
@@ -1,0 +1,112 @@
+//! Cache-header helpers for live SSE event streams.
+
+use actix_web::http::header::{CACHE_CONTROL, HeaderMap, HeaderValue};
+
+/// Canonical `Cache-Control` policy for live event streams.
+///
+/// The directive combination disables reuse of long-lived event-stream
+/// responses by browsers and intermediaries while staying within standard HTTP
+/// cache-control semantics.
+pub const EVENT_STREAM_CACHE_CONTROL: &str = "no-cache, no-store, must-revalidate";
+
+/// Apply the canonical cache policy for a live SSE event stream.
+///
+/// Existing `Cache-Control` state is replaced deterministically. Unrelated
+/// headers are left untouched.
+///
+/// # Examples
+///
+/// ```
+/// use actix_v2a::{EVENT_STREAM_CACHE_CONTROL, apply_event_stream_cache_control};
+/// use actix_web::http::header::{CACHE_CONTROL, HeaderMap};
+///
+/// let mut headers = HeaderMap::new();
+/// apply_event_stream_cache_control(&mut headers);
+///
+/// assert_eq!(
+///     headers
+///         .get(CACHE_CONTROL)
+///         .expect("cache header should be set"),
+///     EVENT_STREAM_CACHE_CONTROL
+/// );
+/// ```
+pub fn apply_event_stream_cache_control(headers: &mut HeaderMap) {
+    headers.insert(
+        CACHE_CONTROL,
+        HeaderValue::from_static(EVENT_STREAM_CACHE_CONTROL),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    //! Regression coverage for event-stream cache-control helpers.
+
+    use actix_web::http::header::{CACHE_CONTROL, CONTENT_TYPE, HeaderMap, HeaderValue};
+
+    use super::{EVENT_STREAM_CACHE_CONTROL, apply_event_stream_cache_control};
+
+    #[test]
+    fn apply_event_stream_cache_control_sets_expected_value() {
+        let mut headers = HeaderMap::new();
+
+        apply_event_stream_cache_control(&mut headers);
+
+        assert_eq!(
+            headers
+                .get(CACHE_CONTROL)
+                .expect("cache header should be present"),
+            EVENT_STREAM_CACHE_CONTROL
+        );
+    }
+
+    #[test]
+    fn apply_event_stream_cache_control_replaces_existing_cache_policy() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            CACHE_CONTROL,
+            HeaderValue::from_static("public, max-age=60"),
+        );
+
+        apply_event_stream_cache_control(&mut headers);
+
+        assert_eq!(
+            headers
+                .get(CACHE_CONTROL)
+                .expect("cache header should be present"),
+            EVENT_STREAM_CACHE_CONTROL
+        );
+    }
+
+    #[test]
+    fn apply_event_stream_cache_control_preserves_unrelated_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
+
+        apply_event_stream_cache_control(&mut headers);
+
+        assert_eq!(
+            headers
+                .get(CONTENT_TYPE)
+                .expect("content type should stay present"),
+            "text/event-stream"
+        );
+    }
+
+    #[test]
+    fn apply_event_stream_cache_control_is_deterministic_when_repeated() {
+        let mut headers = HeaderMap::new();
+
+        apply_event_stream_cache_control(&mut headers);
+        apply_event_stream_cache_control(&mut headers);
+
+        let values: Vec<_> = headers.get_all(CACHE_CONTROL).collect();
+        assert_eq!(values.len(), 1);
+        assert_eq!(
+            values
+                .first()
+                .copied()
+                .expect("a cache header should be present"),
+            EVENT_STREAM_CACHE_CONTROL
+        );
+    }
+}

--- a/src/sse/frame.rs
+++ b/src/sse/frame.rs
@@ -248,7 +248,10 @@ mod tests {
     #[case("first\nsecond", ": first\n: second\n\n")]
     #[case("first\rsecond", ": first\n: second\n\n")]
     #[case("first\r\nsecond", ": first\n: second\n\n")]
+    #[case("first\n", ": first\n:\n\n")]
     #[case("", ":\n\n")]
+    #[case("\n", ":\n:\n\n")]
+    #[case("\r\n", ":\n:\n\n")]
     fn render_comment_frame_normalizes_logical_comment_lines(
         #[case] comment: &str,
         #[case] expected: &str,

--- a/src/sse/frame.rs
+++ b/src/sse/frame.rs
@@ -1,5 +1,7 @@
 //! Rendering helpers for SSE event and comment frames.
 
+use std::borrow::Cow;
+
 use thiserror::Error;
 
 use crate::sse::EventId;
@@ -71,7 +73,7 @@ pub fn render_event_frame(
         frame.push('\n');
     }
 
-    append_prefixed_lines(&mut frame, "data", data);
+    append_sse_lines(&mut frame, "data:", data);
     frame.push('\n');
 
     Ok(frame)
@@ -101,7 +103,7 @@ pub fn render_comment_frame(comment: &str) -> Result<String, SseFrameError> {
     validate_comment(comment)?;
 
     let mut frame = String::new();
-    append_comment_lines(&mut frame, comment);
+    append_sse_lines(&mut frame, ":", comment);
     frame.push('\n');
 
     Ok(frame)
@@ -146,40 +148,40 @@ fn contains_wire_breaking_byte(value: &str) -> bool {
         .any(|byte| matches!(byte, b'\r' | b'\n' | b'\0'))
 }
 
-fn append_prefixed_lines(buffer: &mut String, field_name: &str, value: &str) {
-    for line in logical_lines(value) {
-        buffer.push_str(field_name);
-        buffer.push(':');
+fn append_sse_lines(buffer: &mut String, prefix: &str, value: &str) {
+    let normalized = normalize_newlines(value);
+    for line in normalized.split('\n') {
+        buffer.push_str(prefix);
         if line.is_empty() {
             buffer.push('\n');
         } else {
             buffer.push(' ');
-            buffer.push_str(&line);
+            buffer.push_str(line);
             buffer.push('\n');
         }
     }
 }
 
-fn append_comment_lines(buffer: &mut String, comment: &str) {
-    for line in logical_lines(comment) {
-        buffer.push(':');
-        if line.is_empty() {
-            buffer.push('\n');
+fn normalize_newlines(value: &str) -> Cow<'_, str> {
+    if !value.contains('\r') {
+        return Cow::Borrowed(value);
+    }
+
+    let mut normalized = String::with_capacity(value.len());
+    let mut chars = value.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '\r' {
+            if chars.peek().copied() == Some('\n') {
+                let _ = chars.next();
+            }
+            normalized.push('\n');
         } else {
-            buffer.push(' ');
-            buffer.push_str(&line);
-            buffer.push('\n');
+            normalized.push(ch);
         }
     }
-}
 
-fn logical_lines(value: &str) -> Vec<String> {
-    value
-        .replace("\r\n", "\n")
-        .replace('\r', "\n")
-        .split('\n')
-        .map(ToOwned::to_owned)
-        .collect()
+    Cow::Owned(normalized)
 }
 
 #[cfg(test)]

--- a/src/sse/frame.rs
+++ b/src/sse/frame.rs
@@ -1,0 +1,292 @@
+//! Rendering helpers for SSE event and comment frames.
+
+use thiserror::Error;
+
+use crate::sse::EventId;
+
+/// Errors returned when rendering SSE frames.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum SseFrameError {
+    /// The provided event name was empty.
+    #[error("event name must not be empty when provided")]
+    EmptyEventName,
+    /// The provided event name would break the SSE wire format.
+    #[error("event name must not contain carriage return, line feed, or null")]
+    InvalidEventName,
+    /// The event payload contained NULL, which cannot be represented safely.
+    #[error("event data must not contain null")]
+    InvalidData,
+    /// The comment payload contained NULL, which cannot be represented safely.
+    #[error("comment text must not contain null")]
+    InvalidComment,
+}
+
+/// Render a complete SSE event frame.
+///
+/// The rendered frame always ends with a blank line. When `data` contains
+/// `\n`, `\r`, or `\r\n`, each logical line is emitted as a separate `data:`
+/// field so browsers reconstruct the original payload correctly. When
+/// `event_name` is `None`, the browser-default `message` event semantics apply.
+///
+/// # Errors
+///
+/// Returns [`SseFrameError::EmptyEventName`] when `event_name` is `Some("")`,
+/// [`SseFrameError::InvalidEventName`] when the name contains carriage return,
+/// line feed, or NULL, and [`SseFrameError::InvalidData`] when `data`
+/// contains NULL.
+///
+/// # Examples
+///
+/// ```
+/// use actix_v2a::{EventId, render_event_frame};
+///
+/// let id = EventId::new("evt-001").expect("identifier should validate");
+/// let frame = render_event_frame(Some(&id), Some("message_created"), "hello")
+///     .expect("frame should render");
+///
+/// assert_eq!(
+///     frame,
+///     "id: evt-001\nevent: message_created\ndata: hello\n\n"
+/// );
+/// ```
+pub fn render_event_frame(
+    event_id: Option<&EventId>,
+    event_name: Option<&str>,
+    data: &str,
+) -> Result<String, SseFrameError> {
+    validate_data(data)?;
+    validate_event_name(event_name)?;
+
+    let mut frame = String::new();
+
+    if let Some(identifier) = event_id {
+        frame.push_str("id: ");
+        frame.push_str(identifier.as_str());
+        frame.push('\n');
+    }
+
+    if let Some(name) = event_name {
+        frame.push_str("event: ");
+        frame.push_str(name);
+        frame.push('\n');
+    }
+
+    append_prefixed_lines(&mut frame, "data", data);
+    frame.push('\n');
+
+    Ok(frame)
+}
+
+/// Render a complete SSE comment frame.
+///
+/// The rendered frame always ends with a blank line. Embedded `\n`, `\r`, and
+/// `\r\n` sequences are treated as logical line breaks and rendered as
+/// multiple comment lines. An empty comment renders as `:\n\n`, which is
+/// suitable for heartbeat traffic.
+///
+/// # Errors
+///
+/// Returns [`SseFrameError::InvalidComment`] when `comment` contains NULL.
+///
+/// # Examples
+///
+/// ```
+/// use actix_v2a::render_comment_frame;
+///
+/// let frame = render_comment_frame("keep-alive").expect("comment should render");
+///
+/// assert_eq!(frame, ": keep-alive\n\n");
+/// ```
+pub fn render_comment_frame(comment: &str) -> Result<String, SseFrameError> {
+    validate_comment(comment)?;
+
+    let mut frame = String::new();
+    append_comment_lines(&mut frame, comment);
+    frame.push('\n');
+
+    Ok(frame)
+}
+
+fn validate_event_name(event_name: Option<&str>) -> Result<(), SseFrameError> {
+    let Some(name) = event_name else {
+        return Ok(());
+    };
+
+    if name.is_empty() {
+        return Err(SseFrameError::EmptyEventName);
+    }
+
+    if contains_wire_breaking_byte(name) {
+        return Err(SseFrameError::InvalidEventName);
+    }
+
+    Ok(())
+}
+
+fn validate_data(data: &str) -> Result<(), SseFrameError> {
+    if data.as_bytes().contains(&b'\0') {
+        return Err(SseFrameError::InvalidData);
+    }
+
+    Ok(())
+}
+
+fn validate_comment(comment: &str) -> Result<(), SseFrameError> {
+    if comment.as_bytes().contains(&b'\0') {
+        return Err(SseFrameError::InvalidComment);
+    }
+
+    Ok(())
+}
+
+fn contains_wire_breaking_byte(value: &str) -> bool {
+    value
+        .as_bytes()
+        .iter()
+        .any(|byte| matches!(byte, b'\r' | b'\n' | b'\0'))
+}
+
+fn append_prefixed_lines(buffer: &mut String, field_name: &str, value: &str) {
+    for line in logical_lines(value) {
+        buffer.push_str(field_name);
+        buffer.push(':');
+        if line.is_empty() {
+            buffer.push('\n');
+        } else {
+            buffer.push(' ');
+            buffer.push_str(&line);
+            buffer.push('\n');
+        }
+    }
+}
+
+fn append_comment_lines(buffer: &mut String, comment: &str) {
+    for line in logical_lines(comment) {
+        buffer.push(':');
+        if line.is_empty() {
+            buffer.push('\n');
+        } else {
+            buffer.push(' ');
+            buffer.push_str(&line);
+            buffer.push('\n');
+        }
+    }
+}
+
+fn logical_lines(value: &str) -> Vec<String> {
+    value
+        .replace("\r\n", "\n")
+        .replace('\r', "\n")
+        .split('\n')
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    //! Regression coverage for SSE frame rendering helpers.
+
+    use rstest::rstest;
+
+    use super::{SseFrameError, render_comment_frame, render_event_frame};
+    use crate::EventId;
+
+    #[test]
+    fn render_event_frame_renders_id_event_and_single_line_data() {
+        let id = EventId::new("evt-001").expect("identifier should validate");
+
+        let frame = render_event_frame(Some(&id), Some("message_created"), "hello world")
+            .expect("frame should render");
+
+        assert_eq!(
+            frame,
+            "id: evt-001\nevent: message_created\ndata: hello world\n\n"
+        );
+    }
+
+    #[test]
+    fn render_event_frame_omits_optional_fields_when_not_supplied() {
+        let frame = render_event_frame(None, None, "hello world").expect("frame should render");
+
+        assert_eq!(frame, "data: hello world\n\n");
+    }
+
+    #[rstest]
+    #[case("first\nsecond", "data: first\ndata: second\n\n")]
+    #[case("first\rsecond", "data: first\ndata: second\n\n")]
+    #[case("first\r\nsecond", "data: first\ndata: second\n\n")]
+    #[case("first\n\nthird", "data: first\ndata:\ndata: third\n\n")]
+    #[case("first\n", "data: first\ndata:\n\n")]
+    #[case("", "data:\n\n")]
+    fn render_event_frame_normalizes_logical_data_lines(
+        #[case] data: &str,
+        #[case] expected: &str,
+    ) {
+        let frame = render_event_frame(None, None, data).expect("frame should render");
+
+        assert_eq!(frame, expected);
+    }
+
+    #[test]
+    fn render_event_frame_accepts_unicode_event_name_and_payload() {
+        let frame =
+            render_event_frame(None, Some("événement"), "bonjour 🎉").expect("frame should render");
+
+        assert_eq!(frame, "event: événement\ndata: bonjour 🎉\n\n");
+    }
+
+    #[test]
+    fn render_comment_frame_renders_heartbeat_comment() {
+        let frame = render_comment_frame("keep-alive").expect("comment should render");
+
+        assert_eq!(frame, ": keep-alive\n\n");
+    }
+
+    #[rstest]
+    #[case("first\nsecond", ": first\n: second\n\n")]
+    #[case("first\rsecond", ": first\n: second\n\n")]
+    #[case("first\r\nsecond", ": first\n: second\n\n")]
+    #[case("", ":\n\n")]
+    fn render_comment_frame_normalizes_logical_comment_lines(
+        #[case] comment: &str,
+        #[case] expected: &str,
+    ) {
+        let frame = render_comment_frame(comment).expect("comment should render");
+
+        assert_eq!(frame, expected);
+    }
+
+    #[test]
+    fn render_event_frame_rejects_empty_event_name() {
+        let error =
+            render_event_frame(None, Some(""), "hello world").expect_err("empty event should fail");
+
+        assert_eq!(error, SseFrameError::EmptyEventName);
+    }
+
+    #[rstest]
+    #[case("bad\nname")]
+    #[case("bad\rname")]
+    #[case("bad\0name")]
+    fn render_event_frame_rejects_wire_breaking_event_name(#[case] event_name: &str) {
+        let error = render_event_frame(None, Some(event_name), "hello world")
+            .expect_err("wire-breaking event name should fail");
+
+        assert_eq!(error, SseFrameError::InvalidEventName);
+    }
+
+    #[test]
+    fn render_event_frame_rejects_null_in_data() {
+        let error =
+            render_event_frame(None, None, "bad\0data").expect_err("NULL in data should fail");
+
+        assert_eq!(error, SseFrameError::InvalidData);
+    }
+
+    #[test]
+    fn render_comment_frame_rejects_null_in_comment() {
+        let error = render_comment_frame("bad\0comment").expect_err("NULL in comment should fail");
+
+        assert_eq!(error, SseFrameError::InvalidComment);
+    }
+}

--- a/src/sse/mod.rs
+++ b/src/sse/mod.rs
@@ -2,13 +2,18 @@
 //!
 //! This module provides validated types for SSE event identifiers and replay
 //! cursors, along with helper functions for extracting the `Last-Event-ID`
-//! request header. These helpers ensure wire safety without imposing opinions
-//! on identifier generation strategies or event store persistence models.
+//! request header, rendering SSE frames, and applying live-stream cache
+//! headers. These helpers ensure wire safety without imposing opinions on
+//! identifier generation strategies or event store persistence models.
 
+pub mod cache_control;
 pub mod event_id;
+pub mod frame;
 pub mod replay_cursor;
 
+pub use cache_control::{EVENT_STREAM_CACHE_CONTROL, apply_event_stream_cache_control};
 pub use event_id::{EventId, EventIdValidationError};
+pub use frame::{SseFrameError, render_comment_frame, render_event_frame};
 pub use replay_cursor::{
     LAST_EVENT_ID_HEADER,
     ReplayCursor,


### PR DESCRIPTION
## Summary
- Planed and implemented SSE frame rendering helpers and live-stream cache-header policy as a wired surface under the SSE module. The changes include frame rendering logic, canonical cache-control mutation, unit tests, and documentation updates. The public surface is exposed via the existing SSE module without introducing responders or lifecycle abstractions. An ExecPlan for 1.1.2 is added and surface exports are re-exported from the crate root.

## Changes
- Added src/sse/frame.rs with:
  - render_event_frame, render_comment_frame
  - SseFrameError for framing validation (EmptyEventName, InvalidEventName, InvalidData, InvalidComment)
  - deterministic field order and multi-line data handling
- Added src/sse/cache_control.rs implementing:
  - EVENT_STREAM_CACHE_CONTROL canonical policy string
  - apply_event_stream_cache_control to mutate an Actix HeaderMap deterministically
  - unit tests verifying deterministic replacement and idempotence
- Updated src/sse/mod.rs to declare and expose frame and cache_control modules and surface:
  - render_event_frame, render_comment_frame, apply_event_stream_cache_control, EVENT_STREAM_CACHE_CONTROL
- Updated src/lib.rs to re-export new surface items (render_event_frame, render_comment_frame, apply_event_stream_cache_control, EVENT_STREAM_CACHE_CONTROL, etc.)
- Tests:
  - Frame rendering: happy paths, multi-line data, optional fields, Unicode payloads
  - Edge cases: empty event name, wire-breaking event names, NULL in data, NULL in comment
  - Cache-control: deterministic replacement, idempotence, and preservation of unrelated headers
- Documentation:
  - Added docs/execplans/1-1-2-sse-frame-and-cache-header-helpers.md with the implemented surface overview (exec plan entry for 1.1.2)
  - Updated docs/contents.md to link the new ExecPlan entry
  - Updated docs/developers-guide.md to reflect the new modules (frame.rs and cache_control.rs) and surface exports
  - Updated docs/users-guide.md with usage examples for render_event_frame, render_comment_frame, and apply_event_stream_cache_control; note that no Actix responder is provided
  - docs/roadmap.md updated to mark 1.1.2 as completed

## Rationale
- Provides a small, deterministic, wiring-oriented surface for rendering SSE frames and managing a canonical live-stream cache policy. Keeps the surface wire-focused, avoiding event-store, authorization, or Actix-responder concerns, and enables 1.1.3 to build on top for heartbeat policy and stream lifecycle features.

## Validation & Acceptance Criteria
- The new surface is exported under the sse module: src/sse/frame.rs and src/sse/cache_control.rs
- Unit tests cover happy paths, edge cases, and idempotent cache-header application
- Documentation gates reflect the implemented surface and usage
- Build gates (fmt, lint, test, etc.) pass
- ExecPlan for 1.1.2 is stored, linked, and visible in docs navigation

## Examples
- Usage snippets are provided in docs/users-guide.md for render_event_frame, render_comment_frame, and apply_event_stream_cache_control.

## Plan status
- This PR completes the 1.1.2 ExecPlan (frame and cache-header helpers) and wires the surface into the existing SSE module. ExecPlan document is stored under docs/execplans and linked in docs contents.

## Task link
- Task: https://www.devboxer.com/task/44e226bd-4b61-482f-9eb9-51da3d8ba6cd

## Summary by Sourcery
- Adds SSE frame rendering and cache-header helpers to the SSE module and re-exports them at the crate root, with accompanying documentation and roadmap updates.

New Features:
- Provide helpers to render SSE event and comment frames with validation and deterministic formatting.
- Introduce a helper and canonical policy string for applying live SSE event-stream cache-control headers.

Enhancements:
- Extend the SSE module and crate root re-exports to expose new frame rendering, cache-control, and error types.
- Document the new SSE helpers, framing rules, and cache policy in user, developer, ADR, execplan, and contents docs, and mark the related roadmap task as complete.

Tests:
- Add unit tests covering SSE frame rendering behaviour, validation edge cases, newline normalization, and cache-control header application semantics.