### PR TITLE
Port Wildside pagination documentation hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ dependencies = [
  "actix-web",
  "base64",
  "hex",
+ "insta",
  "rstest",
  "rstest-bdd",
  "rstest-bdd-macros",
@@ -390,6 +391,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,6 +541,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +570,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-crate"
@@ -1019,6 +1043,18 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
+ "tempfile",
 ]
 
 [[package]]
@@ -1772,6 +1808,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,6 +1896,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,7 @@ dependencies = [
  "sha2",
  "thiserror 2.0.18",
  "tracing",
+ "tracing-test",
  "url",
  "utoipa",
  "uuid",
@@ -1140,6 +1141,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1196,6 +1203,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1240,6 +1256,15 @@ name = "newt-hype"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8b7b69b0eafaa88ec8dc9fe7c3860af0a147517e5207cfbd0ecd21cd7cde18"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-conv"
@@ -1786,6 +1811,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1963,6 +1997,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2102,6 +2145,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2265,6 +2359,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ insta = "1.47.2"
 rstest = "0.26.1"
 rstest-bdd = "0.5.0"
 rstest-bdd-macros = { version = "0.5.0", features = ["strict-compile-time-validation"] }
+tracing-test = "0.2.6"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ url = "2.5.7"
 uuid = { version = "1", features = ["serde", "v4"] }
 
 [dev-dependencies]
+insta = "1.47.2"
 rstest = "0.26.1"
 rstest-bdd = "0.5.0"
 rstest-bdd-macros = { version = "0.5.0", features = ["strict-compile-time-validation"] }

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,8 @@ CARGO_FLAGS ?= --all-targets --all-features
 CLIPPY_FLAGS ?= $(CARGO_FLAGS) -- $(RUST_FLAGS)
 TEST_FLAGS ?= $(CARGO_FLAGS)
 TEST_CMD := $(if $(shell $(CARGO) nextest --version 2>/dev/null),nextest run,test)
-MDLINT ?= $(shell command -v markdownlint-cli2 2>/dev/null || \
-	if [ -x "$$HOME/.bun/bin/markdownlint-cli2" ]; then \
-		printf '%s\n' "$$HOME/.bun/bin/markdownlint-cli2"; \
-	else \
-		printf '%s\n' markdownlint-cli2; \
-	fi)
+MDLINT ?= markdownlint-cli2
+BUN_BIN ?= $(HOME)/.bun/bin
 NIXIE ?= nixie
 
 build: target/debug/$(TARGET) ## Build debug binary
@@ -58,7 +54,7 @@ check-fmt: ## Verify formatting
 	$(CARGO) fmt --all -- --check
 
 markdownlint: ## Lint Markdown files
-	$(MDLINT) '**/*.md'
+	PATH="$(BUN_BIN):$$PATH" $(MDLINT) '**/*.md'
 
 nixie: ## Validate Mermaid diagrams
 	$(NIXIE) --no-sandbox

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@
 TARGET ?= libactix_v2a.rlib
 
 CARGO ?= cargo
+CARGO_BIN ?= $(HOME)/.cargo/bin
+CARGO_ENV := PATH="$(CARGO_BIN):$$PATH"
 BUILD_JOBS ?=
 RUST_FLAGS ?=
 RUST_FLAGS := -D warnings $(RUST_FLAGS)
@@ -12,7 +14,7 @@ RUSTDOC_FLAGS := -D warnings $(RUSTDOC_FLAGS)
 CARGO_FLAGS ?= --all-targets --all-features
 CLIPPY_FLAGS ?= $(CARGO_FLAGS) -- $(RUST_FLAGS)
 TEST_FLAGS ?= $(CARGO_FLAGS)
-TEST_CMD := $(if $(shell $(CARGO) nextest --version 2>/dev/null),nextest run,test)
+TEST_CMD := $(if $(shell $(CARGO_ENV) $(CARGO) nextest --version 2>/dev/null),nextest run,test)
 MDLINT ?= markdownlint-cli2
 BUN_BIN ?= $(HOME)/.bun/bin
 NIXIE ?= nixie
@@ -23,35 +25,35 @@ release: target/release/$(TARGET) ## Build release binary
 all: check-fmt lint test ## Perform a comprehensive check of code
 
 clean: ## Remove build artifacts
-	$(CARGO) clean
+	$(CARGO_ENV) $(CARGO) clean
 
 test: ## Run tests with warnings treated as errors
-	RUSTFLAGS="$(RUST_FLAGS)" $(CARGO) $(TEST_CMD) $(TEST_FLAGS) $(BUILD_JOBS)
+	$(CARGO_ENV) RUSTFLAGS="$(RUST_FLAGS)" $(CARGO) $(TEST_CMD) $(TEST_FLAGS) $(BUILD_JOBS)
 ifneq ($(TEST_CMD),test)
-	RUSTFLAGS="$(RUST_FLAGS)" $(CARGO) test --doc --workspace --all-features
+	$(CARGO_ENV) RUSTFLAGS="$(RUST_FLAGS)" $(CARGO) test --doc --workspace --all-features
 endif
 
 target/%/$(TARGET): ## Build binary in debug or release mode
-	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release)
+	$(CARGO_ENV) $(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release)
 
 lint: ## Run Clippy with warnings denied
-	RUSTDOCFLAGS="$(RUSTDOC_FLAGS)" $(CARGO) doc --no-deps
-	$(CARGO) clippy $(CLIPPY_FLAGS)
+	$(CARGO_ENV) RUSTDOCFLAGS="$(RUSTDOC_FLAGS)" $(CARGO) doc --no-deps
+	$(CARGO_ENV) $(CARGO) clippy $(CLIPPY_FLAGS)
 	@if command -v whitaker >/dev/null 2>&1; then \
-		RUSTFLAGS="$(RUST_FLAGS)" whitaker --all -- $(CARGO_FLAGS); \
+		$(CARGO_ENV) RUSTFLAGS="$(RUST_FLAGS)" whitaker --all -- $(CARGO_FLAGS); \
 	else \
 		echo "whitaker not found on PATH; skipping whitaker lint. Install whitaker to run this check."; \
 	fi
 
 typecheck: ## Type-check without building
-	RUSTFLAGS="$(RUST_FLAGS)" $(CARGO) check $(CARGO_FLAGS)
+	$(CARGO_ENV) RUSTFLAGS="$(RUST_FLAGS)" $(CARGO) check $(CARGO_FLAGS)
 
 fmt: ## Format Rust and Markdown sources
-	$(CARGO) +nightly fmt --all
+	$(CARGO_ENV) $(CARGO) +nightly fmt --all
 	mdformat-all
 
 check-fmt: ## Verify formatting
-	$(CARGO) fmt --all -- --check
+	$(CARGO_ENV) $(CARGO) fmt --all -- --check
 
 markdownlint: ## Lint Markdown files
 	PATH="$(BUN_BIN):$$PATH" $(MDLINT) '**/*.md'

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,12 @@ CARGO_FLAGS ?= --all-targets --all-features
 CLIPPY_FLAGS ?= $(CARGO_FLAGS) -- $(RUST_FLAGS)
 TEST_FLAGS ?= $(CARGO_FLAGS)
 TEST_CMD := $(if $(shell $(CARGO) nextest --version 2>/dev/null),nextest run,test)
-MDLINT ?= markdownlint-cli2
+MDLINT ?= $(shell command -v markdownlint-cli2 2>/dev/null || \
+	if [ -x "$$HOME/.bun/bin/markdownlint-cli2" ]; then \
+		printf '%s\n' "$$HOME/.bun/bin/markdownlint-cli2"; \
+	else \
+		printf '%s\n' markdownlint-cli2; \
+	fi)
 NIXIE ?= nixie
 
 build: target/debug/$(TARGET) ## Build debug binary

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -30,6 +30,10 @@
   proposed shared Server-Sent Events (SSE) contract for cross-application
   streaming helpers in `actix-v2a`.
 - `execplans/`: living execution plans for non-trivial change work.
+  - [Port Wildside pagination documentation
+    hardening](execplans/portwildsidepagination.md): draft plan for adapting
+    Wildside commit `9d6b7655` pagination documentation and invariant tests
+    into `actix-v2a`.
   - [Import components from Wildside](execplans/import-components-from-wildside.md):
     draft plan for extracting shared HTTP and API primitives from
     `../wildside/backend` into this crate.

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -31,9 +31,9 @@
   streaming helpers in `actix-v2a`.
 - `execplans/`: living execution plans for non-trivial change work.
   - [Port Wildside pagination documentation
-    hardening](execplans/portwildsidepagination.md): draft plan for adapting
-    Wildside commit `9d6b7655` pagination documentation and invariant tests
-    into `actix-v2a`.
+    hardening](execplans/portwildsidepagination.md): completed execution plan
+    and retrospective for porting Wildside commit `9d6b7655` pagination
+    documentation hardening and invariant tests into `actix-v2a`.
   - [Import components from Wildside](execplans/import-components-from-wildside.md):
     draft plan for extracting shared HTTP and API primitives from
     `../wildside/backend` into this crate.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -210,9 +210,10 @@ Markdown linting uses `BUN_BIN`:
 BUN_BIN ?= $(HOME)/.bun/bin
 ```
 
-The `markdownlint` target prepends `$(HOME)/.bun/bin` to `PATH` because
-`markdownlint-cli2` is installed there in the standard development
-environment:
+Unlike Cargo-based targets, `markdownlint` does not use a shared environment
+variable such as `CARGO_ENV`. Its recipe prepends `$(BUN_BIN)` directly to
+`PATH`, which resolves to `$(HOME)/.bun/bin`, because `markdownlint-cli2` is
+installed there in the standard development environment:
 
 ```bash
 make markdownlint

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -175,6 +175,55 @@ an `ErrorCode::InvalidRequest` error with a descriptive message:
 These messages are suitable for client-facing error responses and follow the
 same pattern as `map_idempotency_key_error`.
 
+## Build tooling
+
+The Makefile normalizes tool discovery for reduced-`PATH` environments such as
+CI hooks, local git hooks, and non-interactive shells. Prefer running the
+documented `make` targets instead of calling the underlying commands directly.
+
+Cargo-based targets use `CARGO_ENV`:
+
+```make
+CARGO_BIN ?= $(HOME)/.cargo/bin
+CARGO_ENV := PATH="$(CARGO_BIN):$$PATH"
+```
+
+`CARGO_ENV` prepends `$(HOME)/.cargo/bin` to `PATH` while preserving the
+caller-provided path. This keeps targets working when hook environments omit
+Cargo's default install directory. The `clean`, `test`, `build`, `release`,
+`lint`, `typecheck`, `fmt`, and `check-fmt` targets all run Cargo through this
+environment.
+
+The `test` target also detects `cargo-nextest` through `CARGO_ENV`. Install
+`cargo-nextest` under `~/.cargo/bin` when you want `make test` to use nextest:
+
+```bash
+cargo install cargo-nextest
+```
+
+If `cargo-nextest` is absent, `make test` falls back to `cargo test` and still
+runs doctests.
+
+Markdown linting uses `BUN_BIN`:
+
+```make
+BUN_BIN ?= $(HOME)/.bun/bin
+```
+
+The `markdownlint` target prepends `$(HOME)/.bun/bin` to `PATH` because
+`markdownlint-cli2` is installed there in the standard development
+environment:
+
+```bash
+make markdownlint
+```
+
+Developers using CI hooks, reduced-`PATH` shells, or other non-standard shell
+environments must ensure the Cargo and Bun binary directories exist when those
+tools are installed. The Makefile prepend mechanism handles ordinary
+`~/.cargo/bin` and `~/.bun/bin` installs automatically; it does not install
+missing tools or create shims.
+
 ## Quality gates
 
 All changes to the SSE module (and the broader crate) must pass the following

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -195,7 +195,7 @@ Cargo's default install directory. The `clean`, `test`, `build`, `release`,
 environment.
 
 The `test` target also detects `cargo-nextest` through `CARGO_ENV`. Install
-`cargo-nextest` under `~/.cargo/bin` when you want `make test` to use nextest:
+`cargo-nextest` to `~/.cargo/bin` to enable `make test` to use nextest.
 
 ```bash
 cargo install cargo-nextest
@@ -212,7 +212,7 @@ BUN_BIN ?= $(HOME)/.bun/bin
 
 Unlike Cargo-based targets, `markdownlint` does not use a shared environment
 variable such as `CARGO_ENV`. Its recipe prepends `$(BUN_BIN)` directly to
-`PATH`, which resolves to `$(HOME)/.bun/bin`, because `markdownlint-cli2` is
+`PATH`, which resolves to `$(HOME)/.bun/bin` because `markdownlint-cli2` is
 installed there in the standard development environment:
 
 ```bash

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -365,6 +365,74 @@ now complete:
 
 See [`roadmap.md`](roadmap.md) for the full delivery plan.
 
