### PR TITLE
Implement shared heartbeat and stream_reset helpers (1.1.3)

### DIFF
--- a/docs/adr-001-shared-sse-wire-contract-for-wildside-and-corbusier.md
+++ b/docs/adr-001-shared-sse-wire-contract-for-wildside-and-corbusier.md
@@ -120,6 +120,10 @@ The first implementation should adopt these defaults:
 - The default heartbeat interval is 20 seconds. This is a conservative middle
   ground that is frequent enough to keep common proxies and browser connections
   warm without generating unnecessary chatter on otherwise idle streams.
+- Heartbeat policy overrides are explicit and typed. The shared helper rejects
+  a zero-length interval because disabling heartbeats is application policy,
+  not a wire-helper concern, and a zero interval would not represent a useful
+  scheduling cadence.
 - Event-frame `data:` payloads and comment payloads normalize `\r`, `\n`, and
   `\r\n` into logical line breaks. Each logical line is rendered as its own
   `data:` or comment line so browsers reconstruct the original payload
@@ -134,6 +138,9 @@ The first implementation should adopt these defaults:
   `{"reason":"replay_unavailable"}`. The event name stays `stream_reset`, while
   the payload gives clients a machine-readable explanation that can be extended
   later without redefining the event itself.
+- The shared heartbeat and `stream_reset` helpers reuse the lower-level frame
+  rendering helpers. They standardize the wire contract without broadening the
+  crate into a generic application-event API or scheduler abstraction.
 - The first pass should expose wire helpers, header helpers, and framing
   helpers only. It should not add a convenience Actix responder until both
   applications demonstrate the same responder shape and lifecycle needs.

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -41,3 +41,7 @@
     helpers](execplans/1-1-2-sse-frame-and-cache-header-helpers.md):
     execution plan for shared SSE frame rendering and live event-stream
     cache-control helpers (task 1.1.2).
+  - [Implement shared heartbeat and `stream_reset`
+    helpers](execplans/1-1-3-shared-heartbeat-and-stream-reset-helpers.md):
+    execution plan for the shared 20-second heartbeat policy and standard
+    replay-reset SSE helper (task 1.1.3).

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -17,7 +17,9 @@ src/sse/
   cache_control.rs     # Live event-stream cache policy helper
   event_id.rs          # EventId validated newtype and validation error
   frame.rs             # SSE event and comment frame rendering
+  heartbeat.rs         # Heartbeat interval policy and canonical heartbeat frame
   replay_cursor.rs     # ReplayCursor type and Last-Event-ID header extraction