+## Pagination module internals
+
+The `src/pagination/` module provides reusable cursor pagination primitives
+without binding the crate to a database, repository, or route shape.
+
+### Pagination module layout
+
+- `src/pagination/mod.rs` — module documentation, public re-exports, and the
+  documented pagination error-mapping table.
+- `src/pagination/cursor.rs` — `Cursor<Key>` encoding and decoding, direction
+  handling, token validation, and tracing spans.
+- `src/pagination/params.rs` — `PageParams` parsing, limit normalisation, and
+  shared query parameter constants.
+- `src/pagination/envelope.rs` — `Paginated<T>` response envelopes and
+  `PaginationLinks` link construction.
+
+### Cursor ordering invariant
+
+Cursor keys must implement `Serialize` and `Deserialize` with a consistent
+representation that is compatible with the endpoint's total ordering. The
+module encodes and decodes opaque cursor tokens, but it does not prove that a
+database query, index, or repository predicate applies the same ordering on
+every page. Downstream persistence logic owns that invariant.
+
+### Limit normalisation
+
+`PageParams` normalises page limits consistently:
+
+- missing `limit` values use `DEFAULT_LIMIT`;
+- limits greater than `MAX_LIMIT` are clamped to `MAX_LIMIT`;
+- `limit=0` is rejected with `PageParamsError::InvalidLimit`.
+
+### Tracing
+
+`Cursor::encode` and `Cursor::decode` are instrumented with `#[instrument]`
+spans. `CursorError::Serialize` additionally emits a `tracing::error!` event at
+the public `Cursor::encode` boundary because it indicates that the server could
+not serialise its own cursor key. The caller-controlled variants
+`CursorError::InvalidBase64`, `CursorError::Deserialize`,
+`CursorError::TokenTooLong`, and `PageParamsError::InvalidLimit` do not emit
+library error events.
+
+### Pagination error mapping
+
+HTTP adapters should map caller-controlled pagination failures to HTTP 400 and
+`ErrorCode::InvalidRequest`:
+
+- `CursorError::InvalidBase64`
+- `CursorError::Deserialize`
+- `CursorError::TokenTooLong`
+- `PageParamsError::InvalidLimit`
+
+`CursorError::Serialize` should map to HTTP 500 and
+`ErrorCode::InternalError` because it is a server-side serialisation failure.
+
+### Testing patterns
+
+Pagination tests are split by contract:
+
+- `tests/pagination_documentation_bdd.rs` validates documented invariants for
+  limits, cursor errors, and display text.
+- `tests/pagination_http_bdd.rs` verifies handler-level HTTP status and
+  `ErrorCode` mappings.
+- `tests/pagination_tracing_tests.rs` verifies cursor span and event
+  observability.
+- `tests/snapshots/` stores `insta` snapshots for error `Display` outputs and
+  OpenAPI schema JSON.
+
 ## Additional resources
 
 - [ADR 001: Shared SSE wire contract for Wildside and
@@ -376,4 +444,8 @@ See [`roadmap.md`](roadmap.md) for the full delivery plan.
 - [ExecPlan: Implement SSE frame and cache-header
   helpers](execplans/1-1-2-sse-frame-and-cache-header-helpers.md) —
   implementation plan for task 1.1.2
+- [Port Wildside pagination documentation hardening
+  execplan](execplans/portwildsidepagination.md) — records the port scope,
+  constraints, surprises, and acceptance criteria for the pagination
+  documentation hardening workstream
 - [AGENTS.md](../AGENTS.md) — code style, testing, and commit conventions

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -631,8 +631,8 @@ change after reviewing this draft.
 Revision note: Initial draft created after reviewing Wildside commit
 `9d6b7655e3ad1a666a0e96beebd0a27b0d139388` and the current `actix-v2a`
 pagination surface. The plan was then updated with planning-gate evidence and
-the local `mdformat-all` limitation. The remaining work is blocked on explicit
-approval because this plan recommends implementation changes beyond the
+the local `mdformat-all` limitation. The remaining work was blocked on explicit
+approval because this plan recommended implementation changes beyond the
 planning phase.
 
 Revision note: Implementation began on 2026-04-27 after explicit user approval.

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -162,6 +162,10 @@ and documentation port itself starts only after approval.
 - [x] (2026-04-27 02:05Z) Verified the latest inline review findings, updated
   the contents index and `Paginated<T>` sentence, and confirmed the URL example
   already constructs an absolute URL before parsing.
+- [x] (2026-04-28 12:38Z) Verified the latest inline findings, updated the
+  stale Stage B plan text to match variant-and-field error assertions, and made
+  `decode_response` return observed status, trace header, and payload values
+  for caller-side assertions.
 
 ## Surprises & Discoveries
 
@@ -351,6 +355,10 @@ Later inline review findings were verified against the current code. The
 contents index now describes the plan as complete, the `Paginated<T>` OpenAPI
 sentence no longer has a comma before its "because" clause, and the URL example
 already builds an absolute URL before parsing.
+The remaining stale Stage B wording now describes documented cursor error
+variants and structured fields instead of display-string checks. The HTTP error
+test helper now decodes observed response values and leaves status and trace
+header assertions to the individual tests.
 The stricter lint run also exposed test helper `expect` calls; these were
 converted to fallible helpers and the review-response change passed
 `cargo test --test pagination_documentation_bdd`, `make check-fmt`,
@@ -410,9 +418,10 @@ schema wrappers in this stage.
 Stage B adds documentation-invariant coverage. Create
 `tests/features/pagination_documentation.feature` with scenarios for default
 limits, maximum limits, zero-limit rejection, invalid base64 cursor errors,
-invalid JSON cursor errors, token-too-long errors, and human-readable display
-strings. Create `tests/pagination_documentation_bdd.rs` to implement those
-scenarios. If shared state duplication becomes material, create
+invalid JSON cursor errors, token-too-long errors, and documented cursor error
+variants with their structured fields. Create
+`tests/pagination_documentation_bdd.rs` to implement those scenarios. If shared
+state duplication becomes material, create
 `tests/pagination_common.rs` or `tests/common/pagination.rs` and move only
 shared `World`, `FixtureKey`, and limit setup helpers there, then update
 `tests/pagination_bdd.rs` to use that helper module. Keep this extraction small

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -189,6 +189,9 @@ began after user approval.
 - [x] (2026-04-30 00:06Z) Moved the cursor serialization error event from the
   private `encode_cursor` helper to the public `Cursor::encode` boundary and
   updated the module observability contract.
+- [x] (2026-04-30 00:24Z) Replaced the documentation BDD synthetic serialize
+  error with `Cursor::new(FailingKey).encode()` and added tracing capture
+  coverage for cursor encode/decode spans and serialization error events.
 
 ## Surprises & Discoveries
 

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -182,6 +182,11 @@ and documentation port itself starts only after approval.
   documentation and pagination HTTP query parsing, then clarified the
   `markdownlint` inline `PATH` behaviour and replaced substring matching with
   exact query-parameter parsing.
+- [x] (2026-04-29 23:27Z) Verified follow-up review findings, then removed
+  second-person build-tooling prose, fixed punctuation around the
+  `markdownlint` path clause, documented `CursorError::TokenTooLong` on
+  `Cursor::decode`, and collapsed pagination HTTP error cases into one
+  parameterized `rstest`.
 
 ## Surprises & Discoveries
 

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: IN PROGRESS
+Status: COMPLETE
 
 ## Purpose / big picture
 
@@ -131,9 +131,18 @@ and documentation port itself starts only after approval.
   `docs/users-guide.md`.
 - [x] (2026-04-27 00:46Z) Validated Stage A with `make check-fmt`,
   `make lint`, `make markdownlint`, and `make nixie`.
-- [ ] Implement approved documentation and test changes.
-- [ ] Run and record the full validation gates.
-- [ ] Commit the implementation after the gates pass.
+- [x] (2026-04-27 00:52Z) Completed Stage B by adding
+  `tests/features/pagination_documentation.feature` and
+  `tests/pagination_documentation_bdd.rs`.
+- [x] (2026-04-27 00:52Z) Completed Stage C by adding
+  `CursorError::Serialize` unit coverage and `PageParams` limit-boundary
+  coverage around `MAX_LIMIT`.
+- [x] (2026-04-27 00:52Z) Ran the full implementation gates:
+  `make check-fmt`, `make lint`, `make test`, `make markdownlint`, and
+  `make nixie`.
+- [x] (2026-04-27 00:52Z) Implemented all approved documentation and test
+  changes.
+- [ ] Commit the completed implementation after this final plan update.
 
 ## Surprises & Discoveries
 
@@ -182,6 +191,22 @@ and documentation port itself starts only after approval.
   Impact: The pagination heading was renamed to "Pagination error mapping",
   preserving the intended content while keeping the guide lint-clean.
 
+- Observation: A self-contained documentation-invariant BDD suite avoided
+  pushing the existing `tests/pagination_bdd.rs` file over the repository's
+  400-line limit.
+  Evidence: `tests/pagination_bdd.rs` was already 367 lines before Stage B, and
+  the new scenarios fit cleanly in `tests/pagination_documentation_bdd.rs`.
+  Impact: No shared fixture extraction was needed for this port, keeping the
+  change smaller than the optional common-fixture path in the plan.
+
+- Observation: The first isolated run of the new BDD suite caught a borrowed
+  `Err(...)` comparison and a macro-expanded unused-braces warning in the
+  `world` fixture.
+  Evidence: `cargo test --test pagination_documentation_bdd` failed before
+  those local issues were fixed, then passed after the targeted correction.
+  Impact: The focused red/green run validated the new suite before the full
+  repository gates.
+
 ## Decision Log
 
 - Decision: Treat this as a documentation and test hardening port, not an
@@ -211,19 +236,27 @@ and documentation port itself starts only after approval.
   concrete item type.
   Date/Author: 2026-04-27 00:46Z / Codex.
 
+- Decision: Keep the documentation-invariant BDD suite self-contained rather
+  than extracting shared pagination BDD fixtures.
+  Rationale: The existing pagination BDD file was already near the line-count
+  limit, and the new suite needed only small state and helper functions.
+  Date/Author: 2026-04-27 00:52Z / Codex.
+
 ## Outcomes & Retrospective
 
-This plan is currently a draft. No port implementation has started. The
-planning outcome is a bounded, reviewable path that separates portable
-pagination documentation hardening from Wildside-specific application cleanup.
-The planning-only documentation change passed `make check-fmt`,
-`make markdownlint`, and `make nixie`; `make fmt` is partially blocked by a
-missing `mdformat-all` command after Rust formatting completes.
-Implementation is now in progress after explicit user approval on
-2026-04-27.
-Stage A has landed locally and shows users how to consume `PageParams`, build
-`Paginated<T>` responses, map pagination errors, and document endpoint-local
-OpenAPI query parameters.
+This plan is complete. The port delivered pagination module and user-guide
+documentation for ordering requirements, limit normalization, error mapping,
+scope boundaries, Actix query extraction, and endpoint-local OpenAPI parameter
+documentation. It also added documentation-invariant BDD coverage plus unit
+tests for `CursorError::Serialize` and `PageParams` behaviour around
+`MAX_LIMIT`.
+
+The implementation deliberately did not add public API, new dependencies, or
+Wildside application-specific code. Full validation passed with
+`make check-fmt`, `make lint`, `make test`, `make markdownlint`, and
+`make nixie`. `make fmt` remains partially blocked in this environment because
+`mdformat-all` is not installed, but `cargo fmt --all` and
+`make check-fmt` both succeeded.
 
 ## Context and orientation
 
@@ -483,3 +516,7 @@ outcome.
 Revision note: Stage A documentation changes were completed and validated on
 2026-04-27. The remaining work is Stage B documentation-invariant BDD coverage,
 Stage C unit test hardening, final validation, and completion notes.
+
+Revision note: Stages B and C were completed on 2026-04-27, full validation
+passed, and the plan status changed to `COMPLETE`. The only remaining workflow
+step is to commit this final implementation and plan update.

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -36,9 +36,11 @@ began after user approval.
   `Direction`, `PageParams`, `PageParamsError`, `Paginated`,
   `PaginationLinks`, `DEFAULT_LIMIT`, `MAX_LIMIT`, `PAGE_PARAM_LIMIT`, and
   `PAGE_PARAM_CURSOR`.
-- Do not add new external dependencies. The current crate already has
-  `base64`, `serde`, `serde_json`, `thiserror`, `url`, `utoipa`, `rstest`, and
-  `rstest-bdd`, which are enough for the planned port.
+- Do not add new runtime dependencies without approval. The current crate
+  already has `base64`, `serde`, `serde_json`, `thiserror`, `url`, `utoipa`,
+  `rstest`, and `rstest-bdd`, which are enough for the planned port.
+- Approved test-only additions are `insta` and `tracing-test`; any further
+  dependency changes must distinguish between runtime and test scope.
 - Keep every Rust source file at or below 400 lines. If added tests would push
   `tests/pagination_bdd.rs` or any module over that limit, split the test
   support into a focused sibling file.
@@ -166,7 +168,8 @@ began after user approval.
   `decode_response` return observed status, trace header, and payload values
   for caller-side assertions.
 - [x] (2026-04-29 22:10Z) Added snapshot tests for documented pagination error
-  display text and shared OpenAPI schema JSON, accepted the initial `insta`
+  display text and shared OpenAPI schema JSON, using the approved test-only
+  dependencies `insta` and `tracing-test`, accepted the initial `insta`
   snapshots, and documented that `trybuild` is unnecessary because no
   compile-time public API constraint was identified.
 - [x] (2026-04-29 22:31Z) Added handler-level Actix integration tests for the

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -142,7 +142,11 @@ and documentation port itself starts only after approval.
   `make nixie`.
 - [x] (2026-04-27 00:52Z) Implemented all approved documentation and test
   changes.
-- [ ] Commit the completed implementation after this final plan update.
+- [x] (2026-04-27 00:52Z) Committed the completed implementation and plan
+  update.
+- [x] (2026-04-27 01:00Z) Fixed the post-turn hook environment issue where
+  `cargo` was absent from `PATH` by making Cargo recipes prepend the existing
+  `$HOME/.cargo/bin` directory while still invoking `cargo` by name.
 
 ## Surprises & Discoveries
 
@@ -207,6 +211,15 @@ and documentation port itself starts only after approval.
   Impact: The focused red/green run validated the new suite before the full
   repository gates.
 
+- Observation: The post-turn hook runs with a reduced `PATH` that did not
+  include the existing Cargo installation directory.
+  Evidence: The hook reported `make: cargo: No such file or directory` while
+  running `make check-fmt lint`; `env PATH=/usr/bin:/bin make check-fmt lint`
+  reproduced the same environment shape.
+  Impact: The Makefile now prepends `$HOME/.cargo/bin` to Cargo recipe `PATH`
+  values while continuing to call `cargo` by name. No shim, install step, or
+  recreated system script was introduced.
+
 ## Decision Log
 
 - Decision: Treat this as a documentation and test hardening port, not an
@@ -242,6 +255,12 @@ and documentation port itself starts only after approval.
   limit, and the new suite needed only small state and helper functions.
   Date/Author: 2026-04-27 00:52Z / Codex.
 
+- Decision: Make Cargo discovery recipe-local, not global, in the Makefile.
+  Rationale: The hook needed the existing Cargo binary directory on `PATH`, but
+  the repository should still call `cargo` directly and avoid shims or
+  generated wrapper scripts.
+  Date/Author: 2026-04-27 01:00Z / Codex.
+
 ## Outcomes & Retrospective
 
 This plan is complete. The port delivered pagination module and user-guide
@@ -257,6 +276,13 @@ Wildside application-specific code. Full validation passed with
 `make nixie`. `make fmt` remains partially blocked in this environment because
 `mdformat-all` is not installed, but `cargo fmt --all` and
 `make check-fmt` both succeeded.
+
+After completion, the post-turn hook exposed a reduced-`PATH` environment that
+could not find `cargo`. The Makefile now prepends the existing Cargo bin
+directory for Cargo recipes and the existing Bun bin directory for
+`markdownlint-cli2`, without installing or creating any replacement scripts.
+The reduced-`PATH` reproductions passed for `make check-fmt lint` and
+`make markdownlint`.
 
 ## Context and orientation
 
@@ -520,3 +546,8 @@ Stage C unit test hardening, final validation, and completion notes.
 Revision note: Stages B and C were completed on 2026-04-27, full validation
 passed, and the plan status changed to `COMPLETE`. The only remaining workflow
 step is to commit this final implementation and plan update.
+
+Revision note: Post-completion hook hardening was added on 2026-04-27 after a
+reduced-`PATH` hook could not find `cargo`. This does not change the pagination
+implementation; it keeps the documented validation commands runnable in the
+hook environment.

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -186,6 +186,9 @@ began after user approval.
   `markdownlint` path clause, documented `CursorError::TokenTooLong` on
   `Cursor::decode`, and collapsed pagination HTTP error cases into one
   parameterized `rstest`.
+- [x] (2026-04-30 00:06Z) Moved the cursor serialization error event from the
+  private `encode_cursor` helper to the public `Cursor::encode` boundary and
+  updated the module observability contract.
 
 ## Surprises & Discoveries
 

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -175,6 +175,9 @@ and documentation port itself starts only after approval.
 - [x] (2026-04-29 22:47Z) Documented Makefile build-tooling requirements for
   `CARGO_ENV`, `BUN_BIN`, reduced-`PATH` shells, and nextest detection in
   `docs/developers-guide.md`.
+- [x] (2026-04-29 23:02Z) Verified the cursor observability review finding and
+  removed `err` from `Cursor::encode` and `Cursor::decode` instrumentation so
+  only `CursorError::Serialize` emits the explicit library error event.
 
 ## Surprises & Discoveries
 

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -203,6 +203,8 @@ began after user approval.
 - [x] (2026-04-30 01:10Z) Aligned the normalized-limit helper name, argument
   order, and en-GB error text with review guidance, and used a structurally
   invalid JSON payload for deserialize tracing coverage.
+- [x] (2026-04-30 01:18Z) Documented the `Cursor::decode` parameter rename
+  from `value` to `token` in the user guide API changes section.
 
 ## Surprises & Discoveries
 

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -20,8 +20,9 @@ The goal is to port the parts of that commit that improve the reusable
 `actix-v2a` library without importing Wildside application code. Success is
 observable when a maintainer can read `src/pagination/mod.rs` and
 `docs/users-guide.md` to understand how to integrate cursor pagination, run a
-dedicated documentation-invariant BDD suite, and see the same repository gates
-pass with the new tests and documentation in place.
+dedicated documentation-invariant behaviour-driven development (BDD) suite, and
+see the same repository gates pass with the new tests and documentation in
+place.
 
 Do not begin implementation from this draft until the user explicitly approves
 the plan. The planning phase may create and commit this document, but the code
@@ -112,8 +113,8 @@ and documentation port itself starts only after approval.
   branch is `feat/portwildsidepagination`.
 - [x] (2026-04-26 23:31Z) Used a wyvern agent team for read-only
   reconnaissance: one agent analysed Wildside commit `9d6b7655`, and one agent
-  mapped the relevant `actix-v2a` pagination, OpenAPI, query DTO, test, and
-  gate surfaces.
+  mapped the relevant `actix-v2a` pagination, OpenAPI, query data transfer
+  object (DTO), test, and gate surfaces.
 - [x] (2026-04-26 23:31Z) Cloned Wildside commit `9d6b7655` into
   `/tmp/wildside-9d6b7655-read` and reviewed the upstream pagination docs,
   feature file, BDD documentation tests, and shared test fixture.
@@ -147,6 +148,14 @@ and documentation port itself starts only after approval.
 - [x] (2026-04-27 01:00Z) Fixed the post-turn hook environment issue where
   `cargo` was absent from `PATH` by making Cargo recipes prepend the existing
   `$HOME/.cargo/bin` directory while still invoking `cargo` by name.
+- [x] (2026-04-27 01:54Z) Addressed review comments by expanding first-use
+  acronyms, fixing the user-guide URL example, and changing documentation BDD
+  coverage to inspect structured `CursorError` variants instead of display
+  message substrings.
+- [x] (2026-04-27 02:01Z) Converted lint-exposed test helpers to return
+  `Result` values instead of using `expect`, then validated the review fixes
+  with `cargo test --test pagination_documentation_bdd`, `make check-fmt`,
+  `make lint`, `make markdownlint`, and `make test`.
 
 ## Surprises & Discoveries
 
@@ -220,6 +229,31 @@ and documentation port itself starts only after approval.
   values while continuing to call `cargo` by name. No shim, install step, or
   recreated system script was introduced.
 
+- Observation: The original user-guide pagination example parsed
+  `req.uri().to_string()` directly, but Actix request URIs are usually relative
+  paths.
+  Evidence: Code review noted that `Url::parse` expects an absolute URL for
+  this use, so the example would normally fail at runtime.
+  Impact: The example now combines Actix connection information with the
+  request URI before parsing the URL used for pagination links.
+
+- Observation: Checking `CursorError` display text made the documentation BDD
+  coverage sensitive to wording-only changes.
+  Evidence: Code review highlighted that substring checks were too tightly
+  coupled to error message prose.
+  Impact: The BDD step now asserts the documented variants and structured
+  fields instead of matching display strings.
+
+- Observation: The stricter lint toolchain now detects `expect` in helper
+  functions that are compiled only for tests but are not themselves test
+  functions.
+  Evidence: `make lint` reported `no_expect_outside_tests` for helper
+  functions in `src/http/error.rs`, `src/openapi/schemas.rs`, and
+  `src/pagination/cursor.rs`.
+  Impact: Those helpers now return `Result` where they perform fallible work,
+  and the actual test functions keep the assertion and failure-message
+  responsibility.
+
 ## Decision Log
 
 - Decision: Treat this as a documentation and test hardening port, not an
@@ -261,6 +295,23 @@ and documentation port itself starts only after approval.
   generated wrapper scripts.
   Date/Author: 2026-04-27 01:00Z / Codex.
 
+- Decision: Use Actix connection information for the user-guide pagination URL
+  example.
+  Rationale: `PaginationLinks::from_request` needs an absolute `Url`, while
+  `HttpRequest::uri()` is commonly relative. Combining scheme, host, and URI
+  documents a runtime-valid pattern.
+  Date/Author: 2026-04-27 01:54Z / Codex.
+
+- Decision: Keep documentation-invariant tests structural.
+  Rationale: The purpose is to verify documented error classes, not freeze
+  human-facing error wording.
+  Date/Author: 2026-04-27 01:54Z / Codex.
+
+- Decision: Fix the lint-exposed test helpers without adding suppressions.
+  Rationale: Returning `Result` from helpers keeps failure causes structured
+  while avoiding broad lint allowances or new test-only wrapper scripts.
+  Date/Author: 2026-04-27 02:01Z / Codex.
+
 ## Outcomes & Retrospective
 
 This plan is complete. The port delivered pagination module and user-guide
@@ -283,6 +334,15 @@ directory for Cargo recipes and the existing Bun bin directory for
 `markdownlint-cli2`, without installing or creating any replacement scripts.
 The reduced-`PATH` reproductions passed for `make check-fmt lint` and
 `make markdownlint`.
+
+Review feedback was incorporated after completion. The user-guide example now
+constructs an absolute URL from Actix connection information, the
+documentation-invariant BDD test inspects `CursorError` variants and fields
+instead of message substrings, and uncommon acronyms are expanded on first use.
+The stricter lint run also exposed test helper `expect` calls; these were
+converted to fallible helpers and the review-response change passed
+`cargo test --test pagination_documentation_bdd`, `make check-fmt`,
+`make lint`, `make markdownlint`, and `make test`.
 
 ## Context and orientation
 
@@ -551,3 +611,7 @@ Revision note: Post-completion hook hardening was added on 2026-04-27 after a
 reduced-`PATH` hook could not find `cargo`. This does not change the pagination
 implementation; it keeps the documented validation commands runnable in the
 hook environment.
+
+Revision note: Review comments were addressed on 2026-04-27 by correcting the
+pagination URL example, removing message-substring coupling from the
+documentation BDD test, and expanding first-use acronyms.

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -200,6 +200,9 @@ began after user approval.
   failure tracing coverage for caller-controlled cursor errors.
 - [x] (2026-04-30 01:02Z) Extracted shared normalized-limit BDD assertions and
   extended decode-failure tracing coverage to include the `Deserialize` variant.
+- [x] (2026-04-30 01:10Z) Aligned the normalized-limit helper name, argument
+  order, and en-GB error text with review guidance, and used a structurally
+  invalid JSON payload for deserialize tracing coverage.
 
 ## Surprises & Discoveries
 

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -1,0 +1,450 @@
+# Port Wildside pagination documentation hardening
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+Wildside commit `9d6b7655e3ad1a666a0e96beebd0a27b0d139388` published
+stronger pagination documentation, documentation-invariant tests, and several
+related test cleanups. `actix-v2a` already contains the shared pagination
+primitives imported from Wildside, but its local documentation and tests do not
+yet carry the full ordering, limit, error-mapping, and scope-boundary guidance
+from that later Wildside commit.
+
+The goal is to port the parts of that commit that improve the reusable
+`actix-v2a` library without importing Wildside application code. Success is
+observable when a maintainer can read `src/pagination/mod.rs` and
+`docs/users-guide.md` to understand how to integrate cursor pagination, run a
+dedicated documentation-invariant BDD suite, and see the same repository gates
+pass with the new tests and documentation in place.
+
+Do not begin implementation from this draft until the user explicitly approves
+the plan. The planning phase may create and commit this document, but the code
+and documentation port itself starts only after approval.
+
+## Constraints
+
+- Keep `actix-v2a` transport- and persistence-neutral. Do not add Diesel,
+  Wildside domain, repository, route, or service concepts.
+- Preserve the current public pagination API unless the user approves a public
+  API change. The existing surface includes `Cursor`, `CursorError`,
+  `Direction`, `PageParams`, `PageParamsError`, `Paginated`,
+  `PaginationLinks`, `DEFAULT_LIMIT`, `MAX_LIMIT`, `PAGE_PARAM_LIMIT`, and
+  `PAGE_PARAM_CURSOR`.
+- Do not add new external dependencies. The current crate already has
+  `base64`, `serde`, `serde_json`, `thiserror`, `url`, `utoipa`, `rstest`, and
+  `rstest-bdd`, which are enough for the planned port.
+- Keep every Rust source file at or below 400 lines. If added tests would push
+  `tests/pagination_bdd.rs` or any module over that limit, split the test
+  support into a focused sibling file.
+- Use `actix-v2a` error codes when documenting HTTP mapping. Wildside's
+  `invalid_cursor` and `invalid_page_params` envelope codes are not present in
+  this crate; this crate currently exposes `ErrorCode::InvalidRequest` and
+  `ErrorCode::InternalError` for those classes of failures.
+- Documentation and comments must use en-GB Oxford spelling, while preserving
+  external API spellings such as `Serialize`, `Deserialize`, `OpenAPI`, and
+  `base64url`.
+- Follow repository workflow: prefer Makefile targets, capture long command
+  output through `tee` under `/tmp`, run gates sequentially, and commit with a
+  message file via `git commit -F`.
+
+## Tolerances (exception triggers)
+
+- Scope: stop and escalate if implementation requires changes to more than 12
+  repository files or more than 450 net lines, excluding generated formatting
+  changes to this plan.
+- Interface: stop and escalate if any public function, type, enum variant, or
+  constant must be renamed, removed, or made public.
+- Dependencies: stop and escalate if a new crate, tool, or non-Makefile gate is
+  required.
+- Semantics: stop and escalate if the port reveals that `actix-v2a` runtime
+  pagination behaviour differs from the Wildside documentation in a way that
+  cannot be fixed without changing public API behaviour.
+- Tests: stop and escalate if `make check-fmt`, `make lint`, `make test`,
+  `make markdownlint`, or `make nixie` still fails after two focused fix
+  attempts for the same failure.
+- Ambiguity: stop and present options if OpenAPI pagination documentation would
+  require choosing between exposing a new reusable schema and documenting only
+  endpoint-local `#[utoipa::path]` query parameters.
+
+## Risks
+
+- Risk: Wildside's error-mapping table names envelope codes that do not exist
+  in `actix-v2a`.
+  Severity: medium.
+  Likelihood: high.
+  Mitigation: port the client-versus-server classification, not the literal
+  code strings. Document `CursorError::InvalidBase64`,
+  `CursorError::Deserialize`, `CursorError::TokenTooLong`, and
+  `PageParamsError::InvalidLimit` as `ErrorCode::InvalidRequest`, and
+  `CursorError::Serialize` as `ErrorCode::InternalError`.
+
+- Risk: The upstream commit contains many non-pagination test and domain
+  refactors that are tempting but not suitable for this library.
+  Severity: medium.
+  Likelihood: high.
+  Mitigation: limit implementation to pagination docs, pagination tests,
+  documentation-invariant tests, and directly relevant guide updates.
+
+- Risk: Adding a shared BDD fixture module could duplicate too much of the
+  existing `tests/pagination_bdd.rs` setup.
+  Severity: low.
+  Likelihood: medium.
+  Mitigation: extract only the state and helper functions that are needed by
+  both existing pagination scenarios and the new documentation scenarios.
+
+- Risk: Markdown formatting and Rustdoc examples can fail after prose changes.
+  Severity: medium.
+  Likelihood: medium.
+  Mitigation: run `make fmt`, `make markdownlint`, `make nixie`, `make lint`,
+  and `make test`, and keep examples executable unless they intentionally
+  demonstrate pseudocode or endpoint-local integration.
+
+## Progress
+
+- [x] (2026-04-26 23:31Z) Loaded repository instructions, the `leta`,
+  `rust-router`, `execplans`, and `commit-message` skills, and confirmed the
+  branch is `feat/portwildsidepagination`.
+- [x] (2026-04-26 23:31Z) Used a wyvern agent team for read-only
+  reconnaissance: one agent analysed Wildside commit `9d6b7655`, and one agent
+  mapped the relevant `actix-v2a` pagination, OpenAPI, query DTO, test, and
+  gate surfaces.
+- [x] (2026-04-26 23:31Z) Cloned Wildside commit `9d6b7655` into
+  `/tmp/wildside-9d6b7655-read` and reviewed the upstream pagination docs,
+  feature file, BDD documentation tests, and shared test fixture.
+- [x] (2026-04-26 23:31Z) Drafted this ExecPlan for user review.
+- [x] (2026-04-26 23:33Z) Added this plan to `docs/contents.md` and validated
+  the planning-only documentation change with `make check-fmt`,
+  `make markdownlint`, and `make nixie`.
+- [-] (2026-04-26 23:33Z) Attempted `make fmt`; `cargo +nightly fmt --all`
+  completed, but the target failed because `mdformat-all` is not installed in
+  this environment.
+- [ ] Await explicit approval before implementing the port.
+- [ ] Implement approved documentation and test changes.
+- [ ] Run and record the full validation gates.
+- [ ] Commit the implementation after the gates pass.
+
+## Surprises & Discoveries
+
+- Observation: `actix-v2a` already contains the imported pagination foundation,
+  including direction-aware cursors, `PageParams` normalization, and
+  `PaginationLinks::from_request`.
+  Evidence: `src/pagination/mod.rs`, `src/pagination/cursor.rs`,
+  `src/pagination/params.rs`, `src/pagination/envelope.rs`, and
+  `tests/pagination_bdd.rs` already cover these behaviours.
+  Impact: The port should harden documentation and coverage, not re-import the
+  pagination implementation.
+
+- Observation: Wildside commit `9d6b7655` changed 71 files, but most changes
+  are Wildside-specific domain, adapter, example-data, and script fixes.
+  Evidence: `git show --stat 9d6b7655` lists broad backend modules such as
+  catalogue, offline bundles, Overpass enrichment, users, WebSocket sessions,
+  `bun.lock`, and example-data generator modules.
+  Impact: These are excluded from the `actix-v2a` port unless a later user
+  request asks for a separate test-fixture refactor.
+
+- Observation: Wildside's pagination documentation says OpenAPI schema
+  generation is out of scope for its standalone pagination crate, while
+  `actix-v2a` already has reusable `utoipa` schema fragments for other shared
+  envelopes.
+  Evidence: Wildside `backend/crates/pagination/src/lib.rs` documents OpenAPI
+  schema generation as a consumer responsibility; local
+  `src/openapi/schemas.rs` contains `ErrorCodeSchema`, `ErrorSchema`, and
+  `ReplayMetadataSchema` only.
+  Impact: The plan should document endpoint-local pagination query parameters
+  rather than introduce a new reusable pagination OpenAPI schema by default.
+
+- Observation: `make fmt` is not fully runnable in this environment because
+  `mdformat-all` is missing.
+  Evidence: `/tmp/fmt-actix-v2a-feat-portwildsidepagination.out` records
+  `make: mdformat-all: No such file or directory` after
+  `cargo +nightly fmt --all` completed.
+  Impact: The planning commit can still be gated by `make check-fmt`,
+  `make markdownlint`, and `make nixie`, but the implementation phase should
+  either install `mdformat-all` or record the same environmental limitation.
+
+## Decision Log
+
+- Decision: Treat this as a documentation and test hardening port, not an
+  implementation import.
+  Rationale: The implementation was already imported by
+  `docs/execplans/import-components-from-wildside.md`; the later Wildside
+  commit mainly improves crate-level explanation and verification.
+  Date/Author: 2026-04-26 23:31Z / Codex.
+
+- Decision: Exclude Wildside domain, example-data, Bun/script, and broad
+  backend test-fixture changes from this port.
+  Rationale: Those changes target Wildside's application architecture and do
+  not map cleanly to a small shared Actix helper library.
+  Date/Author: 2026-04-26 23:31Z / Codex.
+
+- Decision: Adapt Wildside's error-mapping guidance to `actix-v2a`'s current
+  `ErrorCode` enum.
+  Rationale: Porting literal `invalid_cursor` or `invalid_page_params` codes
+  would require public API changes and contradict this plan's compatibility
+  constraint.
+  Date/Author: 2026-04-26 23:31Z / Codex.
+
+## Outcomes & Retrospective
+
+This plan is currently a draft. No port implementation has started. The
+planning outcome is a bounded, reviewable path that separates portable
+pagination documentation hardening from Wildside-specific application cleanup.
+The planning-only documentation change passed `make check-fmt`,
+`make markdownlint`, and `make nixie`; `make fmt` is partially blocked by a
+missing `mdformat-all` command after Rust formatting completes.
+
+## Context and orientation
+
+The current repository is the `actix_v2a` Rust crate. Pagination code lives
+under `src/pagination/`:
+
+- `src/pagination/mod.rs` provides module-level documentation and re-exports.
+- `src/pagination/cursor.rs` defines `Cursor<Key>`, `Direction`, and
+  `CursorError`.
+- `src/pagination/params.rs` defines `PageParams`, `PageParamsError`,
+  `DEFAULT_LIMIT`, `MAX_LIMIT`, `PAGE_PARAM_LIMIT`, and `PAGE_PARAM_CURSOR`.
+- `src/pagination/envelope.rs` defines `Paginated<T>` and `PaginationLinks`.
+
+User-facing crate documentation currently lives in `docs/users-guide.md`, and
+maintainer guidance lives in `docs/developers-guide.md`. Behavioural tests use
+`rstest-bdd` in `tests/pagination_bdd.rs` with Gherkin scenarios in
+`tests/features/pagination.feature` and
+`tests/features/direction_aware_cursors.feature`. OpenAPI component tests live
+in `tests/openapi_schemas_bdd.rs`.
+
+The relevant upstream Wildside files from commit `9d6b7655` are:
+
+- `backend/crates/pagination/src/lib.rs`
+- `backend/crates/pagination/src/cursor.rs`
+- `backend/crates/pagination/src/envelope.rs`
+- `backend/crates/pagination/src/params.rs`
+- `backend/crates/pagination/tests/common.rs`
+- `backend/crates/pagination/tests/features/pagination_documentation.feature`
+- `backend/crates/pagination/tests/pagination_bdd.rs`
+- `backend/crates/pagination/tests/pagination_documentation_bdd.rs`
+- `docs/developers-guide.md`
+
+The upstream commit also contains useful local test fixes, including
+`CursorError::Serialize` coverage and `PageParams` boundary coverage around
+`MAX_LIMIT`. Those are portable because the same error variants and constants
+exist in `actix-v2a`.
+
+## Plan of work
+
+Stage A updates documentation without changing behaviour. Expand
+`src/pagination/mod.rs` with the Wildside ordering requirements, default and
+maximum limit contract, consumer-owned database ordering responsibility,
+property-based testing responsibility, error-mapping guidance adapted to
+`ErrorCode::InvalidRequest` and `ErrorCode::InternalError`, and scope
+boundaries. Add short module-level context to `src/pagination/cursor.rs`,
+`src/pagination/params.rs`, and `src/pagination/envelope.rs` covering cursor
+encoding security, `PageParams` deserialization normalization, and link query
+parameter preservation. Add a concise pagination section to
+`docs/users-guide.md` with an `actix_web::web::Query<PageParams>` integration
+example and endpoint-local `utoipa` query-parameter note. Do not add new public
+schema wrappers in this stage.
+
+Stage B adds documentation-invariant coverage. Create
+`tests/features/pagination_documentation.feature` with scenarios for default
+limits, maximum limits, zero-limit rejection, invalid base64 cursor errors,
+invalid JSON cursor errors, token-too-long errors, and human-readable display
+strings. Create `tests/pagination_documentation_bdd.rs` to implement those
+scenarios. If shared state duplication becomes material, create
+`tests/pagination_common.rs` or `tests/common/pagination.rs` and move only
+shared `World`, `FixtureKey`, and limit setup helpers there, then update
+`tests/pagination_bdd.rs` to use that helper module. Keep this extraction small
+and purely test-local.
+
+Stage C adds unit test hardening copied in spirit from Wildside. In
+`src/pagination/cursor.rs`, add a test-only key type whose `Serialize`
+implementation fails, then assert `Cursor::encode` returns
+`CursorError::Serialize` with a useful message. In
+`src/pagination/params.rs`, replace the single oversized-limit test with
+focused `rstest` cases showing `MAX_LIMIT - 1` passes through unchanged,
+`MAX_LIMIT` passes through unchanged, and values above `MAX_LIMIT` clamp to
+`MAX_LIMIT`. Keep existing zero-limit and deserialization coverage.
+
+Stage D validates and commits. Run formatting and quality gates sequentially
+with `tee` logs in `/tmp`, inspect failures from the logs, make only focused
+fixes, and commit the approved implementation with a file-based commit
+message. If Stage A through C require more scope than the tolerances allow,
+update this ExecPlan and stop for direction.
+
+## Concrete steps
+
+Run all commands from repository root:
+
+```sh
+pwd
+git branch --show
+git status --short
+```
+
+Expected orientation:
+
+```plaintext
+/home/leynos/.lody/repos/github---leynos---actix-v2a/worktrees/5e4b6a0b-5a00-4e8c-b862-6b6b7fe27926
+feat/portwildsidepagination
+```
+
+After user approval, edit these files in order:
+
+1. `src/pagination/mod.rs`
+2. `src/pagination/cursor.rs`
+3. `src/pagination/envelope.rs`
+4. `src/pagination/params.rs`
+5. `docs/users-guide.md`
+6. `docs/developers-guide.md`, only if the shared test-layout guidance from
+   Wildside is still useful after local test changes
+7. `tests/features/pagination_documentation.feature`
+8. `tests/pagination_documentation_bdd.rs`
+9. `tests/pagination_bdd.rs`, only if shared fixture extraction is needed
+
+Format and validate with logs named by action and branch:
+
+```sh
+make fmt 2>&1 | tee /tmp/fmt-actix-v2a-feat-portwildsidepagination.out
+make check-fmt 2>&1 | tee /tmp/check-fmt-actix-v2a-feat-portwildsidepagination.out
+make lint 2>&1 | tee /tmp/lint-actix-v2a-feat-portwildsidepagination.out
+make test 2>&1 | tee /tmp/test-actix-v2a-feat-portwildsidepagination.out
+make markdownlint 2>&1 | tee /tmp/markdownlint-actix-v2a-feat-portwildsidepagination.out
+make nixie 2>&1 | tee /tmp/nixie-actix-v2a-feat-portwildsidepagination.out
+git status --short
+```
+
+If all gates pass, inspect the diff and commit with a message file:
+
+```sh
+git diff -- src/pagination tests docs
+git status --short
+COMMIT_MSG_DIR="$(mktemp -d)"
+cat > "$COMMIT_MSG_DIR/COMMIT_MSG.md" << 'ENDOFMSG'
+Harden pagination docs and invariants
+
+Port the reusable pagination documentation hardening from Wildside while
+adapting error-mapping guidance to the `actix-v2a` shared error codes.
+
+Add documentation-invariant coverage for the documented limit, cursor, and
+error contracts so future changes keep the prose and behaviour aligned.
+ENDOFMSG
+git commit -F "$COMMIT_MSG_DIR/COMMIT_MSG.md"
+rm -rf "$COMMIT_MSG_DIR"
+```
+
+## Validation and acceptance
+
+Acceptance for the implementation is all of the following:
+
+- `src/pagination/mod.rs` explains ordering requirements, default and maximum
+  limits, consumer-owned query ordering, property-based testing responsibility,
+  error mapping, and scope boundaries.
+- `docs/users-guide.md` contains a pagination section that shows how an Actix
+  handler consumes `PageParams`, returns `Paginated<T>`, and documents
+  endpoint-local OpenAPI query parameters without promising a reusable schema
+  wrapper that does not exist.
+- `tests/features/pagination_documentation.feature` and
+  `tests/pagination_documentation_bdd.rs` verify the documented invariants.
+- Unit tests cover `CursorError::Serialize` and `PageParams` behaviour around
+  `MAX_LIMIT`.
+- The gate commands `make check-fmt`, `make lint`, `make test`,
+  `make markdownlint`, and `make nixie` pass. `make fmt` may modify files
+  before the validation gates.
+
+Quality method:
+
+- Inspect `tee` logs under `/tmp` for each gate.
+- Record any unexpected failures in `Surprises & Discoveries`.
+- Update `Progress`, `Decision Log`, and `Outcomes & Retrospective` before the
+  implementation commit.
+
+## Idempotence and recovery
+
+The implementation steps are additive and can be repeated. If formatting
+changes more files than expected, inspect `git diff --stat` before continuing.
+If a gate fails, read the matching `/tmp` log, make one focused fix, rerun that
+gate, and then continue with the remaining gates. If the same gate fails after
+two focused attempts, stop under the tolerance rules.
+
+The Wildside scratch clone in `/tmp/wildside-9d6b7655-read` is read-only
+reference material and can be deleted at any time. The canonical source remains
+GitHub commit `9d6b7655e3ad1a666a0e96beebd0a27b0d139388`.
+
+## Artifacts and notes
+
+Wildside commit summary:
+
+```plaintext
+9d6b765 Publish crate pagination docs, tests, and exec plan (4.1.3) (#333)
+71 files changed, 3727 insertions(+), 1924 deletions(-)
+```
+
+Portable pagination files from that commit:
+
+```plaintext
+backend/crates/pagination/src/lib.rs
+backend/crates/pagination/src/cursor.rs
+backend/crates/pagination/src/envelope.rs
+backend/crates/pagination/src/params.rs
+backend/crates/pagination/tests/common.rs
+backend/crates/pagination/tests/features/pagination_documentation.feature
+backend/crates/pagination/tests/pagination_documentation_bdd.rs
+backend/crates/pagination/tests/pagination_bdd.rs
+```
+
+Excluded Wildside-only surfaces:
+
+```plaintext
+backend/src/domain/*
+backend/src/inbound/http/*
+backend/src/inbound/ws/*
+backend/src/outbound/*
+crates/example-data/*
+bun.lock
+scripts/check-overrides-parity.test.mjs
+docs/backend-roadmap.md
+docs/wildside-backend-architecture.md
+```
+
+## Interfaces and dependencies
+
+The port must keep using the existing pagination interfaces:
+
+```rust
+pub struct Cursor<Key> { /* existing private fields */ }
+pub enum CursorError {
+    Serialize { message: String },
+    InvalidBase64 { message: String },
+    TokenTooLong { max_len: usize },
+    Deserialize { message: String },
+}
+pub enum Direction { Next, Prev }
+pub struct PageParams { /* existing private fields */ }
+pub enum PageParamsError { InvalidLimit }
+pub struct PaginationLinks {
+    pub self_: String,
+    pub next: Option<String>,
+    pub prev: Option<String>,
+}
+pub struct Paginated<T> {
+    pub data: Vec<T>,
+    pub limit: usize,
+    pub links: PaginationLinks,
+}
+```
+
+The port must not introduce a public `RawPageParams`, `PaginationParamsSchema`,
+or endpoint-level OpenAPI wrapper unless the user explicitly approves that
+change after reviewing this draft.
+
+Revision note: Initial draft created after reviewing Wildside commit
+`9d6b7655e3ad1a666a0e96beebd0a27b0d139388` and the current `actix-v2a`
+pagination surface. The plan was then updated with planning-gate evidence and
+the local `mdformat-all` limitation. The remaining work is blocked on explicit
+approval because this plan recommends implementation changes beyond the
+planning phase.

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -327,7 +327,7 @@ and documentation port itself starts only after approval.
 This plan is complete. The port delivered pagination module and user-guide
 documentation for ordering requirements, limit normalization, error mapping,
 scope boundaries, Actix query extraction, and endpoint-local OpenAPI parameter
-documentation. It also added documentation-invariant BDD coverage plus unit
+documentation. It also added documentation-invariant BDD coverage, plus unit
 tests for `CursorError::Serialize` and `PageParams` behaviour around
 `MAX_LIMIT`.
 

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: IN PROGRESS
 
 ## Purpose / big picture
 
@@ -124,7 +124,8 @@ and documentation port itself starts only after approval.
 - [-] (2026-04-26 23:33Z) Attempted `make fmt`; `cargo +nightly fmt --all`
   completed, but the target failed because `mdformat-all` is not installed in
   this environment.
-- [ ] Await explicit approval before implementing the port.
+- [x] (2026-04-27 00:46Z) Received explicit user approval to proceed with the
+  implementation as set out in this ExecPlan.
 - [ ] Implement approved documentation and test changes.
 - [ ] Run and record the full validation gates.
 - [ ] Commit the implementation after the gates pass.
@@ -198,6 +199,8 @@ pagination documentation hardening from Wildside-specific application cleanup.
 The planning-only documentation change passed `make check-fmt`,
 `make markdownlint`, and `make nixie`; `make fmt` is partially blocked by a
 missing `mdformat-all` command after Rust formatting completes.
+Implementation is now in progress after explicit user approval on
+2026-04-27.
 
 ## Context and orientation
 
@@ -448,3 +451,8 @@ pagination surface. The plan was then updated with planning-gate evidence and
 the local `mdformat-all` limitation. The remaining work is blocked on explicit
 approval because this plan recommends implementation changes beyond the
 planning phase.
+
+Revision note: Implementation began on 2026-04-27 after explicit user approval.
+The plan status changed from `DRAFT` to `IN PROGRESS`; the remaining work is to
+ship the approved documentation and test changes, run the gates, and record the
+outcome.

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -172,6 +172,9 @@ and documentation port itself starts only after approval.
   compile-time public API constraint was identified.
 - [x] (2026-04-29 22:31Z) Added handler-level Actix integration tests for the
   pagination HTTP error-mapping table and a valid `Paginated<T>` response.
+- [x] (2026-04-29 22:47Z) Documented Makefile build-tooling requirements for
+  `CARGO_ENV`, `BUN_BIN`, reduced-`PATH` shells, and nextest detection in
+  `docs/developers-guide.md`.
 
 ## Surprises & Discoveries
 

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -205,6 +205,9 @@ began after user approval.
   invalid JSON payload for deserialize tracing coverage.
 - [x] (2026-04-30 01:18Z) Documented the `Cursor::decode` parameter rename
   from `value` to `token` in the user guide API changes section.
+- [x] (2026-04-30 01:28Z) Added pagination internals to the developer guide,
+  linked this ExecPlan from additional resources, and marked the pagination
+  documentation hardening workstream complete in the roadmap.
 
 ## Surprises & Discoveries
 

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -24,9 +24,8 @@ dedicated documentation-invariant behaviour-driven development (BDD) suite, and
 see the same repository gates pass with the new tests and documentation in
 place.
 
-Do not begin implementation from this draft until the user explicitly approves
-the plan. The planning phase may create and commit this document, but the code
-and documentation port itself starts only after approval.
+This plan was created and committed during the planning phase. Implementation
+began after user approval.
 
 ## Constraints
 

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -159,6 +159,9 @@ and documentation port itself starts only after approval.
 - [x] (2026-04-27 02:03Z) Tightened the user-guide URL example to build the
   absolute URL from Actix connection scheme, host, and `path_and_query()`
   explicitly.
+- [x] (2026-04-27 02:05Z) Verified the latest inline review findings, updated
+  the contents index and `Paginated<T>` sentence, and confirmed the URL example
+  already constructs an absolute URL before parsing.
 
 ## Surprises & Discoveries
 
@@ -344,6 +347,10 @@ documentation-invariant BDD test inspects `CursorError` variants and fields
 instead of message substrings, and uncommon acronyms are expanded on first use.
 The URL example was then tightened to show explicit `path_and_query()` handling
 instead of interpolating the full request URI.
+Later inline review findings were verified against the current code. The
+contents index now describes the plan as complete, the `Paginated<T>` OpenAPI
+sentence no longer has a comma before its "because" clause, and the URL example
+already builds an absolute URL before parsing.
 The stricter lint run also exposed test helper `expect` calls; these were
 converted to fallible helpers and the review-response change passed
 `cargo test --test pagination_documentation_bdd`, `make check-fmt`,

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -166,6 +166,12 @@ and documentation port itself starts only after approval.
   stale Stage B plan text to match variant-and-field error assertions, and made
   `decode_response` return observed status, trace header, and payload values
   for caller-side assertions.
+- [x] (2026-04-29 22:10Z) Added snapshot tests for documented pagination error
+  display text and shared OpenAPI schema JSON, accepted the initial `insta`
+  snapshots, and documented that `trybuild` is unnecessary because no
+  compile-time public API constraint was identified.
+- [x] (2026-04-29 22:31Z) Added handler-level Actix integration tests for the
+  pagination HTTP error-mapping table and a valid `Paginated<T>` response.
 
 ## Surprises & Discoveries
 
@@ -636,3 +642,7 @@ hook environment.
 Revision note: Review comments were addressed on 2026-04-27 by correcting the
 pagination URL example, removing message-substring coupling from the
 documentation BDD test, and expanding first-use acronyms.
+
+Revision note: Follow-up hardening continued on 2026-04-29 with tracing
+instrumentation, snapshot tests, and handler-level HTTP integration coverage
+for the pagination mapping contract.

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -126,6 +126,11 @@ and documentation port itself starts only after approval.
   this environment.
 - [x] (2026-04-27 00:46Z) Received explicit user approval to proceed with the
   implementation as set out in this ExecPlan.
+- [x] (2026-04-27 00:46Z) Completed Stage A documentation changes by expanding
+  pagination module docs and adding pagination integration guidance to
+  `docs/users-guide.md`.
+- [x] (2026-04-27 00:46Z) Validated Stage A with `make check-fmt`,
+  `make lint`, `make markdownlint`, and `make nixie`.
 - [ ] Implement approved documentation and test changes.
 - [ ] Run and record the full validation gates.
 - [ ] Commit the implementation after the gates pass.
@@ -169,6 +174,14 @@ and documentation port itself starts only after approval.
   `make markdownlint`, and `make nixie`, but the implementation phase should
   either install `mdformat-all` or record the same environmental limitation.
 
+- Observation: Adding a pagination "Error mapping" heading to
+  `docs/users-guide.md` conflicted with the existing SSE "Error mapping"
+  heading under Markdown lint's duplicate-heading rule.
+  Evidence: `make markdownlint` reported `MD024/no-duplicate-heading` for
+  `docs/users-guide.md`.
+  Impact: The pagination heading was renamed to "Pagination error mapping",
+  preserving the intended content while keeping the guide lint-clean.
+
 ## Decision Log
 
 - Decision: Treat this as a documentation and test hardening port, not an
@@ -191,6 +204,13 @@ and documentation port itself starts only after approval.
   constraint.
   Date/Author: 2026-04-26 23:31Z / Codex.
 
+- Decision: Document endpoint-local `utoipa::path` query parameters in the user
+  guide instead of adding reusable pagination schema wrappers.
+  Rationale: The plan's compatibility constraint forbids public API expansion
+  without approval, and pagination response schemata depend on each endpoint's
+  concrete item type.
+  Date/Author: 2026-04-27 00:46Z / Codex.
+
 ## Outcomes & Retrospective
 
 This plan is currently a draft. No port implementation has started. The
@@ -201,6 +221,9 @@ The planning-only documentation change passed `make check-fmt`,
 missing `mdformat-all` command after Rust formatting completes.
 Implementation is now in progress after explicit user approval on
 2026-04-27.
+Stage A has landed locally and shows users how to consume `PageParams`, build
+`Paginated<T>` responses, map pagination errors, and document endpoint-local
+OpenAPI query parameters.
 
 ## Context and orientation
 
@@ -456,3 +479,7 @@ Revision note: Implementation began on 2026-04-27 after explicit user approval.
 The plan status changed from `DRAFT` to `IN PROGRESS`; the remaining work is to
 ship the approved documentation and test changes, run the gates, and record the
 outcome.
+
+Revision note: Stage A documentation changes were completed and validated on
+2026-04-27. The remaining work is Stage B documentation-invariant BDD coverage,
+Stage C unit test hardening, final validation, and completion notes.

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -198,6 +198,8 @@ began after user approval.
 - [x] (2026-04-30 00:46Z) Converted pagination documentation BDD steps from
   panic-based `expect` calls to `StepResult` error propagation and added decode
   failure tracing coverage for caller-controlled cursor errors.
+- [x] (2026-04-30 01:02Z) Extracted shared normalized-limit BDD assertions and
+  extended decode-failure tracing coverage to include the `Deserialize` variant.
 
 ## Surprises & Discoveries
 

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -156,6 +156,9 @@ and documentation port itself starts only after approval.
   `Result` values instead of using `expect`, then validated the review fixes
   with `cargo test --test pagination_documentation_bdd`, `make check-fmt`,
   `make lint`, `make markdownlint`, and `make test`.
+- [x] (2026-04-27 02:03Z) Tightened the user-guide URL example to build the
+  absolute URL from Actix connection scheme, host, and `path_and_query()`
+  explicitly.
 
 ## Surprises & Discoveries
 
@@ -234,8 +237,8 @@ and documentation port itself starts only after approval.
   paths.
   Evidence: Code review noted that `Url::parse` expects an absolute URL for
   this use, so the example would normally fail at runtime.
-  Impact: The example now combines Actix connection information with the
-  request URI before parsing the URL used for pagination links.
+  Impact: The example now combines Actix connection information with
+  `path_and_query()` before parsing the URL used for pagination links.
 
 - Observation: Checking `CursorError` display text made the documentation BDD
   coverage sensitive to wording-only changes.
@@ -298,8 +301,8 @@ and documentation port itself starts only after approval.
 - Decision: Use Actix connection information for the user-guide pagination URL
   example.
   Rationale: `PaginationLinks::from_request` needs an absolute `Url`, while
-  `HttpRequest::uri()` is commonly relative. Combining scheme, host, and URI
-  documents a runtime-valid pattern.
+  `HttpRequest::uri()` is commonly relative. Combining scheme, host, and
+  `path_and_query()` documents a runtime-valid pattern.
   Date/Author: 2026-04-27 01:54Z / Codex.
 
 - Decision: Keep documentation-invariant tests structural.
@@ -339,6 +342,8 @@ Review feedback was incorporated after completion. The user-guide example now
 constructs an absolute URL from Actix connection information, the
 documentation-invariant BDD test inspects `CursorError` variants and fields
 instead of message substrings, and uncommon acronyms are expanded on first use.
+The URL example was then tightened to show explicit `path_and_query()` handling
+instead of interpolating the full request URI.
 The stricter lint run also exposed test helper `expect` calls; these were
 converted to fallible helpers and the review-response change passed
 `cargo test --test pagination_documentation_bdd`, `make check-fmt`,

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -178,6 +178,10 @@ and documentation port itself starts only after approval.
 - [x] (2026-04-29 23:02Z) Verified the cursor observability review finding and
   removed `err` from `Cursor::encode` and `Cursor::decode` instrumentation so
   only `CursorError::Serialize` emits the explicit library error event.
+- [x] (2026-04-29 23:13Z) Verified review findings around Makefile
+  documentation and pagination HTTP query parsing, then clarified the
+  `markdownlint` inline `PATH` behaviour and replaced substring matching with
+  exact query-parameter parsing.
 
 ## Surprises & Discoveries
 

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -195,6 +195,9 @@ began after user approval.
 - [x] (2026-04-30 00:24Z) Replaced the documentation BDD synthetic serialize
   error with `Cursor::new(FailingKey).encode()` and added tracing capture
   coverage for cursor encode/decode spans and serialization error events.
+- [x] (2026-04-30 00:46Z) Converted pagination documentation BDD steps from
+  panic-based `expect` calls to `StepResult` error propagation and added decode
+  failure tracing coverage for caller-controlled cursor errors.
 
 ## Surprises & Discoveries
 

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -236,7 +236,7 @@ and documentation port itself starts only after approval.
   running `make check-fmt lint`; `env PATH=/usr/bin:/bin make check-fmt lint`
   reproduced the same environment shape.
   Impact: The Makefile now prepends `$HOME/.cargo/bin` to Cargo recipe `PATH`
-  values while continuing to call `cargo` by name. No shim, install step, or
+  values, while continuing to call `cargo` by name. No shim, install step, or
   recreated system script was introduced.
 
 - Observation: The original user-guide pagination example parsed
@@ -255,7 +255,7 @@ and documentation port itself starts only after approval.
   fields instead of matching display strings.
 
 - Observation: The stricter lint toolchain now detects `expect` in helper
-  functions that are compiled only for tests but are not themselves test
+  functions that are compiled only for tests, but are not themselves test
   functions.
   Evidence: `make lint` reported `no_expect_outside_tests` for helper
   functions in `src/http/error.rs`, `src/openapi/schemas.rs`, and

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -51,3 +51,19 @@ without pulling event-store, routing, or authorization logic into this crate.
     by the execplan closing milestone.
   - Pass `make fmt`, `make markdownlint`, and `make nixie` on the final
     documentation set.
+
+## 2. Pagination documentation hardening
+
+Harden the reusable `actix-v2a` pagination module with expanded documentation,
+BDD and handler-level test coverage, and observability instrumentation.
+
+- [x] 2.1. Port Wildside pagination documentation hardening.
+  See
+  [`docs/execplans/portwildsidepagination.md`](execplans/portwildsidepagination.md).
+  - Documented cursor key ordering invariants and limit normalisation semantics
+    in `src/pagination/mod.rs`.
+  - Added BDD coverage (`tests/pagination_documentation_bdd.rs`) and
+    handler-level coverage (`tests/pagination_http_bdd.rs`).
+  - Added snapshot tests for error `Display` outputs and OpenAPI schemas.
+  - Instrumented `Cursor::encode` and `Cursor::decode` with tracing spans and
+    error events.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -3,6 +3,106 @@
 This guide provides usage documentation for the `actix-v2a` crate's public API.
 It assumes familiarity with Rust, Actix Web, and HTTP fundamentals.
 
+## Cursor pagination helpers
+
+The `pagination` module provides shared cursor, query parameter, response
+envelope, and link-building primitives for keyset pagination. Keyset
+pagination means that each page uses an opaque cursor containing an ordered
+boundary key rather than a numeric offset.
+
+### Query parameters (`PageParams`)
+
+Use `PageParams` with Actix Web's query extractor to parse the shared
+`cursor` and `limit` query parameters:
+
+```rust
+use actix_v2a::pagination::{PageParams, Paginated, PaginationLinks};
+use actix_web::{HttpRequest, get, web};
+use url::Url;
+
+#[get("/users")]
+async fn list_users(
+    req: HttpRequest,
+    params: web::Query<PageParams>,
+) -> Result<web::Json<Paginated<String>>, actix_v2a::Error> {
+    let params = params.into_inner();
+    let request_url = Url::parse(&req.uri().to_string())
+        .map_err(|_| actix_v2a::Error::invalid_request_static("invalid request URI"))?;
+
+    // Application code applies the cursor predicates and stable ordering.
+    let users = vec!["Ada Lovelace".to_owned()];
+    let next_cursor = None;
+    let prev_cursor = None;
+
+    Ok(web::Json(Paginated::new(
+        users,
+        params.limit(),
+        PaginationLinks::from_request(&request_url, &params, next_cursor, prev_cursor),
+    )))
+}
+```
+
+`PageParams` normalizes page sizes consistently:
+
+- Missing `limit`: uses `DEFAULT_LIMIT` (`20`).
+- `limit` greater than `MAX_LIMIT`: clamps to `MAX_LIMIT` (`100`).
+- `limit=0`: fails with `PageParamsError::InvalidLimit`.
+
+### Cursor keys (`Cursor`)
+
+Cursor keys must match the endpoint's stable ordering. A typical key contains a
+sortable field followed by a unique tie-breaker:
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct UserCursorKey {
+    created_at: String,
+    id: String,
+}
+```
+
+The backing query must use the same fields in the same order for every page.
+If the ordering changes between requests, clients may see skipped or duplicated
+records. `actix-v2a` validates cursor encoding and decoding, but it cannot
+prove that a downstream database index or query predicate is correct. Consumers
+should cover those ordering invariants in their own repository or integration
+tests.
+
+### Pagination error mapping
+
+HTTP adapters should map caller-controlled pagination failures to
+`ErrorCode::InvalidRequest`:
+
+- `CursorError::InvalidBase64`
+- `CursorError::Deserialize`
+- `CursorError::TokenTooLong`
+- `PageParamsError::InvalidLimit`
+
+`CursorError::Serialize` indicates that the server could not encode its own
+cursor key type. Map that failure to `ErrorCode::InternalError` and log the
+underlying serialization error for investigation.
+
+### OpenAPI notes
+
+Pagination query parameters are endpoint-local API details. Document them on
+each endpoint rather than exposing a shared schema wrapper:
+
+```rust
+#[utoipa::path(
+    params(
+        ("cursor" = Option<String>, Query, description = "Opaque pagination cursor"),
+        ("limit" = Option<usize>, Query, description = "Page size, capped at 100")
+    )
+)]
+async fn list_users() {}
+```
+
+Endpoint response schemata should describe the concrete item type carried in
+`Paginated<T>`, because each endpoint owns its item schema and cursor key
+shape.
+
 ## Server-Sent Events (SSE) helpers
 
 The `sse` module provides wire-level helpers for implementing Server-Sent

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -26,7 +26,13 @@ async fn list_users(
     params: web::Query<PageParams>,
 ) -> Result<web::Json<Paginated<String>>, actix_v2a::Error> {
     let params = params.into_inner();
-    let request_url = Url::parse(&req.uri().to_string())
+    let connection = req.connection_info();
+    let request_url = Url::parse(&format!(
+        "{}://{}{}",
+        connection.scheme(),
+        connection.host(),
+        req.uri()
+    ))
         .map_err(|_| actix_v2a::Error::invalid_request_static("invalid request URI"))?;
 
     // Application code applies the cursor predicates and stable ordering.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -111,8 +111,7 @@ async fn list_users() {}
 ```
 
 Endpoint response schemata should describe the concrete item type carried in
-`Paginated<T>`, because each endpoint owns its item schema and cursor key
-shape.
+`Paginated<T>` because each endpoint owns its item schema and cursor key shape.
 
 ## Server-Sent Events (SSE) helpers
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -113,6 +113,14 @@ async fn list_users() {}
 Endpoint response schemata should describe the concrete item type carried in
 `Paginated<T>` because each endpoint owns its item schema and cursor key shape.
 
+## API changes
+
+### `Cursor::decode` parameter rename
+
+The `value` parameter of `Cursor::decode` has been renamed to `token` to better
+reflect its role as an opaque cursor token. Call sites are unaffected; no
+source changes are required.
+
 ## Server-Sent Events (SSE) helpers
 
 The `sse` module provides wire-level helpers for implementing Server-Sent

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -27,12 +27,17 @@ async fn list_users(
 ) -> Result<web::Json<Paginated<String>>, actix_v2a::Error> {
     let params = params.into_inner();
     let connection = req.connection_info();
-    let request_url = Url::parse(&format!(
+    let path_and_query = req
+        .uri()
+        .path_and_query()
+        .map_or("/", |value| value.as_str());
+    let absolute_url = format!(
         "{}://{}{}",
         connection.scheme(),
         connection.host(),
-        req.uri()
-    ))
+        path_and_query
+    );
+    let request_url = Url::parse(&absolute_url)
         .map_err(|_| actix_v2a::Error::invalid_request_static("invalid request URI"))?;
 
     // Application code applies the cursor predicates and stable ordering.

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -125,28 +125,28 @@ mod tests {
 
     use crate::{Error, ErrorCode, TRACE_ID_HEADER};
 
-    async fn decode_response(
-        error: Error,
-        expected_status: StatusCode,
-        expected_trace_id: Option<&str>,
-    ) -> Result<Error, Box<dyn std::error::Error>> {
-        let response = error.error_response();
-        assert_eq!(response.status(), expected_status);
+    struct DecodedResponse {
+        status: StatusCode,
+        trace_id: Option<String>,
+        payload: Error,
+    }
 
-        let trace_header = response.headers().get(TRACE_ID_HEADER);
-        match expected_trace_id {
-            Some(expected) => {
-                let trace_id = trace_header
-                    .ok_or_else(|| std::io::Error::other("trace header should be present"))?
-                    .to_str()?;
-                assert_eq!(trace_id, expected);
-            }
-            None => assert!(trace_header.is_none()),
-        }
+    async fn decode_response(error: Error) -> Result<DecodedResponse, Box<dyn std::error::Error>> {
+        let response = error.error_response();
+        let status = response.status();
+        let trace_id = response
+            .headers()
+            .get(TRACE_ID_HEADER)
+            .map(|value| value.to_str().map(ToOwned::to_owned))
+            .transpose()?;
 
         let body = to_bytes(response.into_body()).await?;
 
-        Ok(serde_json::from_slice(&body)?)
+        Ok(DecodedResponse {
+            status,
+            trace_id,
+            payload: serde_json::from_slice(&body)?,
+        })
     }
 
     #[test]
@@ -195,14 +195,16 @@ mod tests {
             .expect("trace identifier should be valid")
             .with_details(json!({"secret": true}));
 
-        let payload = decode_response(error, StatusCode::INTERNAL_SERVER_ERROR, Some("trace-123"))
+        let decoded = decode_response(error)
             .await
             .expect("response should decode");
 
-        assert_eq!(payload.code(), ErrorCode::InternalError);
-        assert_eq!(payload.message(), "Internal server error");
-        assert_eq!(payload.trace_id(), Some("trace-123"));
-        assert_eq!(payload.details(), None);
+        assert_eq!(decoded.status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(decoded.trace_id.as_deref(), Some("trace-123"));
+        assert_eq!(decoded.payload.code(), ErrorCode::InternalError);
+        assert_eq!(decoded.payload.message(), "Internal server error");
+        assert_eq!(decoded.payload.trace_id(), Some("trace-123"));
+        assert_eq!(decoded.payload.details(), None);
     }
 
     #[actix_web::test]
@@ -211,11 +213,13 @@ mod tests {
             .try_with_trace_id("trace\n123")
             .expect("trace identifier should be stored before HTTP validation");
 
-        let payload = decode_response(error, StatusCode::INTERNAL_SERVER_ERROR, None)
+        let decoded = decode_response(error)
             .await
             .expect("response should decode");
 
-        assert_eq!(payload.trace_id(), Some("trace\n123"));
+        assert_eq!(decoded.status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(decoded.trace_id, None);
+        assert_eq!(decoded.payload.trace_id(), Some("trace\n123"));
     }
 
     #[actix_web::test]
@@ -225,14 +229,16 @@ mod tests {
             .expect("trace identifier should be valid")
             .with_details(json!({"field": "name"}));
 
-        let payload = decode_response(error, StatusCode::BAD_REQUEST, Some("trace-456"))
+        let decoded = decode_response(error)
             .await
             .expect("response should decode");
 
-        assert_eq!(payload.code(), ErrorCode::InvalidRequest);
-        assert_eq!(payload.message(), "bad");
-        assert_eq!(payload.trace_id(), Some("trace-456"));
-        assert_eq!(payload.details(), Some(&json!({"field": "name"})));
+        assert_eq!(decoded.status, StatusCode::BAD_REQUEST);
+        assert_eq!(decoded.trace_id.as_deref(), Some("trace-456"));
+        assert_eq!(decoded.payload.code(), ErrorCode::InvalidRequest);
+        assert_eq!(decoded.payload.message(), "bad");
+        assert_eq!(decoded.payload.trace_id(), Some("trace-456"));
+        assert_eq!(decoded.payload.details(), Some(&json!({"field": "name"})));
     }
 
     fn bad_request_error() -> actix_web::Error { actix_web::error::ErrorBadRequest("boom") }

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -129,7 +129,7 @@ mod tests {
         error: Error,
         expected_status: StatusCode,
         expected_trace_id: Option<&str>,
-    ) -> Error {
+    ) -> Result<Error, Box<dyn std::error::Error>> {
         let response = error.error_response();
         assert_eq!(response.status(), expected_status);
 
@@ -137,19 +137,16 @@ mod tests {
         match expected_trace_id {
             Some(expected) => {
                 let trace_id = trace_header
-                    .expect("trace header should be present")
-                    .to_str()
-                    .expect("trace header should be UTF-8");
+                    .ok_or_else(|| std::io::Error::other("trace header should be present"))?
+                    .to_str()?;
                 assert_eq!(trace_id, expected);
             }
             None => assert!(trace_header.is_none()),
         }
 
-        let body = to_bytes(response.into_body())
-            .await
-            .expect("response body should be readable");
+        let body = to_bytes(response.into_body()).await?;
 
-        serde_json::from_slice(&body).expect("error payload should deserialize")
+        Ok(serde_json::from_slice(&body)?)
     }
 
     #[test]
@@ -198,8 +195,9 @@ mod tests {
             .expect("trace identifier should be valid")
             .with_details(json!({"secret": true}));
 
-        let payload =
-            decode_response(error, StatusCode::INTERNAL_SERVER_ERROR, Some("trace-123")).await;
+        let payload = decode_response(error, StatusCode::INTERNAL_SERVER_ERROR, Some("trace-123"))
+            .await
+            .expect("response should decode");
 
         assert_eq!(payload.code(), ErrorCode::InternalError);
         assert_eq!(payload.message(), "Internal server error");
@@ -213,7 +211,9 @@ mod tests {
             .try_with_trace_id("trace\n123")
             .expect("trace identifier should be stored before HTTP validation");
 
-        let payload = decode_response(error, StatusCode::INTERNAL_SERVER_ERROR, None).await;
+        let payload = decode_response(error, StatusCode::INTERNAL_SERVER_ERROR, None)
+            .await
+            .expect("response should decode");
 
         assert_eq!(payload.trace_id(), Some("trace\n123"));
     }
@@ -225,7 +225,9 @@ mod tests {
             .expect("trace identifier should be valid")
             .with_details(json!({"field": "name"}));
 
-        let payload = decode_response(error, StatusCode::BAD_REQUEST, Some("trace-456")).await;
+        let payload = decode_response(error, StatusCode::BAD_REQUEST, Some("trace-456"))
+            .await
+            .expect("response should decode");
 
         assert_eq!(payload.code(), ErrorCode::InvalidRequest);
         assert_eq!(payload.message(), "bad");

--- a/src/openapi/schemas.rs
+++ b/src/openapi/schemas.rs
@@ -83,17 +83,7 @@ mod tests {
         let schema = schema_json::<ErrorCodeSchema>().expect("schema should serialize");
 
         assert_eq!(ErrorCodeSchema::name(), "crate.ErrorCode");
-        for variant in [
-            "invalid_request",
-            "unauthorized",
-            "forbidden",
-            "not_found",
-            "conflict",
-            "service_unavailable",
-            "internal_error",
-        ] {
-            assert!(schema.contains(variant), "missing variant {variant}");
-        }
+        insta::assert_snapshot!("error_code_schema_json", schema);
     }
 
     #[test]
@@ -131,9 +121,7 @@ mod tests {
         let schema = schema_json::<ErrorSchema>().expect("schema should serialize");
 
         assert_eq!(ErrorSchema::name(), "crate.Error");
-        for field in ["code", "message", "traceId", "details"] {
-            assert!(schema.contains(field), "missing field {field}");
-        }
+        insta::assert_snapshot!("error_schema_json", schema);
     }
 
     #[test]
@@ -144,6 +132,6 @@ mod tests {
             ReplayMetadataSchema::name(),
             "crate.idempotency.ReplayMetadata"
         );
-        assert!(schema.contains("replayed"));
+        insta::assert_snapshot!("replay_metadata_schema_json", schema);
     }
 }

--- a/src/openapi/schemas.rs
+++ b/src/openapi/schemas.rs
@@ -74,13 +74,13 @@ mod tests {
     use super::{ErrorCodeSchema, ErrorSchema, ReplayMetadataSchema};
     use crate::ErrorCode;
 
-    fn schema_json<T: PartialSchema>() -> String {
-        serde_json::to_string(&T::schema()).expect("schema should serialize")
+    fn schema_json<T: PartialSchema>() -> serde_json::Result<String> {
+        serde_json::to_string(&T::schema())
     }
 
     #[test]
     fn error_code_schema_has_expected_name_and_variants() {
-        let schema = schema_json::<ErrorCodeSchema>();
+        let schema = schema_json::<ErrorCodeSchema>().expect("schema should serialize");
 
         assert_eq!(ErrorCodeSchema::name(), "crate.ErrorCode");
         for variant in [
@@ -128,7 +128,7 @@ mod tests {
 
     #[test]
     fn error_schema_has_expected_name_and_fields() {
-        let schema = schema_json::<ErrorSchema>();
+        let schema = schema_json::<ErrorSchema>().expect("schema should serialize");
 
         assert_eq!(ErrorSchema::name(), "crate.Error");
         for field in ["code", "message", "traceId", "details"] {
@@ -138,7 +138,7 @@ mod tests {
 
     #[test]
     fn replay_metadata_schema_has_expected_name_and_field() {
-        let schema = schema_json::<ReplayMetadataSchema>();
+        let schema = schema_json::<ReplayMetadataSchema>().expect("schema should serialize");
 
         assert_eq!(
             ReplayMetadataSchema::name(),

--- a/src/openapi/snapshots/actix_v2a__openapi__schemas__tests__error_code_schema_json.snap
+++ b/src/openapi/snapshots/actix_v2a__openapi__schemas__tests__error_code_schema_json.snap
@@ -1,0 +1,5 @@
+---
+source: src/openapi/schemas.rs
+expression: schema
+---
+{"type":"string","description":"`OpenAPI` schema for [`crate::ErrorCode`].","enum":["invalid_request","unauthorized","forbidden","not_found","conflict","service_unavailable","internal_error"]}

--- a/src/openapi/snapshots/actix_v2a__openapi__schemas__tests__error_schema_json.snap
+++ b/src/openapi/snapshots/actix_v2a__openapi__schemas__tests__error_schema_json.snap
@@ -1,0 +1,5 @@
+---
+source: src/openapi/schemas.rs
+expression: schema
+---
+{"type":"object","description":"`OpenAPI` schema for [`crate::Error`].","required":["code","message"],"properties":{"code":{"$ref":"#/components/schemas/crate.ErrorCode","description":"Stable machine-readable error code."},"details":{"description":"Supplementary error details for clients."},"message":{"type":"string","description":"Human-readable message returned to clients.","example":"Something went wrong"},"traceId":{"type":["string","null"],"description":"Correlation identifier for tracing this error across systems.","example":"trace-123"}}}

--- a/src/openapi/snapshots/actix_v2a__openapi__schemas__tests__replay_metadata_schema_json.snap
+++ b/src/openapi/snapshots/actix_v2a__openapi__schemas__tests__replay_metadata_schema_json.snap
@@ -1,0 +1,5 @@
+---
+source: src/openapi/schemas.rs
+expression: schema
+---
+{"type":"object","description":"`OpenAPI` schema for [`crate::idempotency::ReplayMetadata`].","required":["replayed"],"properties":{"replayed":{"type":"boolean","description":"Whether the response was replayed from an existing idempotency record.","example":true}}}

--- a/src/pagination/cursor.rs
+++ b/src/pagination/cursor.rs
@@ -175,7 +175,11 @@ where
     /// Returns [`CursorError::Serialize`] when the cursor key cannot be
     /// serialized into JSON.
     #[instrument(skip(self))]
-    pub fn encode(&self) -> Result<String, CursorError> { encode_cursor(self) }
+    pub fn encode(&self) -> Result<String, CursorError> {
+        encode_cursor(self).inspect_err(|error| {
+            tracing::error!(error = %error, "cursor serialization failed");
+        })
+    }
 }
 
 impl<Key> Cursor<Key>
@@ -198,11 +202,8 @@ fn encode_cursor<Key>(cursor: &Cursor<Key>) -> Result<String, CursorError>
 where
     Key: Serialize,
 {
-    let payload = serde_json::to_vec(cursor).map_err(|e| {
-        tracing::error!(error = %e, "cursor serialization failed");
-        CursorError::Serialize {
-            message: e.to_string(),
-        }
+    let payload = serde_json::to_vec(cursor).map_err(|error| CursorError::Serialize {
+        message: error.to_string(),
     })?;
     Ok(URL_SAFE_NO_PAD.encode(payload))
 }

--- a/src/pagination/cursor.rs
+++ b/src/pagination/cursor.rs
@@ -11,6 +11,7 @@ use base64::{
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use thiserror::Error;
+use tracing::instrument;
 
 const MAX_CURSOR_TOKEN_LEN: usize = 8 * 1024;
 
@@ -173,12 +174,12 @@ where
     ///
     /// Returns [`CursorError::Serialize`] when the cursor key cannot be
     /// serialized into JSON.
-    pub fn encode(&self) -> Result<String, CursorError> {
-        let payload = serde_json::to_vec(self).map_err(|error| CursorError::Serialize {
-            message: error.to_string(),
-        })?;
-        Ok(URL_SAFE_NO_PAD.encode(payload))
-    }
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "tracing::instrument expands guard code that trips the lint"
+    )]
+    #[instrument(skip(self), err)]
+    pub fn encode(&self) -> Result<String, CursorError> { encode_cursor(self) }
 }
 
 impl<Key> Cursor<Key>
@@ -189,26 +190,49 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`CursorError::InvalidBase64`] when `value` is not valid
+    /// Returns [`CursorError::InvalidBase64`] when `token` is not valid
     /// base64url and [`CursorError::Deserialize`] when the decoded JSON does
     /// not match the expected cursor shape.
-    pub fn decode(value: &str) -> Result<Self, CursorError> {
-        if value.len() > MAX_CURSOR_TOKEN_LEN {
-            return Err(CursorError::TokenTooLong {
-                max_len: MAX_CURSOR_TOKEN_LEN,
-            });
-        }
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "tracing::instrument expands guard code that trips the lint"
+    )]
+    #[instrument(skip(token), err)]
+    pub fn decode(token: &str) -> Result<Self, CursorError> { decode_cursor(token) }
+}
 
-        let payload = URL_SAFE_NO_PAD
-            .decode(value)
-            .or_else(|_| URL_SAFE.decode(value))
-            .map_err(|error| CursorError::InvalidBase64 {
-                message: error.to_string(),
-            })?;
-        serde_json::from_slice(&payload).map_err(|error| CursorError::Deserialize {
-            message: error.to_string(),
-        })
+fn encode_cursor<Key>(cursor: &Cursor<Key>) -> Result<String, CursorError>
+where
+    Key: Serialize,
+{
+    let payload = serde_json::to_vec(cursor).map_err(|e| {
+        tracing::error!(error = %e, "cursor serialization failed");
+        CursorError::Serialize {
+            message: e.to_string(),
+        }
+    })?;
+    Ok(URL_SAFE_NO_PAD.encode(payload))
+}
+
+fn decode_cursor<Key>(token: &str) -> Result<Cursor<Key>, CursorError>
+where
+    Key: DeserializeOwned,
+{
+    if token.len() > MAX_CURSOR_TOKEN_LEN {
+        return Err(CursorError::TokenTooLong {
+            max_len: MAX_CURSOR_TOKEN_LEN,
+        });
     }
+
+    let payload = URL_SAFE_NO_PAD
+        .decode(token)
+        .or_else(|_| URL_SAFE.decode(token))
+        .map_err(|error| CursorError::InvalidBase64 {
+            message: error.to_string(),
+        })?;
+    serde_json::from_slice(&payload).map_err(|error| CursorError::Deserialize {
+        message: error.to_string(),
+    })
 }
 
 #[cfg(test)]

--- a/src/pagination/cursor.rs
+++ b/src/pagination/cursor.rs
@@ -174,11 +174,7 @@ where
     ///
     /// Returns [`CursorError::Serialize`] when the cursor key cannot be
     /// serialized into JSON.
-    #[expect(
-        clippy::cognitive_complexity,
-        reason = "tracing::instrument expands guard code that trips the lint"
-    )]
-    #[instrument(skip(self), err)]
+    #[instrument(skip(self))]
     pub fn encode(&self) -> Result<String, CursorError> { encode_cursor(self) }
 }
 
@@ -193,11 +189,7 @@ where
     /// Returns [`CursorError::InvalidBase64`] when `token` is not valid
     /// base64url and [`CursorError::Deserialize`] when the decoded JSON does
     /// not match the expected cursor shape.
-    #[expect(
-        clippy::cognitive_complexity,
-        reason = "tracing::instrument expands guard code that trips the lint"
-    )]
-    #[instrument(skip(token), err)]
+    #[instrument(skip(token))]
     pub fn decode(token: &str) -> Result<Self, CursorError> { decode_cursor(token) }
 }
 

--- a/src/pagination/cursor.rs
+++ b/src/pagination/cursor.rs
@@ -1,4 +1,9 @@
 //! Opaque cursor encoding and decoding helpers.
+//!
+//! A cursor is a base64url-encoded JSON representation of one ordering key and
+//! a pagination direction. The token is URL-safe and opaque to clients, but it
+//! is not signed or encrypted. Do not place secrets in cursor keys, and treat
+//! decoded cursor data as caller-controlled input.
 
 use base64::{
     Engine as _,

--- a/src/pagination/cursor.rs
+++ b/src/pagination/cursor.rs
@@ -217,7 +217,7 @@ mod tests {
 
     use base64::Engine as _;
     use rstest::{fixture, rstest};
-    use serde::{Deserialize, Serialize};
+    use serde::{Deserialize, Serialize, Serializer};
 
     use super::{Cursor, CursorError, Direction, MAX_CURSOR_TOKEN_LEN};
 
@@ -225,6 +225,17 @@ mod tests {
     struct FixtureKey {
         created_at: String,
         id: String,
+    }
+
+    struct FailingKey;
+
+    impl Serialize for FailingKey {
+        fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            Err(serde::ser::Error::custom("fixture serialization failed"))
+        }
     }
 
     #[fixture]
@@ -262,6 +273,20 @@ mod tests {
             Cursor::<FixtureKey>::decode(&encoded).expect("cursor decoding should succeed");
 
         assert_eq!(decoded, cursor);
+    }
+
+    #[test]
+    fn cursor_encode_reports_serialization_failure() {
+        let cursor = Cursor::new(FailingKey);
+
+        let result = cursor.encode();
+
+        assert_eq!(
+            result,
+            Err(CursorError::Serialize {
+                message: "fixture serialization failed".to_owned(),
+            })
+        );
     }
 
     #[rstest]

--- a/src/pagination/cursor.rs
+++ b/src/pagination/cursor.rs
@@ -186,8 +186,9 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`CursorError::InvalidBase64`] when `token` is not valid
-    /// base64url and [`CursorError::Deserialize`] when the decoded JSON does
+    /// Returns [`CursorError::TokenTooLong`] when `token` exceeds the accepted
+    /// input size, [`CursorError::InvalidBase64`] when `token` is not valid
+    /// base64url, and [`CursorError::Deserialize`] when the decoded JSON does
     /// not match the expected cursor shape.
     #[instrument(skip(token))]
     pub fn decode(token: &str) -> Result<Self, CursorError> { decode_cursor(token) }

--- a/src/pagination/cursor.rs
+++ b/src/pagination/cursor.rs
@@ -250,13 +250,15 @@ mod tests {
     const _CONST_DIRECTIONAL_CURSOR: Cursor<&str> =
         Cursor::with_direction("compile-time-test", Direction::Prev);
 
-    fn encode_without_padding(cursor: &Cursor<FixtureKey>) -> String {
-        cursor.encode().expect("cursor encoding should succeed")
+    fn encode_without_padding(cursor: &Cursor<FixtureKey>) -> Result<String, CursorError> {
+        cursor.encode()
     }
 
-    fn encode_with_padding(cursor: &Cursor<FixtureKey>) -> String {
-        let payload = serde_json::to_vec(cursor).expect("cursor should serialize");
-        base64::engine::general_purpose::URL_SAFE.encode(payload)
+    fn encode_with_padding(cursor: &Cursor<FixtureKey>) -> Result<String, CursorError> {
+        let payload = serde_json::to_vec(cursor).map_err(|error| CursorError::Serialize {
+            message: error.to_string(),
+        })?;
+        Ok(base64::engine::general_purpose::URL_SAFE.encode(payload))
     }
 
     #[rstest]
@@ -264,10 +266,10 @@ mod tests {
     #[case::padded(encode_with_padding)]
     fn cursor_decodes_successfully(
         fixture_key: FixtureKey,
-        #[case] encode: for<'a> fn(&'a Cursor<FixtureKey>) -> String,
+        #[case] encode: for<'a> fn(&'a Cursor<FixtureKey>) -> Result<String, CursorError>,
     ) {
         let cursor = Cursor::new(fixture_key);
-        let encoded = encode(&cursor);
+        let encoded = encode(&cursor).expect("cursor encoding should succeed");
 
         let decoded =
             Cursor::<FixtureKey>::decode(&encoded).expect("cursor decoding should succeed");

--- a/src/pagination/envelope.rs
+++ b/src/pagination/envelope.rs
@@ -1,4 +1,10 @@
 //! Paginated response envelopes and hypermedia links.
+//!
+//! [`Paginated<T>`] wraps one stable page of response data, the effective page
+//! size, and navigation links. [`PaginationLinks::from_request`] preserves
+//! non-pagination query parameters while replacing the shared `limit` and
+//! `cursor` parameters, so filters remain stable as clients follow `next` and
+//! `prev` links.
 
 use serde::Serialize;
 use url::{Url, form_urlencoded};

--- a/src/pagination/mod.rs
+++ b/src/pagination/mod.rs
@@ -10,6 +10,77 @@
 //! Cursors are opaque tokens that encode a position within an ordered dataset.
 //! They support bidirectional navigation via [`Direction`] (`Next` or `Prev`).
 //!
+//! # Ordering requirements
+//!
+//! Key types used with [`Cursor`] must satisfy strict ordering guarantees so
+//! that pagination remains stable across all pages of one endpoint:
+//!
+//! - The key type must implement `Serialize` and `DeserializeOwned` so cursors can be encoded into
+//!   and decoded from opaque base64url JSON tokens.
+//! - The key fields must correspond to a total ordering in the backing store. A common pattern is
+//!   ordering by a filterable field such as `created_at`, followed by a unique tie-breaker such as
+//!   a UUID primary key.
+//! - The ordering must remain consistent between requests for the same endpoint. If a query changes
+//!   ordering between pages, clients may see skipped or duplicated records.
+//!
+//! Consumers are responsible for applying the same ordering and cursor
+//! predicates in their repositories or query adapters. This module does not
+//! validate database ordering at runtime because that guarantee depends on the
+//! consumer's key type, filters, and indexes. Property-based tests for ordering
+//! invariants therefore belong in the consuming application.
+//!
+//! # Default and maximum limits
+//!
+//! Page size limits are controlled by two shared constants:
+//!
+//! - [`DEFAULT_LIMIT`]: 20 records per page when no limit is supplied.
+//! - [`MAX_LIMIT`]: 100 records per page as the shared upper bound.
+//!
+//! [`PageParams`] normalizes limits during construction and deserialization.
+//! Missing limits use [`DEFAULT_LIMIT`], oversized limits clamp to
+//! [`MAX_LIMIT`], and zero limits return [`PageParamsError::InvalidLimit`].
+//!
+//! ```
+//! use actix_v2a::pagination::{DEFAULT_LIMIT, MAX_LIMIT, PageParams};
+//!
+//! let default_page = PageParams::new(None, None).expect("default page params are valid");
+//! assert_eq!(default_page.limit(), DEFAULT_LIMIT);
+//!
+//! let capped_page = PageParams::new(None, Some(200)).expect("oversized limit should clamp");
+//! assert_eq!(capped_page.limit(), MAX_LIMIT);
+//!
+//! let zero_limit = PageParams::new(None, Some(0));
+//! assert_eq!(
+//!     zero_limit,
+//!     Err(actix_v2a::pagination::PageParamsError::InvalidLimit)
+//! );
+//! ```
+//!
+//! # Error mapping
+//!
+//! HTTP adapters should map pagination errors into the shared API error
+//! envelope according to whether the caller or server caused the failure:
+//!
+//! | Error type          | Variant         | HTTP status | Error code                   |
+//! |---------------------|-----------------|-------------|------------------------------|
+//! | [`CursorError`]     | `InvalidBase64` | 400         | [`crate::ErrorCode::InvalidRequest`] |
+//! | [`CursorError`]     | `Deserialize`   | 400         | [`crate::ErrorCode::InvalidRequest`] |
+//! | [`CursorError`]     | `TokenTooLong`  | 400         | [`crate::ErrorCode::InvalidRequest`] |
+//! | [`CursorError`]     | `Serialize`     | 500         | [`crate::ErrorCode::InternalError`]  |
+//! | [`PageParamsError`] | `InvalidLimit`  | 400         | [`crate::ErrorCode::InvalidRequest`] |
+//!
+//! `CursorError::Serialize` is a server-side failure because the endpoint's own
+//! key type could not be encoded. It should be logged and investigated rather
+//! than reported as a malformed client cursor.
+//!
+//! # Scope boundaries
+//!
+//! This module intentionally does not provide database filters, connection
+//! pooling, endpoint-specific `OpenAPI` schemata, or framework extractors.
+//! Inbound adapters can deserialize [`PageParams`] with framework facilities
+//! such as Actix Web's query extractor, and outbound adapters must apply the
+//! endpoint-specific ordering and cursor predicates.
+//!
 //! # Example
 //!
 //! ```

--- a/src/pagination/mod.rs
+++ b/src/pagination/mod.rs
@@ -74,9 +74,9 @@
 //! than reported as a malformed client cursor.
 //!
 //! For observability, [`Cursor::encode`] and [`Cursor::decode`] are
-//! instrumented with `tracing` spans. `CursorError::Serialize` also emits a
-//! `tracing::error!` event before the error is returned, so callers do not need
-//! to re-log that failure. Other [`CursorError`] variants and
+//! instrumented with `tracing` spans. The public [`Cursor::encode`] method also
+//! emits a `tracing::error!` event before returning `CursorError::Serialize`,
+//! so callers do not need to re-log that failure. Other [`CursorError`] variants and
 //! [`PageParamsError`] variants are caller-controlled input failures; the
 //! library does not emit error events for them.
 //!

--- a/src/pagination/mod.rs
+++ b/src/pagination/mod.rs
@@ -73,6 +73,13 @@
 //! key type could not be encoded. It should be logged and investigated rather
 //! than reported as a malformed client cursor.
 //!
+//! For observability, [`Cursor::encode`] and [`Cursor::decode`] are
+//! instrumented with `tracing` spans. `CursorError::Serialize` also emits a
+//! `tracing::error!` event before the error is returned, so callers do not need
+//! to re-log that failure. Other [`CursorError`] variants and
+//! [`PageParamsError`] variants are caller-controlled input failures; the
+//! library does not emit error events for them.
+//!
 //! # Scope boundaries
 //!
 //! This module intentionally does not provide database filters, connection

--- a/src/pagination/params.rs
+++ b/src/pagination/params.rs
@@ -100,6 +100,7 @@ fn normalize_limit(limit: Option<usize>) -> Result<usize, PageParamsError> {
 mod tests {
     //! Unit tests for page parameter normalization.
 
+    use rstest::rstest;
     use serde_json::json;
 
     use super::{DEFAULT_LIMIT, MAX_LIMIT, PageParams, PageParamsError};
@@ -112,12 +113,19 @@ mod tests {
         assert_eq!(params.cursor(), None);
     }
 
-    #[test]
-    fn page_params_cap_limit_to_shared_maximum() {
-        let params = PageParams::new(Some("opaque".to_owned()), Some(MAX_LIMIT + 50))
-            .expect("oversized limit should clamp");
+    #[rstest]
+    #[case::one_below_max(MAX_LIMIT - 1, MAX_LIMIT - 1)]
+    #[case::exact_max(MAX_LIMIT, MAX_LIMIT)]
+    #[case::one_above_max(MAX_LIMIT + 1, MAX_LIMIT)]
+    #[case::far_above_max(MAX_LIMIT + 50, MAX_LIMIT)]
+    fn page_params_normalize_limits_around_shared_maximum(
+        #[case] requested_limit: usize,
+        #[case] expected_limit: usize,
+    ) {
+        let params = PageParams::new(Some("opaque".to_owned()), Some(requested_limit))
+            .expect("limit should normalize");
 
-        assert_eq!(params.limit(), MAX_LIMIT);
+        assert_eq!(params.limit(), expected_limit);
         assert_eq!(params.cursor(), Some("opaque"));
     }
 

--- a/src/pagination/params.rs
+++ b/src/pagination/params.rs
@@ -1,4 +1,10 @@
 //! Query parameter parsing and normalization for paginated endpoints.
+//!
+//! [`PageParams`] is the shared query DTO for `cursor` and `limit`. Its custom
+//! `Deserialize` implementation applies the same normalization as
+//! [`PageParams::new`]: missing limits default to [`DEFAULT_LIMIT`], oversized
+//! limits clamp to [`MAX_LIMIT`], and zero limits are rejected. This keeps
+//! Actix Web query extractors and hand-built parameters aligned.
 
 use serde::{Deserialize, Deserializer, Serialize};
 use thiserror::Error;

--- a/tests/features/pagination_documentation.feature
+++ b/tests/features/pagination_documentation.feature
@@ -1,0 +1,35 @@
+Feature: Pagination documentation invariants
+  The pagination documentation promises specific behaviour for limits, cursors,
+  and error handling. These scenarios verify that the documented invariants hold
+  at runtime.
+
+  Scenario: Default limit is applied when no limit is provided
+    Given pagination documentation parameters without a limit
+    Then the documented normalized limit equals DEFAULT_LIMIT
+
+  Scenario: Maximum limit caps oversized requests
+    Given pagination documentation parameters with limit 500
+    Then the documented normalized limit equals MAX_LIMIT
+
+  Scenario: Zero limit is rejected with an error
+    When pagination documentation parameters are created with limit 0
+    Then page parameter creation fails with InvalidLimit error
+
+  Scenario: Invalid base64 token produces InvalidBase64 error
+    Given an invalid base64 cursor token "not!valid"
+    When the documentation cursor is decoded
+    Then decoding fails with InvalidBase64 error
+
+  Scenario: Structurally invalid JSON produces Deserialize error
+    Given a base64url token containing invalid JSON
+    When the documentation cursor is decoded
+    Then decoding fails with Deserialize error
+
+  Scenario: Oversized cursor token produces TokenTooLong error
+    Given an oversized cursor token
+    When the documentation cursor is decoded
+    Then decoding fails with TokenTooLong error
+
+  Scenario: Error display strings are human-readable
+    Given pagination errors of different documented variants
+    Then each pagination error display string contains a descriptive message

--- a/tests/features/pagination_documentation.feature
+++ b/tests/features/pagination_documentation.feature
@@ -30,6 +30,6 @@ Feature: Pagination documentation invariants
     When the documentation cursor is decoded
     Then decoding fails with TokenTooLong error
 
-  Scenario: Error display strings are human-readable
+  Scenario: Documented cursor error variants are represented
     Given pagination errors of different documented variants
-    Then each pagination error display string contains a descriptive message
+    Then each documented cursor error variant is represented

--- a/tests/pagination_documentation_bdd.rs
+++ b/tests/pagination_documentation_bdd.rs
@@ -10,7 +10,7 @@ use actix_v2a::pagination::{
 };
 use base64::Engine as _;
 use rstest::fixture;
-use rstest_bdd::Slot;
+use rstest_bdd::{Slot, StepResult};
 use rstest_bdd_macros::{ScenarioState, given, scenario, then, when};
 use serde::{Deserialize, Serialize, Serializer};
 
@@ -49,24 +49,24 @@ fn world() -> World {
 }
 
 #[given("pagination documentation parameters without a limit")]
-#[expect(
-    clippy::expect_used,
-    reason = "BDD steps use expect for clear failures"
-)]
-fn pagination_documentation_parameters_without_a_limit(world: &World) {
-    let params = PageParams::new(None, None).expect("default params should be valid");
+fn pagination_documentation_parameters_without_a_limit(world: &World) -> StepResult<(), String> {
+    let params = PageParams::new(None, None)
+        .map_err(|error| format!("default params should be valid: {error}"))?;
     world.page_params.set(params);
+    Ok(())
 }
 
 #[given("pagination documentation parameters with limit {limit:u64}")]
-#[expect(
-    clippy::expect_used,
-    reason = "BDD steps use expect for clear failures"
-)]
-fn pagination_documentation_parameters_with_limit(world: &World, limit: u64) {
-    let requested_limit = usize::try_from(limit).expect("fixture limit should fit usize");
-    let params = PageParams::new(None, Some(requested_limit)).expect("params should be valid");
+fn pagination_documentation_parameters_with_limit(
+    world: &World,
+    limit: u64,
+) -> StepResult<(), String> {
+    let requested_limit = usize::try_from(limit)
+        .map_err(|error| format!("fixture limit should fit usize: {error}"))?;
+    let params = PageParams::new(None, Some(requested_limit))
+        .map_err(|error| format!("params should be valid: {error}"))?;
     world.page_params.set(params);
+    Ok(())
 }
 
 #[given("an invalid base64 cursor token {token}")]
@@ -107,130 +107,153 @@ fn collect_cursor_error(errors: &mut Vec<CursorError>, result: Result<impl Sized
 }
 
 #[when("the documentation cursor is decoded")]
-#[expect(
-    clippy::expect_used,
-    reason = "BDD steps use expect for clear failures"
-)]
-fn the_documentation_cursor_is_decoded(world: &World) {
+fn the_documentation_cursor_is_decoded(world: &World) -> StepResult<(), String> {
     let token = world
         .cursor_token
         .get()
-        .expect("cursor token should be set")
+        .ok_or_else(|| "cursor token should be set".to_owned())?
         .clone();
     world
         .decode_result
         .set(Cursor::<FixtureKey>::decode(&token));
+    Ok(())
 }
 
 #[when("pagination documentation parameters are created with limit {limit:u64}")]
-#[expect(
-    clippy::expect_used,
-    reason = "BDD steps use expect for clear failures"
-)]
-fn pagination_documentation_parameters_are_created_with_limit(world: &World, limit: u64) {
-    let requested_limit = usize::try_from(limit).expect("fixture limit should fit usize");
+fn pagination_documentation_parameters_are_created_with_limit(
+    world: &World,
+    limit: u64,
+) -> StepResult<(), String> {
+    let requested_limit = usize::try_from(limit)
+        .map_err(|error| format!("fixture limit should fit usize: {error}"))?;
     let result = PageParams::new(None, Some(requested_limit));
     world.page_params_result.set(result);
+    Ok(())
 }
 
 #[then("the documented normalized limit equals DEFAULT_LIMIT")]
-#[expect(
-    clippy::expect_used,
-    reason = "BDD steps use expect for clear failures"
-)]
-fn the_documented_normalized_limit_equals_default_limit(world: &World) {
-    let params = world.page_params.get().expect("page params should be set");
+fn the_documented_normalized_limit_equals_default_limit(world: &World) -> StepResult<(), String> {
+    let params = world
+        .page_params
+        .get()
+        .ok_or_else(|| "page params should be set".to_owned())?;
 
-    assert_eq!(params.limit(), DEFAULT_LIMIT);
+    if params.limit() == DEFAULT_LIMIT {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected normalized limit {DEFAULT_LIMIT}, got {}",
+            params.limit()
+        ))
+    }
 }
 
 #[then("the documented normalized limit equals MAX_LIMIT")]
-#[expect(
-    clippy::expect_used,
-    reason = "BDD steps use expect for clear failures"
-)]
-fn the_documented_normalized_limit_equals_max_limit(world: &World) {
-    let params = world.page_params.get().expect("page params should be set");
+fn the_documented_normalized_limit_equals_max_limit(world: &World) -> StepResult<(), String> {
+    let params = world
+        .page_params
+        .get()
+        .ok_or_else(|| "page params should be set".to_owned())?;
 
-    assert_eq!(params.limit(), MAX_LIMIT);
+    if params.limit() == MAX_LIMIT {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected normalized limit {MAX_LIMIT}, got {}",
+            params.limit()
+        ))
+    }
 }
 
 #[then("page parameter creation fails with InvalidLimit error")]
-#[expect(
-    clippy::expect_used,
-    reason = "BDD steps use expect for clear failures"
-)]
-fn page_parameter_creation_fails_with_invalid_limit_error(world: &World) {
+fn page_parameter_creation_fails_with_invalid_limit_error(world: &World) -> StepResult<(), String> {
     let result = world
         .page_params_result
         .get()
-        .expect("page params result should be set");
+        .ok_or_else(|| "page params result should be set".to_owned())?;
 
-    assert_eq!(result, Err(PageParamsError::InvalidLimit));
+    if result == Err(PageParamsError::InvalidLimit) {
+        Ok(())
+    } else {
+        Err(format!("expected InvalidLimit error, got {result:?}"))
+    }
 }
 
 #[then("decoding fails with InvalidBase64 error")]
-fn decoding_fails_with_invalid_base64_error(world: &World) {
+fn decoding_fails_with_invalid_base64_error(world: &World) -> StepResult<(), String> {
     assert_decode_error(world, |error| {
         matches!(error, CursorError::InvalidBase64 { .. })
-    });
+    })
 }
 
 #[then("decoding fails with Deserialize error")]
-fn decoding_fails_with_deserialize_error(world: &World) {
+fn decoding_fails_with_deserialize_error(world: &World) -> StepResult<(), String> {
     assert_decode_error(world, |error| {
         matches!(error, CursorError::Deserialize { .. })
-    });
+    })
 }
 
 #[then("decoding fails with TokenTooLong error")]
-fn decoding_fails_with_token_too_long_error(world: &World) {
+fn decoding_fails_with_token_too_long_error(world: &World) -> StepResult<(), String> {
     assert_decode_error(world, |error| {
         matches!(error, CursorError::TokenTooLong { .. })
-    });
+    })
 }
 
-#[expect(
-    clippy::expect_used,
-    reason = "BDD helpers use expect for clear failures"
-)]
-fn assert_decode_error(world: &World, matches_error: impl FnOnce(&CursorError) -> bool) {
+fn assert_decode_error(
+    world: &World,
+    matches_error: impl FnOnce(&CursorError) -> bool,
+) -> StepResult<(), String> {
     let result = world
         .decode_result
         .get()
-        .expect("decode result should be set");
-    let error = result.as_ref().expect_err("cursor decoding should fail");
+        .ok_or_else(|| "decode result should be set".to_owned())?;
 
-    assert!(matches_error(error));
+    match result {
+        Err(error) if matches_error(&error) => Ok(()),
+        Err(error) => Err(format!(
+            "cursor decoding failed with unexpected error: {error:?}"
+        )),
+        Ok(cursor) => Err(format!("cursor decoding should fail, got {cursor:?}")),
+    }
 }
 
 #[then("each documented cursor error variant is represented")]
-#[expect(
-    clippy::expect_used,
-    reason = "BDD steps use expect for clear failures"
-)]
-fn each_documented_cursor_error_variant_is_represented(world: &World) {
+fn each_documented_cursor_error_variant_is_represented(world: &World) -> StepResult<(), String> {
     let errors = world
         .cursor_errors
         .get()
-        .expect("cursor errors should be set");
+        .ok_or_else(|| "cursor errors should be set".to_owned())?;
 
-    assert!(errors.iter().any(
-        |error| matches!(error, CursorError::InvalidBase64 { message } if !message.is_empty())
-    ));
-    assert!(
-        errors.iter().any(
-            |error| matches!(error, CursorError::Deserialize { message } if !message.is_empty())
-        )
+    let has_invalid_base64 = errors.iter().any(
+        |error| matches!(error, CursorError::InvalidBase64 { message } if !message.is_empty()),
     );
-    assert!(errors.iter().any(
-        |error| matches!(error, CursorError::TokenTooLong { max_len } if *max_len == 8 * 1024)
-    ));
-    assert!(
-        errors.iter().any(
-            |error| matches!(error, CursorError::Serialize { message } if !message.is_empty())
-        )
+    let has_deserialize = errors
+        .iter()
+        .any(|error| matches!(error, CursorError::Deserialize { message } if !message.is_empty()));
+    let has_token_too_long = errors.iter().any(
+        |error| matches!(error, CursorError::TokenTooLong { max_len } if *max_len == 8 * 1024),
     );
+    let has_serialize = errors
+        .iter()
+        .any(|error| matches!(error, CursorError::Serialize { message } if !message.is_empty()));
+
+    let all_variants_represented = [
+        has_invalid_base64,
+        has_deserialize,
+        has_token_too_long,
+        has_serialize,
+    ]
+    .into_iter()
+    .all(std::convert::identity);
+
+    if all_variants_represented {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected every documented cursor error variant, got {errors:?}"
+        ))
+    }
 }
 
 #[test]

--- a/tests/pagination_documentation_bdd.rs
+++ b/tests/pagination_documentation_bdd.rs
@@ -133,33 +133,28 @@ fn pagination_documentation_parameters_are_created_with_limit(
 
 #[then("the documented normalized limit equals DEFAULT_LIMIT")]
 fn the_documented_normalized_limit_equals_default_limit(world: &World) -> StepResult<(), String> {
-    let params = world
-        .page_params
-        .get()
-        .ok_or_else(|| "page params should be set".to_owned())?;
-
-    if params.limit() == DEFAULT_LIMIT {
-        Ok(())
-    } else {
-        Err(format!(
-            "expected normalized limit {DEFAULT_LIMIT}, got {}",
-            params.limit()
-        ))
-    }
+    assert_documented_normalized_limit_equals(DEFAULT_LIMIT, world)
 }
 
 #[then("the documented normalized limit equals MAX_LIMIT")]
 fn the_documented_normalized_limit_equals_max_limit(world: &World) -> StepResult<(), String> {
+    assert_documented_normalized_limit_equals(MAX_LIMIT, world)
+}
+
+fn assert_documented_normalized_limit_equals(
+    expected: usize,
+    world: &World,
+) -> StepResult<(), String> {
     let params = world
         .page_params
         .get()
         .ok_or_else(|| "page params should be set".to_owned())?;
 
-    if params.limit() == MAX_LIMIT {
+    if params.limit() == expected {
         Ok(())
     } else {
         Err(format!(
-            "expected normalized limit {MAX_LIMIT}, got {}",
+            "expected normalized limit {expected}, got {}",
             params.limit()
         ))
     }

--- a/tests/pagination_documentation_bdd.rs
+++ b/tests/pagination_documentation_bdd.rs
@@ -133,18 +133,15 @@ fn pagination_documentation_parameters_are_created_with_limit(
 
 #[then("the documented normalized limit equals DEFAULT_LIMIT")]
 fn the_documented_normalized_limit_equals_default_limit(world: &World) -> StepResult<(), String> {
-    assert_documented_normalized_limit_equals(DEFAULT_LIMIT, world)
+    assert_normalized_limit(world, DEFAULT_LIMIT)
 }
 
 #[then("the documented normalized limit equals MAX_LIMIT")]
 fn the_documented_normalized_limit_equals_max_limit(world: &World) -> StepResult<(), String> {
-    assert_documented_normalized_limit_equals(MAX_LIMIT, world)
+    assert_normalized_limit(world, MAX_LIMIT)
 }
 
-fn assert_documented_normalized_limit_equals(
-    expected: usize,
-    world: &World,
-) -> StepResult<(), String> {
+fn assert_normalized_limit(world: &World, expected: usize) -> StepResult<(), String> {
     let params = world
         .page_params
         .get()
@@ -154,7 +151,7 @@ fn assert_documented_normalized_limit_equals(
         Ok(())
     } else {
         Err(format!(
-            "expected normalized limit {expected}, got {}",
+            "expected normalised limit {expected}, got {}",
             params.limit()
         ))
     }

--- a/tests/pagination_documentation_bdd.rs
+++ b/tests/pagination_documentation_bdd.rs
@@ -198,31 +198,33 @@ fn assert_decode_error(world: &World, matches_error: impl FnOnce(&CursorError) -
     assert!(matches_error(error));
 }
 
-#[then("each pagination error display string contains a descriptive message")]
+#[then("each documented cursor error variant is represented")]
 #[expect(
     clippy::expect_used,
     reason = "BDD steps use expect for clear failures"
 )]
-fn each_pagination_error_display_string_contains_a_descriptive_message(world: &World) {
+fn each_documented_cursor_error_variant_is_represented(world: &World) {
     let errors = world
         .cursor_errors
         .get()
         .expect("cursor errors should be set");
 
-    for error in errors {
-        let display = format!("{error}");
-        assert!(
-            has_descriptive_error_text(&display),
-            "error display string should be descriptive; got: {display}"
-        );
-    }
-}
-
-fn has_descriptive_error_text(display: &str) -> bool {
-    display.contains("base64")
-        || display.contains("deserialization")
-        || display.contains("exceeds maximum length")
-        || display.contains("serialization")
+    assert!(errors.iter().any(
+        |error| matches!(error, CursorError::InvalidBase64 { message } if !message.is_empty())
+    ));
+    assert!(
+        errors.iter().any(
+            |error| matches!(error, CursorError::Deserialize { message } if !message.is_empty())
+        )
+    );
+    assert!(errors.iter().any(
+        |error| matches!(error, CursorError::TokenTooLong { max_len } if *max_len == 8 * 1024)
+    ));
+    assert!(
+        errors.iter().any(
+            |error| matches!(error, CursorError::Serialize { message } if !message.is_empty())
+        )
+    );
 }
 
 #[scenario(path = "tests/features/pagination_documentation.feature")]

--- a/tests/pagination_documentation_bdd.rs
+++ b/tests/pagination_documentation_bdd.rs
@@ -12,7 +12,7 @@ use base64::Engine as _;
 use rstest::fixture;
 use rstest_bdd::Slot;
 use rstest_bdd_macros::{ScenarioState, given, scenario, then, when};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 
 const OVERSIZED_CURSOR_LEN: usize = 8 * 1024 + 1;
 
@@ -20,6 +20,17 @@ const OVERSIZED_CURSOR_LEN: usize = 8 * 1024 + 1;
 struct FixtureKey {
     created_at: String,
     id: String,
+}
+
+struct FailingKey;
+
+impl Serialize for FailingKey {
+    fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Err(serde::ser::Error::custom("fixture serialization failed"))
+    }
 }
 
 #[derive(Debug, Default, ScenarioState)]
@@ -84,17 +95,12 @@ fn pagination_errors_of_different_documented_variants(world: &World) {
         Cursor::<FixtureKey>::decode(&"a".repeat(OVERSIZED_CURSOR_LEN)),
     );
 
-    errors.push(CursorError::Serialize {
-        message: "fixture serialization failed".to_owned(),
-    });
+    collect_cursor_error(&mut errors, Cursor::new(FailingKey).encode());
 
     world.cursor_errors.set(errors);
 }
 
-fn collect_cursor_error(
-    errors: &mut Vec<CursorError>,
-    result: Result<Cursor<FixtureKey>, CursorError>,
-) {
+fn collect_cursor_error(errors: &mut Vec<CursorError>, result: Result<impl Sized, CursorError>) {
     if let Err(error) = result {
         errors.push(error);
     }

--- a/tests/pagination_documentation_bdd.rs
+++ b/tests/pagination_documentation_bdd.rs
@@ -1,0 +1,229 @@
+//! Behavioural tests verifying pagination documentation invariants.
+
+use actix_v2a::pagination::{
+    Cursor,
+    CursorError,
+    DEFAULT_LIMIT,
+    MAX_LIMIT,
+    PageParams,
+    PageParamsError,
+};
+use base64::Engine as _;
+use rstest::fixture;
+use rstest_bdd::Slot;
+use rstest_bdd_macros::{ScenarioState, given, scenario, then, when};
+use serde::{Deserialize, Serialize};
+
+const OVERSIZED_CURSOR_LEN: usize = 8 * 1024 + 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct FixtureKey {
+    created_at: String,
+    id: String,
+}
+
+#[derive(Debug, Default, ScenarioState)]
+struct World {
+    cursor_token: Slot<String>,
+    decode_result: Slot<Result<Cursor<FixtureKey>, CursorError>>,
+    page_params: Slot<PageParams>,
+    page_params_result: Slot<Result<PageParams, PageParamsError>>,
+    cursor_errors: Slot<Vec<CursorError>>,
+}
+
+#[fixture]
+fn world() -> World {
+    // Keep an explicit body here so the fixture remains readable in test traces.
+    World::default()
+}
+
+#[given("pagination documentation parameters without a limit")]
+#[expect(
+    clippy::expect_used,
+    reason = "BDD steps use expect for clear failures"
+)]
+fn pagination_documentation_parameters_without_a_limit(world: &World) {
+    let params = PageParams::new(None, None).expect("default params should be valid");
+    world.page_params.set(params);
+}
+
+#[given("pagination documentation parameters with limit {limit:u64}")]
+#[expect(
+    clippy::expect_used,
+    reason = "BDD steps use expect for clear failures"
+)]
+fn pagination_documentation_parameters_with_limit(world: &World, limit: u64) {
+    let requested_limit = usize::try_from(limit).expect("fixture limit should fit usize");
+    let params = PageParams::new(None, Some(requested_limit)).expect("params should be valid");
+    world.page_params.set(params);
+}
+
+#[given("an invalid base64 cursor token {token}")]
+fn an_invalid_base64_cursor_token(world: &World, token: String) { world.cursor_token.set(token); }
+
+#[given("a base64url token containing invalid JSON")]
+fn a_base64url_token_containing_invalid_json(world: &World) {
+    let invalid_json = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"{not-json");
+    world.cursor_token.set(invalid_json);
+}
+
+#[given("an oversized cursor token")]
+fn an_oversized_cursor_token(world: &World) {
+    world.cursor_token.set("a".repeat(OVERSIZED_CURSOR_LEN));
+}
+
+#[given("pagination errors of different documented variants")]
+fn pagination_errors_of_different_documented_variants(world: &World) {
+    let mut errors = Vec::new();
+    collect_cursor_error(&mut errors, Cursor::<FixtureKey>::decode("not!valid"));
+
+    let invalid_json = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"{not-json");
+    collect_cursor_error(&mut errors, Cursor::<FixtureKey>::decode(&invalid_json));
+    collect_cursor_error(
+        &mut errors,
+        Cursor::<FixtureKey>::decode(&"a".repeat(OVERSIZED_CURSOR_LEN)),
+    );
+
+    errors.push(CursorError::Serialize {
+        message: "fixture serialization failed".to_owned(),
+    });
+
+    world.cursor_errors.set(errors);
+}
+
+fn collect_cursor_error(
+    errors: &mut Vec<CursorError>,
+    result: Result<Cursor<FixtureKey>, CursorError>,
+) {
+    if let Err(error) = result {
+        errors.push(error);
+    }
+}
+
+#[when("the documentation cursor is decoded")]
+#[expect(
+    clippy::expect_used,
+    reason = "BDD steps use expect for clear failures"
+)]
+fn the_documentation_cursor_is_decoded(world: &World) {
+    let token = world
+        .cursor_token
+        .get()
+        .expect("cursor token should be set")
+        .clone();
+    world
+        .decode_result
+        .set(Cursor::<FixtureKey>::decode(&token));
+}
+
+#[when("pagination documentation parameters are created with limit {limit:u64}")]
+#[expect(
+    clippy::expect_used,
+    reason = "BDD steps use expect for clear failures"
+)]
+fn pagination_documentation_parameters_are_created_with_limit(world: &World, limit: u64) {
+    let requested_limit = usize::try_from(limit).expect("fixture limit should fit usize");
+    let result = PageParams::new(None, Some(requested_limit));
+    world.page_params_result.set(result);
+}
+
+#[then("the documented normalized limit equals DEFAULT_LIMIT")]
+#[expect(
+    clippy::expect_used,
+    reason = "BDD steps use expect for clear failures"
+)]
+fn the_documented_normalized_limit_equals_default_limit(world: &World) {
+    let params = world.page_params.get().expect("page params should be set");
+
+    assert_eq!(params.limit(), DEFAULT_LIMIT);
+}
+
+#[then("the documented normalized limit equals MAX_LIMIT")]
+#[expect(
+    clippy::expect_used,
+    reason = "BDD steps use expect for clear failures"
+)]
+fn the_documented_normalized_limit_equals_max_limit(world: &World) {
+    let params = world.page_params.get().expect("page params should be set");
+
+    assert_eq!(params.limit(), MAX_LIMIT);
+}
+
+#[then("page parameter creation fails with InvalidLimit error")]
+#[expect(
+    clippy::expect_used,
+    reason = "BDD steps use expect for clear failures"
+)]
+fn page_parameter_creation_fails_with_invalid_limit_error(world: &World) {
+    let result = world
+        .page_params_result
+        .get()
+        .expect("page params result should be set");
+
+    assert_eq!(result, Err(PageParamsError::InvalidLimit));
+}
+
+#[then("decoding fails with InvalidBase64 error")]
+fn decoding_fails_with_invalid_base64_error(world: &World) {
+    assert_decode_error(world, |error| {
+        matches!(error, CursorError::InvalidBase64 { .. })
+    });
+}
+
+#[then("decoding fails with Deserialize error")]
+fn decoding_fails_with_deserialize_error(world: &World) {
+    assert_decode_error(world, |error| {
+        matches!(error, CursorError::Deserialize { .. })
+    });
+}
+
+#[then("decoding fails with TokenTooLong error")]
+fn decoding_fails_with_token_too_long_error(world: &World) {
+    assert_decode_error(world, |error| {
+        matches!(error, CursorError::TokenTooLong { .. })
+    });
+}
+
+#[expect(
+    clippy::expect_used,
+    reason = "BDD helpers use expect for clear failures"
+)]
+fn assert_decode_error(world: &World, matches_error: impl FnOnce(&CursorError) -> bool) {
+    let result = world
+        .decode_result
+        .get()
+        .expect("decode result should be set");
+    let error = result.as_ref().expect_err("cursor decoding should fail");
+
+    assert!(matches_error(error));
+}
+
+#[then("each pagination error display string contains a descriptive message")]
+#[expect(
+    clippy::expect_used,
+    reason = "BDD steps use expect for clear failures"
+)]
+fn each_pagination_error_display_string_contains_a_descriptive_message(world: &World) {
+    let errors = world
+        .cursor_errors
+        .get()
+        .expect("cursor errors should be set");
+
+    for error in errors {
+        let display = format!("{error}");
+        assert!(
+            has_descriptive_error_text(&display),
+            "error display string should be descriptive; got: {display}"
+        );
+    }
+}
+
+fn has_descriptive_error_text(display: &str) -> bool {
+    display.contains("base64")
+        || display.contains("deserialization")
+        || display.contains("exceeds maximum length")
+        || display.contains("serialization")
+}
+
+#[scenario(path = "tests/features/pagination_documentation.feature")]
+fn pagination_documentation_invariants(world: World) { drop(world); }