+  stream_reset.rs      # Standard replay-unavailable control event helper
 ```
 
 ### Validation strategy
@@ -79,6 +81,10 @@ identifier generation strategy.
   - `InvalidEventName` — event name contained CR, LF, or NULL
   - `InvalidData` — event payload contained NULL
   - `InvalidComment` — comment payload contained NULL
+- `HeartbeatPolicy` — typed heartbeat interval wrapper with a 20-second default
+  and explicit non-zero override path
+- `HeartbeatPolicyError` — heartbeat policy validation error enum:
+  - `ZeroInterval` — explicit override used `Duration::ZERO`
 
 The `ReplayCursor` wrapping is semantic, not functional. Both types expose the
 same string via `as_ref()` and `Display`. The distinction allows type
@@ -128,6 +134,23 @@ The framing helpers stay deliberately small:
 The implementation intentionally uses pure string rendering helpers rather than
 an Actix responder, so downstream applications keep control of stream
 lifecycle, heartbeats, authorization, and replay orchestration.
+
+### Heartbeat and stream-reset helpers
+
+Task 1.1.3 adds two higher-level helpers on top of `frame.rs`:
+
+- `render_heartbeat_frame` delegates to `render_comment_frame("")` so the
+  approved heartbeat frame stays aligned with the lower-level comment framing
+  rules.
+- `render_stream_reset_frame` delegates to `render_event_frame` with the fixed
+  event name `stream_reset` and the fixed payload
+  `{"reason":"replay_unavailable"}`.
+
+The heartbeat policy remains data-only. `HeartbeatPolicy::default()` exposes
+the ADR default of 20 seconds, while `HeartbeatPolicy::new` accepts explicit
+non-zero overrides and rejects `Duration::ZERO`. This keeps "disable
+heartbeats" outside the shared wire contract and avoids smuggling scheduler
+policy into the crate.
 
 ### Cache-control policy
 
@@ -205,6 +228,8 @@ tests cover:
 - Data and comment newline normalization, including blank lines and trailing
   newlines
 - Cache-control helper behaviour, replacement semantics, and determinism
+- Heartbeat policy defaults, override validation, and heartbeat frame output
+- Standard `stream_reset` event output and constant alignment
 - Conversion traits (`AsRef<str>`, `Display`, `From`, `TryFrom`)
 - Error mapping to API error envelope
 
@@ -281,11 +306,12 @@ mod tests {
 
 ## Next steps
 
-After completing the SSE identifier, replay cursor, frame, and cache-header
-implementation (tasks 1.1.1 and 1.1.2), the next roadmap task is:
+The initial SSE wire-helper milestone from roadmap tasks 1.1.1 through 1.1.3 is
+now complete:
 
-- **1.1.3** — Heartbeat and `stream_reset` helpers (20-second heartbeat policy,
-  `replay_unavailable` event)
+- validated event identifiers and replay cursors;
+- deterministic frame and cache-header helpers;
+- typed heartbeat policy plus canonical heartbeat and `stream_reset` helpers.
 
 See [`roadmap.md`](roadmap.md) for the full delivery plan.
 

--- a/docs/execplans/1-1-3-shared-heartbeat-and-stream-reset-helpers.md
+++ b/docs/execplans/1-1-3-shared-heartbeat-and-stream-reset-helpers.md
@@ -1,0 +1,399 @@
+# Implement shared heartbeat and stream_reset helpers
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: PENDING APPROVAL
+
+## Purpose / big picture
+
+`actix-v2a` already contains the first two slices of the shared Server-Sent
+Events (SSE) contract from [Architecture Decision Record (ADR) 001][adr-001]:
+validated event identifiers and replay cursors, plus shared frame-rendering and
+live-stream cache-control helpers. Roadmap task 1.1.3 is the next delivery unit
+in that contract. It adds the transport-level helpers that downstream
+applications need to keep idle SSE connections warm and to signal that replay
+can no longer resume from a supplied cursor.
+
+After this change, downstream services should be able to do three things
+without re-implementing small but important pieces of wire policy:
+
+1. Use one shared default heartbeat interval of 20 seconds.
+2. Override that interval explicitly when deployment conditions require a
+   different heartbeat cadence.
+3. Emit one standard `stream_reset` event whose payload is exactly
+   `{"reason":"replay_unavailable"}`.
+
+This work must remain wire-only. It must not pull timer scheduling, event-store
+retention policy, route design, responder lifecycle, or authorization logic
+into the crate. The goal is a narrow helper surface that composes with the
+existing frame helpers from task 1.1.2 while leaving applications in full
+control of when a heartbeat is sent and when replay is declared unavailable.
+
+Success is observable when:
+
+- `src/sse/` exports the approved heartbeat policy helper and a standard
+  `stream_reset` helper alongside the existing frame helpers.
+- The default heartbeat interval is 20 seconds and an explicit override path is
+  available through the public API.
+- The `stream_reset` helper emits the exact ADR-defined event name and payload
+  without introducing generic application-event helpers.
+- New unit tests cover happy paths, unhappy paths, and relevant edge cases
+  using `rstest`.
+- Behavioural tests use `rstest-bdd` only if a scenario-level assertion adds
+  clarity beyond straightforward unit coverage.
+- ADR 001, `docs/users-guide.md`, and `docs/developers-guide.md` describe the
+  approved helper behaviour.
+- `docs/roadmap.md` marks task 1.1.3 done only after all quality gates pass.
+
+[adr-001]: ../adr-001-shared-sse-wire-contract-for-wildside-and-corbusier.md
+
+## Constraints
+
+- Build on the existing `src/sse/` module and reuse the landed helpers from
+  tasks 1.1.1 and 1.1.2 instead of re-implementing framing rules.
+- Keep the implementation wire-only. Do not add:
+  - timer or scheduler ownership;
+  - async stream abstractions;
+  - event-store interfaces or retention policy;
+  - route or authorization logic;
+  - an Actix responder or connection-lifecycle abstraction.
+- Provide the ADR default heartbeat interval of 20 seconds and an explicit
+  override path in the public API.
+- Emit the standard `stream_reset` event with the exact event name
+  `stream_reset` and the exact payload `{"reason":"replay_unavailable"}`.
+- Keep application event names and payload schemata out of scope.
+- Prefer a small, typed helper surface over raw magic strings in downstream
+  code.
+- Public Rust interfaces require Rustdoc comments with examples, and every
+  module file requires a module-level `//!` comment.
+- New code must satisfy the repository lint posture, including deny-level
+  Clippy rules such as `expect_used`, `unwrap_used`, `missing_const_for_fn`,
+  and `cognitive_complexity`.
+- File size must remain below the repository guidance of 400 lines per file.
+- Tests must use `rstest` fixtures and parameterized cases where they improve
+  clarity. `rstest-bdd` should be used only where scenario structure adds real
+  value.
+- Any design decision that sharpens ADR 001 must be recorded in the ADR, not
+  only in code comments or tests.
+
+## Tolerances (exception triggers)
+
+- Scope: if task 1.1.3 requires more than four new source files or roughly 350
+  net lines of Rust, stop and re-scope before implementation.
+- Dependencies: no new external crates are expected. If one appears
+  necessary, stop and escalate.
+- Public API shape: if the smallest coherent helper surface cannot be
+  expressed without introducing a scheduler, responder, or application callback
+  hooks, stop and escalate.
+- Specification ambiguity: if the zero-duration override case, heartbeat frame
+  shape, or `stream_reset` helper signature materially affects downstream
+  behaviour and ADR 001 does not already settle the choice, stop and record the
+  proposed decision in the ADR before code lands.
+- Iterations: if the same failing test or lint issue persists after three
+  focused fix attempts, stop and document the blocker.
+
+## Risks
+
+- Risk: conflating a heartbeat policy helper with runtime scheduling could push
+  `actix-v2a` past the wire-helper boundary. Severity: high. Likelihood:
+  medium. Mitigation: keep the public surface limited to interval data and
+  rendering helpers only; do not add background-task or timer orchestration.
+
+- Risk: `stream_reset` could sprawl into a generic application-event builder,
+  which would violate the ADR's scope boundary. Severity: medium. Likelihood:
+  medium. Mitigation: expose only the fixed `stream_reset` event name and
+  payload defined by ADR 001.
+
+- Risk: the explicit override path may leave zero or otherwise degenerate
+  intervals underspecified. Severity: medium. Likelihood: medium. Mitigation:
+  settle the constructor semantics up front, document them in ADR 001 if they
+  become normative, and cover them with tests.
+
+- Risk: `rstest-bdd` may add ceremony without increasing confidence because the
+  feature is deterministic rendering plus interval validation. Severity: low.
+  Likelihood: high. Mitigation: prefer `rstest` unit tests and record
+  explicitly if behavioural coverage is unnecessary for this slice.
+
+## Progress
+
+- [x] Read `docs/roadmap.md`, ADR 001, the current SSE module, and the prior
+  execplans for tasks 1.1.1 and 1.1.2.
+- [x] Review the referenced testing and documentation guidance.
+- [x] Draft this execution plan.
+- [ ] Receive user approval for the plan.
+- [ ] Implement the heartbeat policy helper.
+- [ ] Implement the `stream_reset` helper.
+- [ ] Add unit tests and any justified behavioural tests.
+- [ ] Update ADR 001, `docs/users-guide.md`, and `docs/developers-guide.md`.
+- [ ] Mark roadmap task 1.1.3 done after the implementation passes all gates.
+- [ ] Run `make check-fmt`, `make lint`, `make test`, `make fmt`,
+  `make markdownlint`, and `make nixie` with `tee` logs for the implementation
+  change.
+
+## Context and orientation
+
+### Current SSE module state
+
+The repository already contains:
+
+```plaintext
+src/sse/
+  mod.rs            # module docs and re-exports
+  event_id.rs       # EventId validation
+  replay_cursor.rs  # Last-Event-ID parsing and mapping
+  frame.rs          # event and comment frame rendering
+  cache_control.rs  # live-stream cache policy helpers
+```
+
+`src/lib.rs` already re-exports the stable wire helpers. Task 1.1.3 should
+extend that surface rather than introducing a parallel SSE module elsewhere.
+
+### Relevant existing patterns
+
+- `render_comment_frame("")` already renders the canonical empty SSE comment
+  frame `:\n\n`. Task 1.1.3 should wrap or codify that output as the approved
+  heartbeat helper instead of inventing a second comment-rendering rule.
+- `render_event_frame` already handles deterministic field ordering and
+  newline-safe `data:` output. The `stream_reset` helper should build on that
+  primitive rather than formatting event frames manually.
+- `EventId` and `ReplayCursor` show the current pattern for transport-focused
+  SSE helpers: typed validation and small Actix-friendly utilities, not
+  responders or lifecycle abstractions.
+- The documentation set already has SSE sections in `docs/users-guide.md` and
+  `docs/developers-guide.md`. Task 1.1.3 should extend those sections rather
+  than creating parallel guides.
+
+### Recommended target layout
+
+Unless implementation reveals a simpler split, add:
+
+```plaintext
+src/sse/
+  heartbeat.rs      # heartbeat policy and canonical heartbeat frame helper
+  stream_reset.rs   # fixed replay-unavailable control event helper
+```
+
+Then update:
+
+- `src/sse/mod.rs` for module declarations and re-exports.
+- `src/lib.rs` for crate-root re-exports.
+
+This keeps heartbeat policy and replay-reset signalling independently testable,
+keeps files under the 400-line limit, and avoids overcrowding `frame.rs` with
+higher-level control-plane helpers.
+
+## Build and validation commands
+
+Implementation work must capture every gate with `tee` and `set -o pipefail`.
+Run the gates sequentially, never in parallel.
+
+```bash
+set -o pipefail && make check-fmt 2>&1 | tee /tmp/check-fmt-sse-heartbeat-stream-reset.out
+set -o pipefail && make lint 2>&1 | tee /tmp/lint-sse-heartbeat-stream-reset.out
+set -o pipefail && make test 2>&1 | tee /tmp/test-sse-heartbeat-stream-reset.out
+set -o pipefail && make fmt 2>&1 | tee /tmp/fmt-sse-heartbeat-stream-reset.out
+set -o pipefail && make markdownlint 2>&1 | tee /tmp/markdownlint-sse-heartbeat-stream-reset.out
+set -o pipefail && make nixie 2>&1 | tee /tmp/nixie-sse-heartbeat-stream-reset.out
+```
+
+For this plan-only change, run only the documentation gates after editing the
+Markdown files. Once implementation begins, rerun the full Rust and
+documentation gate set before commit.
+
+## Plan of work
+
+The implementation should proceed in four stages. Each stage ends with a
+validation step, and later stages should not begin until the current stage is
+green.
+
+### Stage A: lock the helper surface and any ADR refinements
+
+Before writing code, confirm the smallest useful public API for this task. The
+recommended direction is:
+
+- one default heartbeat interval constant set to 20 seconds;
+- one small typed heartbeat policy helper that supports explicit override;
+- one canonical heartbeat frame helper that emits the approved empty comment
+  frame without asking downstream code to call `render_comment_frame("")`
+  directly;
+- one fixed `stream_reset` helper that emits the standard event name and JSON
+  payload without exposing generic application-event wiring.
+
+This stage must also settle the few details ADR 001 leaves implicit:
+
+- whether the explicit override path rejects `Duration::ZERO`;
+- whether the heartbeat helper is entirely infallible or validates override
+  inputs through a small error type;
+- whether any public constants for the `stream_reset` event name or payload are
+  needed, or whether a rendering helper alone is the smallest coherent surface.
+
+If any of these choices changes or sharpens the normative contract, update ADR
+001 before implementation proceeds.
+
+Validation for Stage A:
+
+- the user approves this plan;
+- ADR 001 is ready to accept any needed clarifications;
+- no scheduler, responder, or lifecycle abstraction has leaked into the
+  proposed API.
+
+### Stage B: implement heartbeat policy and rendering helpers
+
+Create `src/sse/heartbeat.rs` with a narrow API that keeps policy data separate
+from runtime scheduling.
+
+Implementation expectations:
+
+- expose the ADR default heartbeat interval of 20 seconds;
+- provide an explicit override path through a small typed helper rather than
+  requiring downstream code to copy raw `Duration` literals;
+- keep scheduling responsibility with the application;
+- provide one canonical heartbeat frame helper that reuses the existing
+  comment-frame behaviour;
+- keep the helper surface deterministic and cheap to call.
+
+Unit test coverage in this stage should include at least:
+
+- the default interval is 20 seconds;
+- an explicit override is preserved exactly;
+- unhappy-path validation for any rejected override values, if the approved API
+  validates them;
+- the heartbeat helper emits the exact approved wire frame;
+- repeated rendering remains deterministic.
+
+`rstest-bdd` is probably unnecessary here because the behaviour is interval
+data plus deterministic frame output. If that remains true during
+implementation, record that decision in the execplan and keep the tests as
+`rstest` unit coverage.
+
+Validation for Stage B:
+
+- `make check-fmt`
+- `make lint`
+- targeted review of rendered output in tests
+
+### Stage C: implement the fixed stream_reset helper
+
+Create `src/sse/stream_reset.rs` as a narrow helper for the replay-unavailable
+control event.
+
+Implementation expectations:
+
+- reuse `render_event_frame` rather than formatting SSE event text manually;
+- emit the exact event name `stream_reset`;
+- emit the exact JSON payload `{"reason":"replay_unavailable"}`;
+- avoid adding any generic event-name or arbitrary JSON-payload helper for
+  applications.
+
+Unit test coverage in this stage should include at least:
+
+- the helper renders the exact expected frame;
+- the output is deterministic across repeated calls;
+- any public constants added for the event name or payload remain aligned with
+  the rendered frame.
+
+If a minimal scenario-level test for "replay cannot resume, so the helper emits
+the standard reset event" materially improves clarity, add one `rstest-bdd`
+behavioural test. If not, document why focused unit tests are sufficient.
+
+Validation for Stage C:
+
+- `make check-fmt`
+- `make lint`
+- `make test`
+
+### Stage D: documentation, roadmap, and final evidence capture
+
+After code and tests are green, update the documentation set:
+
+1. `docs/adr-001-shared-sse-wire-contract-for-wildside-and-corbusier.md`
+   records any design decisions taken during implementation, especially the
+   explicit override semantics and the chosen helper surface.
+2. `docs/users-guide.md` documents the default heartbeat policy, the override
+   path, and the standard `stream_reset` helper with concise examples. It must
+   also state explicitly that this crate still does not provide heartbeat
+   scheduling or a convenience responder.
+3. `docs/developers-guide.md` documents the internal module split, the decision
+   to reuse frame helpers instead of duplicating wire formatting, and the
+   boundary that keeps timers and replay orchestration out of scope.
+4. `docs/roadmap.md` marks task 1.1.3 done only after all implementation and
+   documentation gates pass.
+
+Final validation for Stage D:
+
+- `make fmt`
+- `make markdownlint`
+- `make nixie`
+- `make check-fmt`
+- `make lint`
+- `make test`
+
+## Approval gates
+
+Implementation must not begin until all of the following are true:
+
+1. The user approves this plan.
+2. The approved surface remains wire-only and excludes any scheduler or
+   convenience responder.
+3. Any ADR clarification needed for override validation or helper shape has
+   been accepted before code lands.
+
+## Validation and acceptance
+
+Task 1.1.3 is done when all of the following are true:
+
+- `src/sse/` exports a shared heartbeat policy helper and a shared
+  `stream_reset` helper that remain transport-focused.
+- The default heartbeat interval is 20 seconds and the public API exposes an
+  explicit override path.
+- The `stream_reset` helper emits the exact ADR-defined event name and payload.
+- Unit tests cover happy paths, unhappy paths, and relevant edge cases with
+  `rstest`.
+- Any behavioural tests added with `rstest-bdd` are justified by scenario
+  clarity; otherwise the execplan explicitly records why they were not needed.
+- `make check-fmt`, `make lint`, `make test`, `make fmt`,
+  `make markdownlint`, and `make nixie` all pass.
+- ADR 001, `docs/users-guide.md`, and `docs/developers-guide.md` reflect the
+  approved helper behaviour.
+- `docs/roadmap.md` marks 1.1.3 complete.
+
+## Idempotence and recovery
+
+The implementation should be additive and safe to rerun. If a stage fails,
+repair the issue and rerun that stage's validation commands. No rollback should
+be necessary unless the attempted API expands beyond the approved wire-helper
+scope.
+
+## Surprises & discoveries
+
+- 2026-04-10: the current repository already contains the completed 1.1.2 SSE
+  work (`render_event_frame`, `render_comment_frame`, and cache-control
+  helpers), so task 1.1.3 can build directly on live framing primitives rather
+  than adding new formatting logic.
+- 2026-04-10: the current public docs already describe generic comment-frame
+  heartbeats, so task 1.1.3 needs to document the normative 20-second policy
+  and the dedicated helper surface rather than re-explaining SSE comments in
+  general.
+- 2026-04-10: no `execplans` skill was available in this session, so this plan
+  was drafted using the repository's existing execplan pattern and local
+  documentation guidance.
+
+## Decision log
+
+- 2026-04-10: recommend a split between `heartbeat.rs` and `stream_reset.rs`
+  so interval policy and replay-reset signalling stay independently testable
+  and below the repository's 400-line file guidance.
+- 2026-04-10: recommend keeping task 1.1.3 strictly below the scheduler and
+  responder boundary so downstream applications retain ownership of connection
+  lifecycle and timer orchestration.
+- 2026-04-10: recommend implementing `stream_reset` as a fixed helper that
+  reuses `render_event_frame` and does not broaden into a generic
+  application-event surface.
+
+## Outcomes & retrospective
+
+Pending implementation. Update this section after the feature lands and all
+quality gates pass.

--- a/docs/execplans/1-1-3-shared-heartbeat-and-stream-reset-helpers.md
+++ b/docs/execplans/1-1-3-shared-heartbeat-and-stream-reset-helpers.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: PENDING APPROVAL
+Status: COMPLETED
 
 ## Purpose / big picture
 
@@ -123,13 +123,13 @@ Success is observable when:
   execplans for tasks 1.1.1 and 1.1.2.
 - [x] Review the referenced testing and documentation guidance.
 - [x] Draft this execution plan.
-- [ ] Receive user approval for the plan.
-- [ ] Implement the heartbeat policy helper.
-- [ ] Implement the `stream_reset` helper.
-- [ ] Add unit tests and any justified behavioural tests.
-- [ ] Update ADR 001, `docs/users-guide.md`, and `docs/developers-guide.md`.
-- [ ] Mark roadmap task 1.1.3 done after the implementation passes all gates.
-- [ ] Run `make check-fmt`, `make lint`, `make test`, `make fmt`,
+- [x] Receive user approval for the plan.
+- [x] Implement the heartbeat policy helper.
+- [x] Implement the `stream_reset` helper.
+- [x] Add unit tests and any justified behavioural tests.
+- [x] Update ADR 001, `docs/users-guide.md`, and `docs/developers-guide.md`.
+- [x] Mark roadmap task 1.1.3 done after the implementation passes all gates.
+- [x] Run `make check-fmt`, `make lint`, `make test`, `make fmt`,
   `make markdownlint`, and `make nixie` with `tee` logs for the implementation
   change.
 