--- a/tests/pagination_documentation_bdd.rs
+++ b/tests/pagination_documentation_bdd.rs
@@ -227,5 +227,42 @@ fn each_documented_cursor_error_variant_is_represented(world: &World) {
     );
 }
 
+#[test]
+fn cursor_error_display_messages_match_snapshots() {
+    insta::assert_snapshot!(
+        "cursor_error_invalid_base64_display",
+        CursorError::InvalidBase64 {
+            message: "invalid byte 33, offset 3.".to_owned(),
+        }
+        .to_string()
+    );
+    insta::assert_snapshot!(
+        "cursor_error_deserialize_display",
+        CursorError::Deserialize {
+            message: "expected ident at line 1 column 2".to_owned(),
+        }
+        .to_string()
+    );
+    insta::assert_snapshot!(
+        "cursor_error_token_too_long_display",
+        CursorError::TokenTooLong { max_len: 8 * 1024 }.to_string()
+    );
+    insta::assert_snapshot!(
+        "cursor_error_serialize_display",
+        CursorError::Serialize {
+            message: "fixture serialization failed".to_owned(),
+        }
+        .to_string()
+    );
+}
+
+#[test]
+fn page_params_error_display_messages_match_snapshots() {
+    insta::assert_snapshot!(
+        "page_params_error_invalid_limit_display",
+        PageParamsError::InvalidLimit.to_string()
+    );
+}
+
 #[scenario(path = "tests/features/pagination_documentation.feature")]
 fn pagination_documentation_invariants(world: World) { drop(world); }