@@ -380,6 +380,10 @@ scope.
 - 2026-04-10: no `execplans` skill was available in this session, so this plan
   was drafted using the repository's existing execplan pattern and local
   documentation guidance.
+- 2026-04-11: `make fmt` depends on `mdformat-all`, which shells out to `fd`.
+  This environment lacked `fd` on `PATH`, so validation used a temporary
+  session-local `fd` shim to satisfy the existing Make target without changing
+  repository code.
 
 ## Decision log
 
@@ -392,8 +396,33 @@ scope.
 - 2026-04-10: recommend implementing `stream_reset` as a fixed helper that
   reuses `render_event_frame` and does not broaden into a generic
   application-event surface.
+- 2026-04-11: approved `HeartbeatPolicy::new(Duration)` as the explicit
+  override path and rejected `Duration::ZERO` with a dedicated validation error
+  so the shared helper surface does not silently encode "disable heartbeats".
+- 2026-04-11: kept coverage at the `rstest` unit-test layer because the landed
+  behaviour is typed interval validation plus deterministic frame rendering;
+  `rstest-bdd` would add ceremony without clarifying additional runtime
+  behaviour.
 
 ## Outcomes & retrospective
 
-Pending implementation. Update this section after the feature lands and all
-quality gates pass.
+- Landed `src/sse/heartbeat.rs` with:
+  - `DEFAULT_HEARTBEAT_INTERVAL` set to 20 seconds;
+  - `HeartbeatPolicy` with `Default` and validated explicit overrides;
+  - `render_heartbeat_frame()` as the canonical empty-comment heartbeat helper.
+- Landed `src/sse/stream_reset.rs` with:
+  - `STREAM_RESET_EVENT_NAME`;
+  - `STREAM_RESET_REPLAY_UNAVAILABLE_PAYLOAD`;
+  - `render_stream_reset_frame()` built on `render_event_frame`.
+- Updated crate-root and `src/sse/mod.rs` re-exports so downstream callers can
+  use the helpers directly from `actix_v2a`.
+- Updated ADR 001, the user's guide, the developer's guide, and the roadmap to
+  describe the heartbeat override semantics and the fixed `stream_reset`
+  surface.
+- Passed the mandated quality gates with `tee` logs:
+  - `make fmt`
+  - `make check-fmt`
+  - `make lint`
+  - `make test`
+  - `make markdownlint`
+  - `make nixie`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -27,7 +27,7 @@ without pulling event-store, routing, or authorization logic into this crate.
     streams.
   - Exclude any convenience responder until both downstream applications prove
     the same lifecycle needs.