--- a/tests/pagination_http_bdd.rs
+++ b/tests/pagination_http_bdd.rs
@@ -1,0 +1,232 @@
+//! Handler-level tests for pagination HTTP error mapping.
+
+use actix_v2a::{
+    Error,
+    ErrorCode,
+    pagination::{Cursor, CursorError, PageParams, Paginated, PaginationLinks},
+};
+use actix_web::{
+    App,
+    HttpRequest,
+    HttpResponse,
+    Responder,
+    test,
+    web::{self, ServiceConfig},
+};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use serde::{Deserialize, Serialize, Serializer};
+use url::Url;
+
+const OVERSIZED_CURSOR_LEN: usize = 8 * 1024 + 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct FixtureKey {
+    created_at: String,
+    id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct FixtureItem {
+    id: String,
+    name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LinksResponse {
+    #[serde(rename = "self")]
+    self_: String,
+    next: Option<String>,
+    prev: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+struct PaginatedResponse {
+    data: Vec<FixtureItem>,
+    limit: usize,
+    links: LinksResponse,
+}
+
+struct FailingKey;
+
+impl Serialize for FailingKey {
+    fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Err(serde::ser::Error::custom("fixture serialization failed"))
+    }
+}
+
+#[actix_web::test]
+async fn zero_limit_maps_to_invalid_request() {
+    let response = dispatch("/items?limit=0").await;
+
+    assert_error_response(
+        response,
+        actix_web::http::StatusCode::BAD_REQUEST,
+        ErrorCode::InvalidRequest,
+    )
+    .await;
+}
+
+#[actix_web::test]
+async fn malformed_base64_cursor_maps_to_invalid_request() {
+    let response = dispatch("/items?cursor=not!valid").await;
+
+    assert_error_response(
+        response,
+        actix_web::http::StatusCode::BAD_REQUEST,
+        ErrorCode::InvalidRequest,
+    )
+    .await;
+}
+
+#[actix_web::test]
+async fn json_invalid_cursor_maps_to_invalid_request() {
+    let token = URL_SAFE_NO_PAD.encode(b"{}");
+    let response = dispatch(&format!("/items?cursor={token}")).await;
+
+    assert_error_response(
+        response,
+        actix_web::http::StatusCode::BAD_REQUEST,
+        ErrorCode::InvalidRequest,
+    )
+    .await;
+}
+
+#[actix_web::test]
+async fn oversized_cursor_maps_to_invalid_request() {
+    let token = "a".repeat(OVERSIZED_CURSOR_LEN);
+    let response = dispatch(&format!("/items?cursor={token}")).await;
+
+    assert_error_response(
+        response,
+        actix_web::http::StatusCode::BAD_REQUEST,
+        ErrorCode::InvalidRequest,
+    )
+    .await;
+}
+
+#[actix_web::test]
+async fn cursor_serialize_maps_to_internal_error() {
+    let response = dispatch("/items?forceSerializeFailure=true").await;
+
+    assert_error_response(
+        response,
+        actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
+        ErrorCode::InternalError,
+    )
+    .await;
+}
+
+#[actix_web::test]
+async fn valid_request_returns_paginated_fixture_items() {
+    let response = dispatch("/items?limit=2").await;
+
+    assert_eq!(response.status(), actix_web::http::StatusCode::OK);
+
+    let body: PaginatedResponse = test::read_body_json(response).await;
+    assert_eq!(body.limit, 2);
+    assert_eq!(
+        body.data,
+        vec![
+            FixtureItem {
+                id: "item-1".to_owned(),
+                name: "Ada".to_owned(),
+            },
+            FixtureItem {
+                id: "item-2".to_owned(),
+                name: "Grace".to_owned(),
+            },
+        ]
+    );
+    assert_eq!(body.links.self_, "http://localhost:8080/items?limit=2");
+    assert!(body.links.next.is_none());
+    assert!(body.links.prev.is_none());
+}
+
+async fn dispatch(uri: &str) -> actix_web::dev::ServiceResponse<actix_web::body::BoxBody> {
+    let app = test::init_service(App::new().configure(configure_routes)).await;
+    let request = test::TestRequest::get().uri(uri).to_request();
+
+    test::call_service(&app, request).await
+}
+
+fn configure_routes(config: &mut ServiceConfig) {
+    config.route("/items", web::get().to(paginated_items));
+}
+
+async fn paginated_items(request: HttpRequest) -> Result<impl Responder, Error> {
+    let params = web::Query::<PageParams>::from_query(request.query_string())
+        .map_err(|_| Error::invalid_request_static("invalid pagination parameters"))?
+        .into_inner();
+
+    if request
+        .query_string()
+        .contains("forceSerializeFailure=true")
+    {
+        Cursor::new(FailingKey)
+            .encode()
+            .map_err(|error| map_cursor_error(&error))?;
+    }
+
+    if let Some(cursor) = params.cursor() {
+        Cursor::<FixtureKey>::decode(cursor).map_err(|error| map_cursor_error(&error))?;
+    }
+
+    let request_url = absolute_request_url(&request)?;
+    let links = PaginationLinks::from_request(&request_url, &params, None, None);
+    Ok(HttpResponse::Ok().json(Paginated::new(fixture_items(), params.limit(), links)))
+}
+
+fn map_cursor_error(error: &CursorError) -> Error {
+    match error {
+        CursorError::Serialize { .. } => Error::internal_static("cursor serialization failed"),
+        CursorError::InvalidBase64 { .. }
+        | CursorError::Deserialize { .. }
+        | CursorError::TokenTooLong { .. } => {
+            Error::invalid_request_static("invalid pagination cursor")
+        }
+    }
+}
+
+fn absolute_request_url(request: &HttpRequest) -> Result<Url, Error> {
+    let connection = request.connection_info();
+    let path_and_query = request.uri().path_and_query().map_or_else(
+        || request.uri().path(),
+        actix_web::http::uri::PathAndQuery::as_str,
+    );
+    let absolute_url = format!(
+        "{}://{}{}",
+        connection.scheme(),
+        connection.host(),
+        path_and_query
+    );
+
+    Url::parse(&absolute_url).map_err(|_| Error::internal_static("invalid request URI"))
+}
+
+fn fixture_items() -> Vec<FixtureItem> {
+    vec![
+        FixtureItem {
+            id: "item-1".to_owned(),
+            name: "Ada".to_owned(),
+        },
+        FixtureItem {
+            id: "item-2".to_owned(),
+            name: "Grace".to_owned(),
+        },
+    ]
+}
+
+async fn assert_error_response(
+    response: actix_web::dev::ServiceResponse<actix_web::body::BoxBody>,
+    expected_status: actix_web::http::StatusCode,
+    expected_code: ErrorCode,
+) {
+    assert_eq!(response.status(), expected_status);
+
+    let body: Error = test::read_body_json(response).await;
+    assert_eq!(body.code(), expected_code);
+}

--- a/tests/pagination_http_bdd.rs
+++ b/tests/pagination_http_bdd.rs
@@ -185,7 +185,7 @@ fn absolute_request_url(request: &HttpRequest) -> Result<Url, Error> {
         path_and_query
     );
 
-    Url::parse(&absolute_url).map_err(|_| Error::internal_static("invalid request URI"))
+    Url::parse(&absolute_url).map_err(|_| Error::invalid_request_static("invalid request URI"))
 }
 
 fn fixture_items() -> Vec<FixtureItem> {

--- a/tests/pagination_http_bdd.rs
+++ b/tests/pagination_http_bdd.rs
@@ -10,10 +10,11 @@ use actix_web::{
     HttpRequest,
     HttpResponse,
     Responder,
-    test,
+    test as actix_test,
     web::{self, ServiceConfig},
 };
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use rstest::rstest;
 use serde::{Deserialize, Serialize, Serializer};
 use url::Url;
 
@@ -58,66 +59,44 @@ impl Serialize for FailingKey {
     }
 }
 
+#[rstest]
+#[case::zero_limit(
+    "/items?limit=0".to_owned(),
+    actix_web::http::StatusCode::BAD_REQUEST,
+    ErrorCode::InvalidRequest
+)]
+#[case::malformed_base64_cursor(
+    "/items?cursor=not!valid".to_owned(),
+    actix_web::http::StatusCode::BAD_REQUEST,
+    ErrorCode::InvalidRequest
+)]
+#[case::json_invalid_cursor(
+    format!(
+        "/items?cursor={}",
+        URL_SAFE_NO_PAD.encode(b"{}")
+    ),
+    actix_web::http::StatusCode::BAD_REQUEST,
+    ErrorCode::InvalidRequest
+)]
+#[case::oversized_cursor(
+    format!("/items?cursor={}", "a".repeat(OVERSIZED_CURSOR_LEN)),
+    actix_web::http::StatusCode::BAD_REQUEST,
+    ErrorCode::InvalidRequest
+)]
+#[case::cursor_serialize(
+    "/items?forceSerializeFailure=true".to_owned(),
+    actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
+    ErrorCode::InternalError
+)]
 #[actix_web::test]
-async fn zero_limit_maps_to_invalid_request() {
-    let response = dispatch("/items?limit=0").await;
+async fn pagination_errors_map_to_documented_http_envelopes(
+    #[case] uri: String,
+    #[case] expected_status: actix_web::http::StatusCode,
+    #[case] expected_code: ErrorCode,
+) {
+    let response = dispatch(&uri).await;
 
-    assert_error_response(
-        response,
-        actix_web::http::StatusCode::BAD_REQUEST,
-        ErrorCode::InvalidRequest,
-    )
-    .await;
-}
-
-#[actix_web::test]
-async fn malformed_base64_cursor_maps_to_invalid_request() {
-    let response = dispatch("/items?cursor=not!valid").await;
-
-    assert_error_response(
-        response,
-        actix_web::http::StatusCode::BAD_REQUEST,
-        ErrorCode::InvalidRequest,
-    )
-    .await;
-}
-
-#[actix_web::test]
-async fn json_invalid_cursor_maps_to_invalid_request() {
-    let token = URL_SAFE_NO_PAD.encode(b"{}");
-    let response = dispatch(&format!("/items?cursor={token}")).await;
-
-    assert_error_response(
-        response,
-        actix_web::http::StatusCode::BAD_REQUEST,
-        ErrorCode::InvalidRequest,
-    )
-    .await;
-}
-
-#[actix_web::test]
-async fn oversized_cursor_maps_to_invalid_request() {
-    let token = "a".repeat(OVERSIZED_CURSOR_LEN);
-    let response = dispatch(&format!("/items?cursor={token}")).await;
-
-    assert_error_response(
-        response,
-        actix_web::http::StatusCode::BAD_REQUEST,
-        ErrorCode::InvalidRequest,
-    )
-    .await;
-}
-
-#[actix_web::test]
-async fn cursor_serialize_maps_to_internal_error() {
-    let response = dispatch("/items?forceSerializeFailure=true").await;
-
-    assert_error_response(
-        response,
-        actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
-        ErrorCode::InternalError,
-    )
-    .await;
+    assert_error_response(response, expected_status, expected_code).await;
 }
 
 #[actix_web::test]
@@ -126,7 +105,7 @@ async fn valid_request_returns_paginated_fixture_items() {
 
     assert_eq!(response.status(), actix_web::http::StatusCode::OK);
 
-    let body: PaginatedResponse = test::read_body_json(response).await;
+    let body: PaginatedResponse = actix_test::read_body_json(response).await;
     assert_eq!(body.limit, 2);
     assert_eq!(
         body.data,
@@ -147,10 +126,10 @@ async fn valid_request_returns_paginated_fixture_items() {
 }
 
 async fn dispatch(uri: &str) -> actix_web::dev::ServiceResponse<actix_web::body::BoxBody> {
-    let app = test::init_service(App::new().configure(configure_routes)).await;
-    let request = test::TestRequest::get().uri(uri).to_request();
+    let app = actix_test::init_service(App::new().configure(configure_routes)).await;
+    let request = actix_test::TestRequest::get().uri(uri).to_request();
 
-    test::call_service(&app, request).await
+    actix_test::call_service(&app, request).await
 }
 
 fn configure_routes(config: &mut ServiceConfig) {
@@ -229,6 +208,6 @@ async fn assert_error_response(
 ) {
     assert_eq!(response.status(), expected_status);
 
-    let body: Error = test::read_body_json(response).await;
+    let body: Error = actix_test::read_body_json(response).await;
     assert_eq!(body.code(), expected_code);
 }

--- a/tests/pagination_http_bdd.rs
+++ b/tests/pagination_http_bdd.rs
@@ -162,10 +162,7 @@ async fn paginated_items(request: HttpRequest) -> Result<impl Responder, Error> 
         .map_err(|_| Error::invalid_request_static("invalid pagination parameters"))?
         .into_inner();
 
-    if request
-        .query_string()
-        .contains("forceSerializeFailure=true")
-    {
+    if should_force_serialize_failure(request.query_string()) {
         Cursor::new(FailingKey)
             .encode()
             .map_err(|error| map_cursor_error(&error))?;
@@ -189,6 +186,11 @@ fn map_cursor_error(error: &CursorError) -> Error {
             Error::invalid_request_static("invalid pagination cursor")
         }
     }
+}
+
+fn should_force_serialize_failure(query_string: &str) -> bool {
+    url::form_urlencoded::parse(query_string.as_bytes())
+        .any(|(key, value)| key == "forceSerializeFailure" && value == "true")
 }
 
 fn absolute_request_url(request: &HttpRequest) -> Result<Url, Error> {

--- a/tests/pagination_tracing_tests.rs
+++ b/tests/pagination_tracing_tests.rs
@@ -1,0 +1,174 @@
+//! Tracing coverage for public pagination cursor operations.
+
+use std::sync::{
+    Arc,
+    Mutex,
+    MutexGuard,
+    atomic::{AtomicU64, Ordering},
+};
+
+use actix_v2a::pagination::{Cursor, CursorError};
+use serde::{Serialize, Serializer};
+use tracing::{
+    Event,
+    Id,
+    Level,
+    Metadata,
+    Subscriber,
+    field::{Field, Visit},
+    level_filters::LevelFilter,
+    subscriber::{Interest, with_default},
+};
+
+struct FailingKey;
+
+impl Serialize for FailingKey {
+    fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Err(serde::ser::Error::custom("fixture serialization failed"))
+    }
+}
+
+#[test]
+fn successful_encode_produces_span_without_error_events() {
+    let recorder = TraceRecorder::default();
+    let subscriber = RecordingSubscriber::new(recorder.clone());
+    let cursor = Cursor::new("key");
+
+    let result = with_default(subscriber, || cursor.encode());
+
+    assert_eq!(result, Ok("eyJrZXkiOiJrZXkiLCJkaXIiOiJOZXh0In0".to_owned()));
+    assert!(recorder.span_names().contains(&"encode".to_owned()));
+    assert!(recorder.error_events().is_empty());
+}
+
+#[test]
+fn failing_encode_emits_one_serialization_error_event() {
+    let recorder = TraceRecorder::default();
+    let subscriber = RecordingSubscriber::new(recorder.clone());
+
+    let result = with_default(subscriber, || Cursor::new(FailingKey).encode());
+
+    assert_eq!(
+        result,
+        Err(CursorError::Serialize {
+            message: "fixture serialization failed".to_owned(),
+        })
+    );
+    let error_events = recorder.error_events();
+    assert_eq!(error_events.len(), 1);
+    assert!(
+        error_events
+            .iter()
+            .any(|event| event.contains("cursor serialization failed"))
+    );
+}
+
+#[test]
+fn successful_decode_produces_span_without_error_events() {
+    let cursor = Cursor::new("key");
+    let token = cursor.encode().expect("cursor encoding should succeed");
+    let recorder = TraceRecorder::default();
+    let subscriber = RecordingSubscriber::new(recorder.clone());
+
+    let result = with_default(subscriber, || Cursor::<String>::decode(&token));
+
+    assert_eq!(result, Ok(Cursor::new("key".to_owned())));
+    assert!(recorder.span_names().contains(&"decode".to_owned()));
+    assert!(recorder.error_events().is_empty());
+}
+
+#[derive(Clone, Default)]
+struct TraceRecorder {
+    spans: Arc<Mutex<Vec<String>>>,
+    events: Arc<Mutex<Vec<RecordedEvent>>>,
+}
+
+impl TraceRecorder {
+    fn push_span(&self, name: &str) { recover_lock(&self.spans).push(name.to_owned()); }
+
+    fn push_event(&self, event: RecordedEvent) { recover_lock(&self.events).push(event); }
+
+    fn span_names(&self) -> Vec<String> { recover_lock(&self.spans).clone() }
+
+    fn error_events(&self) -> Vec<String> {
+        recover_lock(&self.events)
+            .iter()
+            .filter(|event| event.level == Level::ERROR)
+            .filter_map(|event| event.message.clone())
+            .collect()
+    }
+}
+
+fn recover_lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+struct RecordingSubscriber {
+    recorder: TraceRecorder,
+    next_id: AtomicU64,
+}
+
+impl RecordingSubscriber {
+    const fn new(recorder: TraceRecorder) -> Self {
+        Self {
+            recorder,
+            next_id: AtomicU64::new(1),
+        }
+    }
+}
+
+impl Subscriber for RecordingSubscriber {
+    fn register_callsite(&self, _metadata: &'static Metadata<'static>) -> Interest {
+        Interest::always()
+    }
+
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool { true }
+
+    fn max_level_hint(&self) -> Option<LevelFilter> { Some(LevelFilter::TRACE) }
+
+    fn new_span(&self, attributes: &tracing::span::Attributes<'_>) -> Id {
+        self.recorder.push_span(attributes.metadata().name());
+        Id::from_u64(self.next_id.fetch_add(1, Ordering::Relaxed))
+    }
+
+    fn record(&self, _span: &Id, _values: &tracing::span::Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+    fn event(&self, event: &Event<'_>) {
+        let mut visitor = MessageVisitor::default();
+        event.record(&mut visitor);
+        self.recorder.push_event(RecordedEvent {
+            level: *event.metadata().level(),
+            message: visitor.message,
+        });
+    }
+
+    fn enter(&self, _span: &Id) {}
+
+    fn exit(&self, _span: &Id) {}
+}
+
+#[derive(Clone)]
+struct RecordedEvent {
+    level: Level,
+    message: Option<String>,
+}
+
+#[derive(Default)]
+struct MessageVisitor {
+    message: Option<String>,
+}
+
+impl Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.message = Some(format!("{value:?}"));
+        }
+    }
+}

--- a/tests/pagination_tracing_tests.rs
+++ b/tests/pagination_tracing_tests.rs
@@ -8,6 +8,7 @@ use std::sync::{
 };
 
 use actix_v2a::pagination::{Cursor, CursorError};
+use base64::Engine as _;
 use serde::{Serialize, Serializer};
 use tracing::{
     Event,
@@ -84,6 +85,7 @@ fn successful_decode_produces_span_without_error_events() {
 fn failing_decode_produces_no_error_events() {
     let recorder = TraceRecorder::default();
     let subscriber = RecordingSubscriber::new(recorder.clone());
+    let invalid_json = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"{not-json");
 
     with_default(subscriber, || {
         assert!(matches!(
@@ -93,6 +95,10 @@ fn failing_decode_produces_no_error_events() {
         assert!(matches!(
             Cursor::<String>::decode(&"a".repeat(8 * 1024 + 1)),
             Err(CursorError::TokenTooLong { .. })
+        ));
+        assert!(matches!(
+            Cursor::<serde_json::Value>::decode(&invalid_json),
+            Err(CursorError::Deserialize { .. })
         ));
     });
 

--- a/tests/pagination_tracing_tests.rs
+++ b/tests/pagination_tracing_tests.rs
@@ -80,6 +80,25 @@ fn successful_decode_produces_span_without_error_events() {
     assert!(recorder.error_events().is_empty());
 }
 
+#[test]
+fn failing_decode_produces_no_error_events() {
+    let recorder = TraceRecorder::default();
+    let subscriber = RecordingSubscriber::new(recorder.clone());
+
+    with_default(subscriber, || {
+        assert!(matches!(
+            Cursor::<String>::decode("not!valid"),
+            Err(CursorError::InvalidBase64 { .. })
+        ));
+        assert!(matches!(
+            Cursor::<String>::decode(&"a".repeat(8 * 1024 + 1)),
+            Err(CursorError::TokenTooLong { .. })
+        ));
+    });
+
+    assert!(recorder.error_events().is_empty());
+}
+
 #[derive(Clone, Default)]
 struct TraceRecorder {
     spans: Arc<Mutex<Vec<String>>>,

--- a/tests/pagination_tracing_tests.rs
+++ b/tests/pagination_tracing_tests.rs
@@ -85,7 +85,8 @@ fn successful_decode_produces_span_without_error_events() {
 fn failing_decode_produces_no_error_events() {
     let recorder = TraceRecorder::default();
     let subscriber = RecordingSubscriber::new(recorder.clone());
-    let invalid_json = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"{not-json");
+    let invalid_json_payload =
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"not valid json {{{");
 
     with_default(subscriber, || {
         assert!(matches!(
@@ -97,7 +98,7 @@ fn failing_decode_produces_no_error_events() {
             Err(CursorError::TokenTooLong { .. })
         ));
         assert!(matches!(
-            Cursor::<serde_json::Value>::decode(&invalid_json),
+            Cursor::<String>::decode(&invalid_json_payload),
             Err(CursorError::Deserialize { .. })
         ));
     });

--- a/tests/snapshots/pagination_documentation_bdd__cursor_error_deserialize_display.snap
+++ b/tests/snapshots/pagination_documentation_bdd__cursor_error_deserialize_display.snap
@@ -1,0 +1,5 @@
+---
+source: tests/pagination_documentation_bdd.rs
+expression: "CursorError::Deserialize\n{ message: \"expected ident at line 1 column 2\".to_owned(), }.to_string()"
+---
+cursor JSON deserialization failed: expected ident at line 1 column 2

--- a/tests/snapshots/pagination_documentation_bdd__cursor_error_invalid_base64_display.snap
+++ b/tests/snapshots/pagination_documentation_bdd__cursor_error_invalid_base64_display.snap
@@ -1,0 +1,5 @@
+---
+source: tests/pagination_documentation_bdd.rs
+expression: "CursorError::InvalidBase64\n{ message: \"invalid byte 33, offset 3.\".to_owned(), }.to_string()"
+---
+cursor is not valid base64url: invalid byte 33, offset 3.

--- a/tests/snapshots/pagination_documentation_bdd__cursor_error_serialize_display.snap
+++ b/tests/snapshots/pagination_documentation_bdd__cursor_error_serialize_display.snap
@@ -1,0 +1,5 @@
+---
+source: tests/pagination_documentation_bdd.rs
+expression: "CursorError::Serialize\n{ message: \"fixture serialization failed\".to_owned(), }.to_string()"
+---
+cursor JSON serialization failed: fixture serialization failed

--- a/tests/snapshots/pagination_documentation_bdd__cursor_error_token_too_long_display.snap
+++ b/tests/snapshots/pagination_documentation_bdd__cursor_error_token_too_long_display.snap
@@ -1,0 +1,5 @@
+---
+source: tests/pagination_documentation_bdd.rs
+expression: "CursorError::TokenTooLong { max_len: 8 * 1024 }.to_string()"
+---
+cursor token exceeds maximum length of 8192 bytes

--- a/tests/snapshots/pagination_documentation_bdd__page_params_error_invalid_limit_display.snap
+++ b/tests/snapshots/pagination_documentation_bdd__page_params_error_invalid_limit_display.snap
@@ -1,0 +1,5 @@
+---
+source: tests/pagination_documentation_bdd.rs
+expression: "PageParamsError::InvalidLimit.to_string()"
+---
+page limit must be greater than zero


### PR DESCRIPTION
## Summary

This branch implements the approved ExecPlan for porting the reusable pagination documentation hardening from Wildside commit `9d6b7655` into `actix-v2a`. It expands the pagination documentation, adds user-guide integration guidance, verifies the documented pagination invariants with behaviour-driven development (BDD), unit, and snapshot coverage, and instruments cursor encode/decode operations with `tracing`.

ExecPlan: [docs/execplans/portwildsidepagination.md](https://github.com/leynos/actix-v2a/blob/644535a35752cab956f6d6e6ce8ba9cd230fcb70/docs/execplans/portwildsidepagination.md)

The implementation deliberately excludes Wildside-specific application, domain, and test-infrastructure changes. It also keeps the `markdownlint` Makefile target calling `markdownlint-cli2` directly while prepending the existing Bun binary directory to `PATH`; no shim, install step, or recreated system script is introduced. Cargo recipes use the same approach for the existing Cargo binary directory so reduced-`PATH` hooks can still run `cargo` by name.

## Review walkthrough

- Start with [docs/execplans/portwildsidepagination.md](https://github.com/leynos/actix-v2a/blob/644535a35752cab956f6d6e6ce8ba9cd230fcb70/docs/execplans/portwildsidepagination.md) to see the completed scope, decisions, discoveries, review response, and validation evidence.
- Review [src/pagination/mod.rs](https://github.com/leynos/actix-v2a/blob/644535a35752cab956f6d6e6ce8ba9cd230fcb70/src/pagination/mod.rs), [src/pagination/cursor.rs](https://github.com/leynos/actix-v2a/blob/644535a35752cab956f6d6e6ce8ba9cd230fcb70/src/pagination/cursor.rs), [src/pagination/params.rs](https://github.com/leynos/actix-v2a/blob/644535a35752cab956f6d6e6ce8ba9cd230fcb70/src/pagination/params.rs), and [src/pagination/envelope.rs](https://github.com/leynos/actix-v2a/blob/644535a35752cab956f6d6e6ce8ba9cd230fcb70/src/pagination/envelope.rs) for the crate-level and module-level pagination contracts and observability note.
- Then review [docs/users-guide.md](https://github.com/leynos/actix-v2a/blob/644535a35752cab956f6d6e6ce8ba9cd230fcb70/docs/users-guide.md) for Actix query extraction, absolute URL construction from connection scheme, host, and `path_and_query()`, `Paginated<T>` response construction, error mapping, and endpoint-local OpenAPI parameter guidance.
- Finish with [docs/contents.md](https://github.com/leynos/actix-v2a/blob/644535a35752cab956f6d6e6ce8ba9cd230fcb70/docs/contents.md), [tests/features/pagination_documentation.feature](https://github.com/leynos/actix-v2a/blob/644535a35752cab956f6d6e6ce8ba9cd230fcb70/tests/features/pagination_documentation.feature), [tests/pagination_documentation_bdd.rs](https://github.com/leynos/actix-v2a/blob/644535a35752cab956f6d6e6ce8ba9cd230fcb70/tests/pagination_documentation_bdd.rs), [src/openapi/schemas.rs](https://github.com/leynos/actix-v2a/blob/644535a35752cab956f6d6e6ce8ba9cd230fcb70/src/openapi/schemas.rs), the new `src/openapi/snapshots/` and `tests/snapshots/` directories, [src/http/error.rs](https://github.com/leynos/actix-v2a/blob/644535a35752cab956f6d6e6ce8ba9cd230fcb70/src/http/error.rs), [src/pagination/cursor.rs](https://github.com/leynos/actix-v2a/blob/644535a35752cab956f6d6e6ce8ba9cd230fcb70/src/pagination/cursor.rs), and [Makefile](https://github.com/leynos/actix-v2a/blob/644535a35752cab956f6d6e6ce8ba9cd230fcb70/Makefile) for the invariant coverage, cursor tracing spans, snapshot coverage, lint-clean test helpers, contents index, and hook-compatible tool resolution.

## Review feedback addressed

- Replace the `Url::parse(&req.uri().to_string())` user-guide example with a runtime-valid pattern that combines Actix connection scheme, host, and `path_and_query()` before parsing.
- Change the pagination documentation BDD scenario so it asserts documented `CursorError` variants and structured fields instead of matching display-message substrings.
- Expand uncommon acronyms on first use in the ExecPlan, including behaviour-driven development (BDD) and data transfer object (DTO).
- Convert helper functions flagged by the stricter lint path to return `Result` values instead of relying on `expect` outside actual test bodies.
- Update the contents index to describe the pagination ExecPlan as complete, and remove the comma before the `Paginated<T>` OpenAPI guidance because-clause.
- Update stale Stage B plan wording to describe variant-and-field assertions, and make the HTTP error response helper return observed status, trace header, and payload values for caller-side assertions.
- Add the requested comma in the ExecPlan retrospective sentence separating documentation-invariant BDD coverage from unit coverage.
- Add the verified commas in the ExecPlan observations for Cargo `PATH` handling and test-only helper compilation.

## Additional instrumentation

- `Cursor::encode` is instrumented with `#[tracing::instrument(skip(self), err)]`.
- `Cursor::decode` is instrumented with `#[tracing::instrument(skip(token), err)]` so raw caller-controlled cursor tokens are not recorded in span fields.
- `CursorError::Serialize` emits `tracing::error!(error = %e, "cursor serialization failed")` before returning.
- `src/pagination/mod.rs` documents that callers do not need to re-log serialization failures, while caller-controlled cursor/page-parameter errors do not emit library error events.

## Snapshot coverage

- Added `insta` as a dev dependency.
- Snapshotted the `Display` output for `CursorError::InvalidBase64`, `CursorError::Deserialize`, `CursorError::TokenTooLong`, `CursorError::Serialize`, and `PageParamsError::InvalidLimit`.
- Snapshotted the serialized OpenAPI schema outputs for `ErrorCodeSchema`, `ErrorSchema`, and `ReplayMetadataSchema`.
- Accepted the initial snapshots with `cargo insta review` and committed the generated `snapshots/` directories.
- Did not add `trybuild`; this task exercises runtime error-display and schema-output contracts, and no compile-time public API constraint tests were identified as necessary.

## Handler-level pagination coverage

- Added `tests/pagination_http_bdd.rs` with a minimal Actix `App` exercised through `actix_web::test::init_service` and `actix_web::test::call_service`.
- Covered `limit=0`, malformed base64 cursors, JSON-invalid cursors, oversized cursor tokens, server-side `CursorError::Serialize`, and a valid `Paginated<FixtureItem>` response.
- Asserted both HTTP status and the shared error-envelope `code` field for every documented error mapping.

## Validation

- `cargo insta test`: generated and verified snapshots; initial snapshots accepted with `cargo insta review`.
- `cargo test --test pagination_documentation_bdd`: passed after snapshot acceptance.
- `make check-fmt`: passed.
- `make lint`: passed, including `cargo doc`, `cargo clippy`, and `whitaker` on the configured nightly toolchain.
- `make test`: passed, including 147 nextest tests and 25 doctests.
- `make markdownlint`: passed.
- `make nixie`: passed.
- `env PATH=/usr/bin:/bin make check-fmt lint`: passed.
- `env PATH=/usr/bin:/bin make markdownlint`: passed.

## Latest follow-up

Commit `644535a` adds handler-level Actix integration tests for the pagination HTTP error-mapping contract. The latest follow-up passed `cargo test --test pagination_http_bdd`, `make check-fmt`, `make lint`, `make test`, and `make markdownlint`.

## Notes

`make fmt` remains partially blocked in this environment because `mdformat-all` is not installed; `cargo fmt --all` and `make check-fmt` both succeeded. The implementation stayed within the approved tolerances and did not add public API beyond the existing pagination surface.