-- [ ] 1.1.3. Implement the shared heartbeat and `stream_reset` helpers.
+- [x] 1.1.3. Implement the shared heartbeat and `stream_reset` helpers.
   Requires 1.1.2. See ADR 001 "Decision outcome / proposed direction".
   - Provide the ADR default 20-second heartbeat policy with an explicit
     override path.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -164,6 +164,66 @@ assert_eq!(heartbeat, ":\n\n");
 Comment rendering also normalizes `\r`, `\n`, and `\r\n` into logical line
 breaks and rejects NULL with `SseFrameError::InvalidComment`.
 
+### Shared heartbeat helper
+
+Use `HeartbeatPolicy` when your endpoint needs the shared heartbeat cadence in
+typed form:
+
+```rust
+use std::time::Duration;
+use actix_v2a::{DEFAULT_HEARTBEAT_INTERVAL, HeartbeatPolicy};
+
+let default_policy = HeartbeatPolicy::default();
+assert_eq!(default_policy.interval(), DEFAULT_HEARTBEAT_INTERVAL);
+
+let custom_policy = HeartbeatPolicy::new(Duration::from_secs(5))?;
+assert_eq!(custom_policy.interval(), Duration::from_secs(5));
+```
+
+The default interval is 20 seconds. `HeartbeatPolicy::new` rejects
+`Duration::ZERO`, so applications must make an explicit choice if they want to
+disable heartbeat scheduling entirely.
+
+Use `render_heartbeat_frame` to emit the canonical heartbeat wire frame:
+
+```rust
+use actix_v2a::render_heartbeat_frame;
+
+let frame = render_heartbeat_frame()?;
+assert_eq!(frame, ":\n\n");
+```
+
+This crate still does not schedule heartbeats for you. Applications remain
+responsible for timer ownership, background tasks, and stream lifecycle.
+
+### Shared `stream_reset` helper
+
+Use `render_stream_reset_frame` when replay cannot resume from the supplied
+cursor:
+
+```rust
+use actix_v2a::{
+    STREAM_RESET_EVENT_NAME,
+    STREAM_RESET_REPLAY_UNAVAILABLE_PAYLOAD,
+    render_stream_reset_frame,
+};
+
+let frame = render_stream_reset_frame()?;
+
+assert_eq!(STREAM_RESET_EVENT_NAME, "stream_reset");
+assert_eq!(
+    STREAM_RESET_REPLAY_UNAVAILABLE_PAYLOAD,
+    "{\"reason\":\"replay_unavailable\"}"
+);
+assert_eq!(
+    frame,
+    "event: stream_reset\ndata: {\"reason\":\"replay_unavailable\"}\n\n"
+);
+```
+
+The helper is fixed to the shared control event and does not expose a generic
+application-event builder.
+
 ### Live-stream cache headers
 
 Use `apply_event_stream_cache_control` to set the canonical anti-reuse policy
@@ -211,6 +271,8 @@ or generation strategy.
 - The `Last-Event-ID` header extraction follows the same single-header-or-error
   pattern used by the `extract_idempotency_key` function in the idempotency
   module.
+- The heartbeat helper surface is intentionally wire-only: this crate exposes
+  interval data and rendered frames, not timer orchestration.
 
 For implementation guidance and internal conventions, see
 [`developers-guide.md`](developers-guide.md).

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -166,7 +166,7 @@ breaks and rejects NULL with `SseFrameError::InvalidComment`.
 
 ### Shared heartbeat helper
 
-Use `HeartbeatPolicy` when your endpoint needs the shared heartbeat cadence in
+Use `HeartbeatPolicy` when an endpoint needs the shared heartbeat cadence in
 typed form:
 
 ```rust
@@ -193,8 +193,8 @@ let frame = render_heartbeat_frame()?;
 assert_eq!(frame, ":\n\n");
 ```
 
-This crate still does not schedule heartbeats for you. Applications remain
-responsible for timer ownership, background tasks, and stream lifecycle.
+This crate still does not schedule heartbeats. Applications remain responsible
+for timer ownership, background tasks, and stream lifecycle.
 
 ### Shared `stream_reset` helper
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,16 +43,23 @@ pub use pagination::{
     PaginationLinks,
 };
 pub use sse::{
+    DEFAULT_HEARTBEAT_INTERVAL,
     EVENT_STREAM_CACHE_CONTROL,
     EventId,
     EventIdValidationError,
+    HeartbeatPolicy,
+    HeartbeatPolicyError,
     LAST_EVENT_ID_HEADER,
     ReplayCursor,
     ReplayCursorError,
+    STREAM_RESET_EVENT_NAME,
+    STREAM_RESET_REPLAY_UNAVAILABLE_PAYLOAD,
     SseFrameError,
     apply_event_stream_cache_control,
     extract_replay_cursor,
     map_replay_cursor_error,
     render_comment_frame,
     render_event_frame,
+    render_heartbeat_frame,
+    render_stream_reset_frame,
 };

--- a/src/sse/heartbeat.rs
+++ b/src/sse/heartbeat.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use thiserror::Error;
 
-use crate::sse::{SseFrameError, render_comment_frame};
+use crate::sse::{SseFrameError, frame::render_comment_frame};
 
 /// Default interval for SSE heartbeat traffic.
 pub const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(20);
@@ -61,6 +61,7 @@ impl HeartbeatPolicy {
     ///
     /// assert_eq!(policy.interval(), Duration::from_secs(15));
     /// ```
+    #[must_use = "ignoring heartbeat policy construction can hide an invalid interval override"]
     pub const fn new(interval: Duration) -> Result<Self, HeartbeatPolicyError> {
         if interval.is_zero() {
             return Err(HeartbeatPolicyError::ZeroInterval);
@@ -102,6 +103,7 @@ impl Default for HeartbeatPolicy {
 ///
 /// assert_eq!(frame, ":\n\n");
 /// ```
+#[must_use = "heartbeat frames must be written to the response stream to keep the connection warm"]
 pub fn render_heartbeat_frame() -> Result<String, SseFrameError> { render_comment_frame("") }
 
 #[cfg(test)]

--- a/src/sse/heartbeat.rs
+++ b/src/sse/heartbeat.rs
@@ -1,0 +1,163 @@
+//! Shared heartbeat policy and frame helpers for SSE streams.
+
+use std::time::Duration;
+
+use thiserror::Error;
+
+use crate::sse::{SseFrameError, render_comment_frame};
+
+/// Default interval for SSE heartbeat traffic.
+pub const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(20);
+
+/// Errors returned when constructing a [`HeartbeatPolicy`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum HeartbeatPolicyError {
+    /// The caller supplied a zero-length heartbeat interval.
+    #[error("heartbeat interval must be greater than zero")]
+    ZeroInterval,
+}
+
+/// Typed heartbeat policy for SSE connections.
+///
+/// This type holds interval data only. It does not own timer scheduling or
+/// stream lifecycle management, which remain the application's responsibility.
+///
+/// # Examples
+///
+/// ```
+/// use std::time::Duration;
+///
+/// use actix_v2a::{DEFAULT_HEARTBEAT_INTERVAL, HeartbeatPolicy};
+///
+/// let default_policy = HeartbeatPolicy::default();
+/// assert_eq!(default_policy.interval(), DEFAULT_HEARTBEAT_INTERVAL);
+///
+/// let custom_policy = HeartbeatPolicy::new(Duration::from_secs(5))
+///     .expect("custom heartbeat interval should validate");
+/// assert_eq!(custom_policy.interval(), Duration::from_secs(5));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HeartbeatPolicy {
+    interval: Duration,
+}
+
+impl HeartbeatPolicy {
+    /// Construct a heartbeat policy with an explicit interval override.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HeartbeatPolicyError::ZeroInterval`] when `interval` is
+    /// [`Duration::ZERO`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::time::Duration;
+    ///
+    /// use actix_v2a::HeartbeatPolicy;
+    ///
+    /// let policy =
+    ///     HeartbeatPolicy::new(Duration::from_secs(15)).expect("custom interval should validate");
+    ///
+    /// assert_eq!(policy.interval(), Duration::from_secs(15));
+    /// ```
+    pub const fn new(interval: Duration) -> Result<Self, HeartbeatPolicyError> {
+        if interval.is_zero() {
+            return Err(HeartbeatPolicyError::ZeroInterval);
+        }
+
+        Ok(Self { interval })
+    }
+
+    /// Access the configured heartbeat interval.
+    #[must_use]
+    pub const fn interval(&self) -> Duration { self.interval }
+}
+
+impl Default for HeartbeatPolicy {
+    fn default() -> Self {
+        Self {
+            interval: DEFAULT_HEARTBEAT_INTERVAL,
+        }
+    }
+}
+
+/// Render the canonical heartbeat frame for an SSE stream.
+///
+/// The frame is the empty SSE comment `:\n\n`, which keeps idle connections
+/// warm without inventing a domain event.
+///
+/// # Errors
+///
+/// Propagates [`SseFrameError`] from [`render_comment_frame`]. The shared
+/// heartbeat frame is currently infallible because it renders an empty
+/// comment.
+///
+/// # Examples
+///
+/// ```
+/// use actix_v2a::render_heartbeat_frame;
+///
+/// let frame = render_heartbeat_frame().expect("heartbeat frame should render");
+///
+/// assert_eq!(frame, ":\n\n");
+/// ```
+pub fn render_heartbeat_frame() -> Result<String, SseFrameError> { render_comment_frame("") }
+
+#[cfg(test)]
+mod tests {
+    //! Regression coverage for the shared SSE heartbeat helpers.
+
+    use std::time::Duration;
+
+    use rstest::rstest;
+
+    use super::{
+        DEFAULT_HEARTBEAT_INTERVAL,
+        HeartbeatPolicy,
+        HeartbeatPolicyError,
+        render_heartbeat_frame,
+    };
+
+    #[test]
+    fn default_heartbeat_policy_uses_adr_interval() {
+        let policy = HeartbeatPolicy::default();
+
+        assert_eq!(policy.interval(), DEFAULT_HEARTBEAT_INTERVAL);
+        assert_eq!(policy.interval(), Duration::from_secs(20));
+    }
+
+    #[rstest]
+    #[case(Duration::from_secs(1))]
+    #[case(Duration::from_secs(5))]
+    #[case(Duration::from_millis(250))]
+    fn heartbeat_policy_preserves_explicit_override(#[case] interval: Duration) {
+        let policy =
+            HeartbeatPolicy::new(interval).expect("non-zero heartbeat interval should validate");
+
+        assert_eq!(policy.interval(), interval);
+    }
+
+    #[test]
+    fn heartbeat_policy_rejects_zero_duration_override() {
+        let error =
+            HeartbeatPolicy::new(Duration::ZERO).expect_err("zero heartbeat interval should fail");
+
+        assert_eq!(error, HeartbeatPolicyError::ZeroInterval);
+    }
+
+    #[test]
+    fn render_heartbeat_frame_emits_canonical_empty_comment() {
+        let frame = render_heartbeat_frame().expect("heartbeat frame should render");
+
+        assert_eq!(frame, ":\n\n");
+    }
+
+    #[test]
+    fn render_heartbeat_frame_is_deterministic_when_repeated() {
+        let first_frame = render_heartbeat_frame().expect("heartbeat frame should render");
+        let second_frame = render_heartbeat_frame().expect("heartbeat frame should render");
+
+        assert_eq!(first_frame, second_frame);
+    }
+}

--- a/src/sse/mod.rs
+++ b/src/sse/mod.rs
@@ -9,15 +9,28 @@
 pub mod cache_control;
 pub mod event_id;
 pub mod frame;
+pub mod heartbeat;
 pub mod replay_cursor;
+pub mod stream_reset;
 
 pub use cache_control::{EVENT_STREAM_CACHE_CONTROL, apply_event_stream_cache_control};
 pub use event_id::{EventId, EventIdValidationError};
 pub use frame::{SseFrameError, render_comment_frame, render_event_frame};
+pub use heartbeat::{
+    DEFAULT_HEARTBEAT_INTERVAL,
+    HeartbeatPolicy,
+    HeartbeatPolicyError,
+    render_heartbeat_frame,
+};
 pub use replay_cursor::{
     LAST_EVENT_ID_HEADER,
     ReplayCursor,
     ReplayCursorError,
     extract_replay_cursor,
     map_replay_cursor_error,
+};
+pub use stream_reset::{
+    STREAM_RESET_EVENT_NAME,
+    STREAM_RESET_REPLAY_UNAVAILABLE_PAYLOAD,
+    render_stream_reset_frame,
 };

--- a/src/sse/stream_reset.rs
+++ b/src/sse/stream_reset.rs
@@ -1,6 +1,6 @@
 //! Shared replay-reset helper for SSE streams.
 
-use crate::sse::{SseFrameError, render_event_frame};
+use crate::sse::{SseFrameError, frame::render_event_frame};
 
 /// Canonical event name for replay-reset control messages.
 pub const STREAM_RESET_EVENT_NAME: &str = "stream_reset";
@@ -31,6 +31,7 @@ pub const STREAM_RESET_REPLAY_UNAVAILABLE_PAYLOAD: &str = r#"{"reason":"replay_u
 ///     "event: stream_reset\ndata: {\"reason\":\"replay_unavailable\"}\n\n"
 /// );
 /// ```
+#[must_use = "stream reset frames must be written to the response stream to notify clients"]
 pub fn render_stream_reset_frame() -> Result<String, SseFrameError> {
     render_event_frame(
         None,

--- a/src/sse/stream_reset.rs
+++ b/src/sse/stream_reset.rs
@@ -1,0 +1,80 @@
+//! Shared replay-reset helper for SSE streams.
+
+use crate::sse::{SseFrameError, render_event_frame};
+
+/// Canonical event name for replay-reset control messages.
+pub const STREAM_RESET_EVENT_NAME: &str = "stream_reset";
+
+/// Canonical payload for replay-reset control messages.
+pub const STREAM_RESET_REPLAY_UNAVAILABLE_PAYLOAD: &str = r#"{"reason":"replay_unavailable"}"#;
+
+/// Render the standard replay-unavailable `stream_reset` frame.
+///
+/// This helper is intentionally fixed to the shared control event defined by
+/// ADR 001. It does not broaden the crate surface into a generic
+/// application-event builder.
+///
+/// # Errors
+///
+/// Propagates [`SseFrameError`] from [`render_event_frame`]. The shared event
+/// name and payload are currently valid and therefore render successfully.
+///
+/// # Examples
+///
+/// ```
+/// use actix_v2a::render_stream_reset_frame;
+///
+/// let frame = render_stream_reset_frame().expect("stream reset frame should render");
+///
+/// assert_eq!(
+///     frame,
+///     "event: stream_reset\ndata: {\"reason\":\"replay_unavailable\"}\n\n"
+/// );
+/// ```
+pub fn render_stream_reset_frame() -> Result<String, SseFrameError> {
+    render_event_frame(
+        None,
+        Some(STREAM_RESET_EVENT_NAME),
+        STREAM_RESET_REPLAY_UNAVAILABLE_PAYLOAD,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    //! Regression coverage for the shared SSE replay-reset helper.
+
+    use super::{
+        STREAM_RESET_EVENT_NAME,
+        STREAM_RESET_REPLAY_UNAVAILABLE_PAYLOAD,
+        render_stream_reset_frame,
+    };
+
+    #[test]
+    fn render_stream_reset_frame_emits_the_shared_control_event() {
+        let frame = render_stream_reset_frame().expect("stream reset frame should render");
+
+        assert_eq!(
+            frame,
+            "event: stream_reset\ndata: {\"reason\":\"replay_unavailable\"}\n\n"
+        );
+    }
+
+    #[test]
+    fn render_stream_reset_frame_is_deterministic_when_repeated() {
+        let first_frame = render_stream_reset_frame().expect("stream reset frame should render");
+        let second_frame = render_stream_reset_frame().expect("stream reset frame should render");
+
+        assert_eq!(first_frame, second_frame);
+    }
+
+    #[test]
+    fn stream_reset_constants_match_rendered_output() {
+        let expected_frame = format!(
+            "event: {STREAM_RESET_EVENT_NAME}\ndata: {STREAM_RESET_REPLAY_UNAVAILABLE_PAYLOAD}\n\n"
+        );
+
+        let frame = render_stream_reset_frame().expect("stream reset frame should render");
+
+        assert_eq!(frame, expected_frame);
+    }
+}


### PR DESCRIPTION
## Summary
- Implements the actual plan for task 1.1.3: shared SSE heartbeat policy and a fixed `stream_reset` helper, wiring them into the existing SSE framing primitives and docs. Includes new modules, tests, and updated ADR/docs to reflect the wire-only surface and ADR decisions. See new exec plan documentation for goals, constraints, risks, and validation gates.
- Updates repository docs to reference the new exec plan and outline the wire-only surface, without introducing runtime scheduling or lifecycle concerns.

## Changes
- docs/contents.md: Link to the new execution plan for 1.1.3.
- docs/execplans/1-1-3-shared-heartbeat-and-stream-reset-helpers.md: New detailed exec plan outlining goals, constraints, tolerances, risks, progress, and validation gates.
- src/sse/heartbeat.rs: New module implementing the default heartbeat interval, a typed HeartbeatPolicy with explicit override validation, and a canonical render_heartbeat_frame helper.
- src/sse/stream_reset.rs: New module implementing a fixed stream_reset helper with canonical event name and payload, built on top of render_event_frame.
- src/sse/mod.rs: Re-exports for the new heartbeat and stream_reset helpers and constants.
- src/sse/heartbeat.rs (new) and src/sse/stream_reset.rs (new): Added unit tests covering default behavior, override validation, deterministic frame output, and edge cases.
- src/lib.rs: Re-exports for DEFAULT_HEARTBEAT_INTERVAL, HeartbeatPolicy, HeartbeatPolicyError, STREAM_RESET_EVENT_NAME, STREAM_RESET_REPLAY_UNAVAILABLE_PAYLOAD, render_heartbeat_frame, and render_stream_reset_frame.
- docs/adr-001-shared-sse-wire-contract-for-wildside-and-corbusier.md: ADR updated to reference the explicit heartbeat policy semantics and fixed stream_reset surface.
- docs/developers-guide.md: Updated to document the new heartbeat policy and stream_reset helpers as wire-only, with module layout and test strategies.
- docs/users-guide.md: Updated usage examples for HeartbeatPolicy and render_heartbeat_frame, plus fixed stream_reset frame rendering examples.
- docs/roadmap.md: Marked 1.1.3 as completed. See ADR 001 references and exec plan.
- src/sse/frame.rs, src/sse/event_id.rs, src/sse/replay_cursor.rs, src/sse/cache_control.rs, and related modules remain the same, now complemented by the new helpers and re-exports.
- Updated tests to cover both new helpers and their deterministic outputs, including repeated rendering checks.

## Why this matters
- Establishes a clear, wire-only API surface for a default 20s heartbeat and a canonical stream_reset event, enabling downstream consumers to rely on consistent behavior without embedding scheduling or app lifecycle logic in the crate.
- Documents decisions and acceptance criteria up front to guide implementation and ensure ADR alignment (ADR 001 referenced).
- Keeps the implementation focused on transport-level concerns, preventing leakage of timers, schedulers, or lifecycle management into the crate.

## Build and validation plan (per exec plan)
- Stage A approvals and ADR clarifications before code landed (now completed).
- Stage B/C unit tests with rstest where appropriate; avoid unnecessary behavioural tests unless they add value.
- Stage D documentation updates across ADRs, users guide, developers guide, and roadmap; publish validation gates.
- Validation gates to run when implementing: `make check-fmt`, `make lint`, `make test`, `make fmt`, `make markdownlint`, and `make nixie`.

## Risks and constraints
- Surface must remain wire-only; avoid timers, schedulers, or lifecycle logic.
- Public API should be small and well-typed; avoid exposing raw strings or overly generic helpers.
- If implementation scope expands beyond a few files or ~350 lines, re-scope per plan.

## Approval
- Implementation proceeds under the updated ADR guidance and the new exec plan. The surface remains transport-focused and does not introduce scheduling or responder surfaces.

## Next steps after this update
- With 1.1.3 completed, update roadmap/ADR references as needed and consider any follow-up cleanup or minor refinements based on upstream feedback.

## Task reference
- Task: https://www.devboxer.com/task/d977747f-592a-49a9-bd53-b3b3ee12e98a

## Summary by Sourcery
Document the execution plan for introducing shared SSE heartbeat and stream_reset helpers and link it into the docs index.

Documentation:
- Add a new exec plan detailing goals, constraints, risks, stages, and validation for the shared SSE heartbeat and stream_reset helpers.
- Update the documentation contents index to reference the new 1.1.3 execution plan for heartbeat and stream_reset helpers.

## Summary by Sourcery

Add shared SSE heartbeat and stream_reset helpers and wire them into the public SSE API and documentation.

New Features:
- Introduce a typed HeartbeatPolicy with a default 20-second interval, validation for explicit overrides, and a canonical heartbeat frame renderer.
- Add a fixed stream_reset helper that emits the standard replay-unavailable control event with shared name and payload constants.

Documentation:
- Document the heartbeat policy and stream_reset helpers in the users and developers guides, including their wire-only scope and usage examples.
- Extend ADR 001 to capture heartbeat override semantics and the fixed stream_reset surface, and add a new execution plan for task 1.1.3.
- Update the docs index and roadmap to reference and mark completion of the 1.1.3 heartbeat and stream_reset work.

Tests:
- Add unit tests for HeartbeatPolicy defaults, override validation, and heartbeat frame determinism.
- Add unit tests for stream_reset frame rendering, determinism, and alignment between constants and rendered output.