### PR TITLE
Adopt Netsuke as build driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: netsuke build check-fmt
       - name: Markdown lint
         run: netsuke build markdownlint
-      - name: Mermaid lint
+      - name: Validate Mermaid diagrams
         run: netsuke build nixie
       - name: Lint
         run: netsuke build lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,24 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@f9f1c863c8a5bef64aa6779caa746e1a4a6c1ad4
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+      - name: Install uv
+        uses: astral-sh/setup-uv@4cda7d73322c50eac316ad623a716f09a2db2ac7
+        # v3.1.2
+        with:
+          python-version: '3.11'
+      - name: Install bun
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
+        # v2
+        with:
+          bun-version: '1.2.21'
+      - name: Install Mermaid CLI
+        run: |
+          set -euxo pipefail
+          bun install --no-progress --global @mermaid-js/mermaid-cli@11.9.0
+          bun x @puppeteer/browsers browsers install chrome-headless-shell
+          mmdc --version
+      - name: Install Nixie
+        run: uv tool install nixie-cli==1.0.0
       - name: Install markdownlint-cli2
         run: bun install -g markdownlint-cli2@0.22.1
       - name: Install Ninja

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,17 +17,23 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@f9f1c863c8a5bef64aa6779caa746e1a4a6c1ad4
+      - name: Install Ninja
+        run: sudo apt-get update && sudo apt-get install -y ninja-build
+      - name: Install Netsuke
+        run: >-
+          cargo install --git https://github.com/leynos/netsuke.git
+          --rev 2fe314a58d7311758640b3daa086c401d79838cf
+          netsuke --locked
+      - name: Show Netsuke version
+        run: netsuke --version
+      - name: Validate Netsuke manifest
+        run: netsuke manifest -
       - name: Format
-        run: make check-fmt
+        run: netsuke build check-fmt
       - name: Markdown lint
-        uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e
-        with:
-          globs: |
-            **/*.md
-            !**/target/**
-            !**/dist/**
+        run: netsuke build markdownlint
       - name: Lint
-        run: make lint
+        run: netsuke build lint
       - name: Test and Measure Coverage
         uses: leynos/shared-actions/.github/actions/generate-coverage@f9f1c863c8a5bef64aa6779caa746e1a4a6c1ad4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,21 @@ jobs:
       - name: Validate Netsuke manifest
         run: netsuke manifest -
       - name: Format
-        run: netsuke build check-fmt
+        run: >-
+          set -o pipefail;
+          netsuke build check-fmt --verbose 2>&1 | tee /tmp/netsuke-check-fmt-actix-v2a-adopt-netsuke-ci.out
       - name: Markdown lint
-        run: netsuke build markdownlint
+        run: >-
+          set -o pipefail;
+          netsuke build markdownlint --verbose 2>&1 | tee /tmp/netsuke-markdownlint-actix-v2a-adopt-netsuke-ci.out
       - name: Validate Mermaid diagrams
-        run: netsuke build nixie
+        run: >-
+          set -o pipefail;
+          netsuke build nixie --verbose 2>&1 | tee /tmp/netsuke-nixie-actix-v2a-adopt-netsuke-ci.out
       - name: Lint
-        run: netsuke build lint
+        run: >-
+          set -o pipefail;
+          netsuke build lint --verbose 2>&1 | tee /tmp/netsuke-lint-actix-v2a-adopt-netsuke-ci.out
       - name: Test and Measure Coverage
         uses: leynos/shared-actions/.github/actions/generate-coverage@f9f1c863c8a5bef64aa6779caa746e1a4a6c1ad4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@f9f1c863c8a5bef64aa6779caa746e1a4a6c1ad4
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
       - name: Install markdownlint-cli2
-        run: bun install -g markdownlint-cli2
+        run: bun install -g markdownlint-cli2@0.22.1
       - name: Install Ninja
         run: sudo apt-get update && sudo apt-get install -y ninja-build
       - name: Install Netsuke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,19 +35,19 @@ jobs:
       - name: Format
         run: >-
           set -o pipefail;
-          netsuke build check-fmt --verbose 2>&1 | tee /tmp/netsuke-check-fmt-actix-v2a-adopt-netsuke-ci.out
+          netsuke --verbose build check-fmt 2>&1 | tee /tmp/netsuke-check-fmt-actix-v2a-adopt-netsuke-ci.out
       - name: Markdown lint
         run: >-
           set -o pipefail;
-          netsuke build markdownlint --verbose 2>&1 | tee /tmp/netsuke-markdownlint-actix-v2a-adopt-netsuke-ci.out
+          netsuke --verbose build markdownlint 2>&1 | tee /tmp/netsuke-markdownlint-actix-v2a-adopt-netsuke-ci.out
       - name: Validate Mermaid diagrams
         run: >-
           set -o pipefail;
-          netsuke build nixie --verbose 2>&1 | tee /tmp/netsuke-nixie-actix-v2a-adopt-netsuke-ci.out
+          netsuke --verbose build nixie 2>&1 | tee /tmp/netsuke-nixie-actix-v2a-adopt-netsuke-ci.out
       - name: Lint
         run: >-
           set -o pipefail;
-          netsuke build lint --verbose 2>&1 | tee /tmp/netsuke-lint-actix-v2a-adopt-netsuke-ci.out
+          netsuke --verbose build lint 2>&1 | tee /tmp/netsuke-lint-actix-v2a-adopt-netsuke-ci.out
       - name: Test and Measure Coverage
         uses: leynos/shared-actions/.github/actions/generate-coverage@f9f1c863c8a5bef64aa6779caa746e1a4a6c1ad4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@f9f1c863c8a5bef64aa6779caa746e1a4a6c1ad4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+      - name: Install markdownlint-cli2
+        run: bun install -g markdownlint-cli2
       - name: Install Ninja
         run: sudo apt-get update && sudo apt-get install -y ninja-build
       - name: Install Netsuke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
         run: netsuke build check-fmt
       - name: Markdown lint
         run: netsuke build markdownlint
+      - name: Mermaid lint
+        run: netsuke build nixie
       - name: Lint
         run: netsuke build lint
       - name: Test and Measure Coverage

--- a/Makefile
+++ b/Makefile
@@ -1,64 +1,41 @@
-.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie
+.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie typecheck
 
-
-TARGET ?= libactix_v2a.rlib
 
 PREPEND_PATH := $(HOME)/.cargo/bin:$(HOME)/.bun/bin:$(HOME)/.local/bin
+NETSUKE ?= $(shell PATH=$(PREPEND_PATH):$(PATH) command -v netsuke 2>/dev/null || printf '%s/.cargo/bin/netsuke' "$$HOME")
 
-CARGO ?= $(shell PATH=$(PREPEND_PATH):$(PATH) command -v cargo 2>/dev/null || printf '%s/.cargo/bin/cargo' "$$HOME")
-BUILD_JOBS ?=
-RUST_FLAGS ?=
-RUST_FLAGS := -D warnings $(RUST_FLAGS)
-RUSTDOC_FLAGS ?=
-RUSTDOC_FLAGS := -D warnings $(RUSTDOC_FLAGS)
-CARGO_FLAGS ?= --all-targets --all-features
-CLIPPY_FLAGS ?= $(CARGO_FLAGS) -- $(RUST_FLAGS)
-TEST_FLAGS ?= $(CARGO_FLAGS)
-TEST_CMD := $(if $(shell PATH=$(PREPEND_PATH):$(PATH) $(CARGO) nextest --version 2>/dev/null),nextest run,test)
-MDLINT ?= $(shell PATH=$(PREPEND_PATH):$(PATH) command -v markdownlint-cli2 2>/dev/null || printf '%s/.bun/bin/markdownlint-cli2' "$$HOME")
-NIXIE ?= $(shell PATH=$(PREPEND_PATH):$(PATH) command -v nixie 2>/dev/null || printf '%s/.bun/bin/nixie' "$$HOME")
+build: ## Build debug artefacts
+	PATH="$(PREPEND_PATH):$(PATH)" $(NETSUKE) build build
 
-build: target/debug/$(TARGET) ## Build debug binary
-release: target/release/$(TARGET) ## Build release binary
+release: ## Build release artefacts
+	PATH="$(PREPEND_PATH):$(PATH)" $(NETSUKE) build release
 
-all: check-fmt lint test ## Perform a comprehensive check of code
+all: ## Perform a comprehensive check of code
+	PATH="$(PREPEND_PATH):$(PATH)" $(NETSUKE) build all
 
-clean: ## Remove build artifacts
-	PATH="$(PREPEND_PATH):$(PATH)" $(CARGO) clean
+clean: ## Remove build artefacts
+	PATH="$(PREPEND_PATH):$(PATH)" $(NETSUKE) build clean
 
 test: ## Run tests with warnings treated as errors
-	PATH="$(PREPEND_PATH):$(PATH)" RUSTFLAGS="$(RUST_FLAGS)" $(CARGO) $(TEST_CMD) $(TEST_FLAGS) $(BUILD_JOBS)
-ifneq ($(TEST_CMD),test)
-	PATH="$(PREPEND_PATH):$(PATH)" RUSTFLAGS="$(RUST_FLAGS)" $(CARGO) test --doc --workspace --all-features
-endif
-
-target/%/$(TARGET): ## Build binary in debug or release mode
-	PATH="$(PREPEND_PATH):$(PATH)" $(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release)
+	PATH="$(PREPEND_PATH):$(PATH)" $(NETSUKE) build test
 
 lint: ## Run Clippy with warnings denied
-	PATH="$(PREPEND_PATH):$(PATH)" RUSTDOCFLAGS="$(RUSTDOC_FLAGS)" $(CARGO) doc --no-deps
-	PATH="$(PREPEND_PATH):$(PATH)" $(CARGO) clippy $(CLIPPY_FLAGS)
-	@if PATH="$(PREPEND_PATH):$(PATH)" command -v whitaker >/dev/null 2>&1; then \
-		PATH="$(PREPEND_PATH):$(PATH)" RUSTFLAGS="$(RUST_FLAGS)" whitaker --all -- $(CARGO_FLAGS); \
-	else \
-		echo "whitaker not found on PATH; skipping whitaker lint. Install whitaker to run this check."; \
-	fi
+	PATH="$(PREPEND_PATH):$(PATH)" $(NETSUKE) build lint
 
 typecheck: ## Type-check without building
-	PATH="$(PREPEND_PATH):$(PATH)" RUSTFLAGS="$(RUST_FLAGS)" $(CARGO) check $(CARGO_FLAGS)
+	PATH="$(PREPEND_PATH):$(PATH)" $(NETSUKE) build typecheck
 
 fmt: ## Format Rust and Markdown sources
-	PATH="$(PREPEND_PATH):$(PATH)" $(CARGO) +nightly fmt --all
-	mdformat-all
+	PATH="$(PREPEND_PATH):$(PATH)" $(NETSUKE) build fmt
 
 check-fmt: ## Verify formatting
-	PATH="$(PREPEND_PATH):$(PATH)" $(CARGO) fmt --all -- --check
+	PATH="$(PREPEND_PATH):$(PATH)" $(NETSUKE) build check-fmt
 
 markdownlint: ## Lint Markdown files
-	PATH="$(PREPEND_PATH):$(PATH)" $(MDLINT) '**/*.md'
+	PATH="$(PREPEND_PATH):$(PATH)" $(NETSUKE) build markdownlint
 
 nixie: ## Validate Mermaid diagrams
-	PATH="$(PREPEND_PATH):$(PATH)" $(NIXIE) --no-sandbox
+	PATH="$(PREPEND_PATH):$(PATH)" $(NETSUKE) build nixie
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \

--- a/Netsukefile
+++ b/Netsukefile
@@ -1,0 +1,84 @@
+netsuke_version: "1.0.0"
+
+vars:
+  prepend_path: "$$HOME/.cargo/bin:$$HOME/.bun/bin:$$HOME/.local/bin"
+  cargo_flags: "--all-targets --all-features"
+  rust_flags: "-D warnings"
+  rustdoc_flags: "-D warnings"
+
+actions:
+  - name: all
+    sources:
+      - check-fmt
+      - lint
+      - test
+    command: "true"
+
+  - name: build
+    command: >-
+      sh -e -c 'PATH="{{ prepend_path }}:$$PATH"
+      "$${CARGO:-cargo}" build $${BUILD_JOBS:-}'
+
+  - name: release
+    command: >-
+      sh -e -c 'PATH="{{ prepend_path }}:$$PATH"
+      "$${CARGO:-cargo}" build --release $${BUILD_JOBS:-}'
+
+  - name: clean
+    command: >-
+      sh -e -c 'PATH="{{ prepend_path }}:$$PATH"
+      "$${CARGO:-cargo}" clean'
+
+  - name: test
+    command: >-
+      sh -e -c 'PATH="{{ prepend_path }}:$$PATH";
+      RUSTFLAGS="{{ rust_flags }} $${RUST_FLAGS:-}";
+      if "$${CARGO:-cargo}" nextest --version >/dev/null 2>&1; then
+      RUSTFLAGS="$$RUSTFLAGS" "$${CARGO:-cargo}" nextest run {{ cargo_flags }} $${BUILD_JOBS:-};
+      RUSTFLAGS="$$RUSTFLAGS" "$${CARGO:-cargo}" test --doc --workspace --all-features;
+      else
+      RUSTFLAGS="$$RUSTFLAGS" "$${CARGO:-cargo}" test {{ cargo_flags }} $${BUILD_JOBS:-};
+      fi'
+
+  - name: lint
+    command: >-
+      sh -e -c 'PATH="{{ prepend_path }}:$$PATH";
+      RUSTDOCFLAGS="{{ rustdoc_flags }} $${RUSTDOC_FLAGS:-}" "$${CARGO:-cargo}" doc --no-deps;
+      "$${CARGO:-cargo}" clippy {{ cargo_flags }} -- {{ rust_flags }} $${RUST_FLAGS:-};
+      if command -v whitaker >/dev/null 2>&1; then
+      RUSTFLAGS="{{ rust_flags }} $${RUST_FLAGS:-}" whitaker --all -- {{ cargo_flags }};
+      else
+      echo "whitaker not found on PATH; skipping whitaker lint. Install whitaker to run this check.";
+      fi'
+
+  - name: typecheck
+    command: >-
+      sh -e -c 'PATH="{{ prepend_path }}:$$PATH"
+      RUSTFLAGS="{{ rust_flags }} $${RUST_FLAGS:-}"
+      "$${CARGO:-cargo}" check {{ cargo_flags }}'
+
+  - name: fmt
+    command: >-
+      sh -e -c 'PATH="{{ prepend_path }}:$$PATH";
+      "$${CARGO:-cargo}" +nightly fmt --all;
+      mdformat-all'
+
+  - name: check-fmt
+    command: >-
+      sh -e -c 'PATH="{{ prepend_path }}:$$PATH"
+      "$${CARGO:-cargo}" fmt --all -- --check'
+
+  - name: markdownlint
+    command: >-
+      sh -e -c 'PATH="{{ prepend_path }}:$$PATH"
+      "$${MDLINT:-markdownlint-cli2}" '"'"'**/*.md'"'"''
+
+  - name: nixie
+    command: >-
+      sh -e -c 'PATH="{{ prepend_path }}:$$PATH"
+      "$${NIXIE:-nixie}" --no-sandbox'
+
+targets: []
+
+defaults:
+  - all

--- a/Netsukefile
+++ b/Netsukefile
@@ -53,9 +53,8 @@ actions:
 
   - name: typecheck
     command: >-
-      sh -e -c 'PATH="{{ prepend_path }}:$$PATH"
-      RUSTFLAGS="{{ rust_flags }} $${RUST_FLAGS:-}"
-      "$${CARGO:-cargo}" check {{ cargo_flags }}'
+      sh -e -c 'PATH="{{ prepend_path }}:$$PATH";
+      RUSTFLAGS="{{ rust_flags }} $${RUST_FLAGS:-}" "$${CARGO:-cargo}" check {{ cargo_flags }}'
 
   - name: fmt
     command: >-

--- a/Netsukefile
+++ b/Netsukefile
@@ -34,9 +34,11 @@ actions:
       sh -e -c 'PATH="{{ prepend_path }}:$$PATH";
       RUSTFLAGS="{{ rust_flags }} $${RUST_FLAGS:-}";
       if "$${CARGO:-cargo}" nextest --version >/dev/null 2>&1; then
+      echo "[netsuke:test] cargo-nextest found; using nextest runner";
       RUSTFLAGS="$$RUSTFLAGS" "$${CARGO:-cargo}" nextest run {{ cargo_flags }} $${BUILD_JOBS:-};
       RUSTFLAGS="$$RUSTFLAGS" "$${CARGO:-cargo}" test --doc --workspace --all-features;
       else
+      echo "[netsuke:test] cargo-nextest not found; falling back to cargo test";
       RUSTFLAGS="$$RUSTFLAGS" "$${CARGO:-cargo}" test {{ cargo_flags }} $${BUILD_JOBS:-};
       fi'
 
@@ -46,9 +48,10 @@ actions:
       RUSTDOCFLAGS="{{ rustdoc_flags }} $${RUSTDOC_FLAGS:-}" "$${CARGO:-cargo}" doc --no-deps;
       "$${CARGO:-cargo}" clippy {{ cargo_flags }} -- {{ rust_flags }} $${RUST_FLAGS:-};
       if command -v whitaker >/dev/null 2>&1; then
+      echo "[netsuke:lint] whitaker found; running whitaker lint";
       RUSTFLAGS="{{ rust_flags }} $${RUST_FLAGS:-}" whitaker --all -- {{ cargo_flags }};
       else
-      echo "whitaker not found on PATH; skipping whitaker lint. Install whitaker to run this check.";
+      echo "[netsuke:lint] whitaker not found on PATH; skipping whitaker lint. Install whitaker to run this check.";
       fi'
 
   - name: typecheck

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -196,64 +196,58 @@ same pattern as `map_idempotency_key_error`.
 
 ## Build tooling
 
-The Makefile normalizes tool discovery for reduced-`PATH` environments such as
-CI hooks, local git hooks, and non-interactive shells. Prefer running the
-documented `make` targets instead of calling the underlying commands directly.
-
-Cargo-based targets resolve Cargo through the Makefile's `CARGO` variable:
-
-<!-- markdownlint-disable MD013 -->
-```make
-PREPEND_PATH := $(HOME)/.cargo/bin:$(HOME)/.bun/bin:$(HOME)/.local/bin
-CARGO ?= $(shell PATH=$(PREPEND_PATH):$(PATH) command -v cargo 2>/dev/null || printf '%s/.cargo/bin/cargo' "$$HOME")
-```
-<!-- markdownlint-enable MD013 -->
-
-The discovery shell prepends `$(HOME)/.cargo/bin`, `$(HOME)/.bun/bin`, and
-`$(HOME)/.local/bin` while preserving the caller-provided path. This keeps
-targets working when hook environments omit common user install directories.
-The `clean`, `test`, `build`, `release`, `lint`, `typecheck`, `fmt`, and
-`check-fmt` recipes also run Cargo with that scoped prepend.
-
-Override Cargo by exporting `CARGO` or by passing it to `make`:
+Netsuke is the primary repository build driver during the dogfooding pilot that
+replaces direct GNU Make usage. Netsuke compiles the root `Netsukefile` into a
+Ninja build graph, then Ninja runs the selected action. Install Ninja and
+Netsuke before running repository gates:
 
 ```bash
-CARGO=/path/to/cargo make test
+sudo dnf install ninja-build
+cargo install --git https://github.com/leynos/netsuke.git \
+  --rev 2fe314a58d7311758640b3daa086c401d79838cf \
+  netsuke --locked
 ```
 
-`PATH` may be modified before invoking `make`; the scoped prepend is applied
-only for Cargo, Bun, and related developer-tool detection.
+Use the documented Netsuke targets instead of calling the underlying commands
+directly. The root `Makefile` remains as a compatibility shim for existing
+hooks and developer habits, but each Make target now delegates to Netsuke.
 
-The `test` target also detects `cargo-nextest` through `CARGO`. Install
-`cargo-nextest` to `~/.cargo/bin` to enable `make test` to use nextest.
+The Netsuke actions prepend `$HOME/.cargo/bin`, `$HOME/.bun/bin`, and
+`$HOME/.local/bin` while preserving the caller-provided `PATH`. This keeps
+targets working when hook environments omit common user install directories.
+Cargo-based actions honour `CARGO`; Markdown and Mermaid actions honour
+`MDLINT` and `NIXIE`.
+
+Override Cargo by exporting `CARGO` before invoking Netsuke:
+
+```bash
+CARGO=/path/to/cargo netsuke build test
+```
+
+The `test` action detects `cargo-nextest` through Cargo. Install
+`cargo-nextest` to `$HOME/.cargo/bin` to enable `netsuke build test` to use
+nextest.
 
 ```bash
 cargo install cargo-nextest
 ```
 
-If `cargo-nextest` is absent, `make test` falls back to `cargo test` and still
-runs doctests.
+If `cargo-nextest` is absent, `netsuke build test` falls back to `cargo test`
+and still runs doctests.
 
-Markdown linting uses `MDLINT`, resolved through the same scoped prepend:
-
-<!-- markdownlint-disable MD013 -->
-```make
-MDLINT ?= $(shell PATH=$(PREPEND_PATH):$(PATH) command -v markdownlint-cli2 2>/dev/null || printf '%s/.bun/bin/markdownlint-cli2' "$$HOME")
-```
-<!-- markdownlint-enable MD013 -->
-
-Its recipe uses the same scoped `PATH` prepend so `markdownlint-cli2` resolves
-from `$(HOME)/.bun/bin` in the standard development environment:
+Markdown linting uses `MDLINT`, resolved through the same scoped prepend. In
+the standard development environment, `markdownlint-cli2` resolves from
+`$HOME/.bun/bin`:
 
 ```bash
-make markdownlint
+netsuke build markdownlint
 ```
 
 Developers using CI hooks, reduced-`PATH` shells, or other non-standard shell
 environments must ensure the Cargo and Bun binary directories exist when those
-tools are installed. The Makefile prepend mechanism handles ordinary
-`~/.cargo/bin` and `~/.bun/bin` installs automatically; it does not install
-missing tools or create shims.
+tools are installed. The Netsuke manifest handles ordinary `$HOME/.cargo/bin`
+and `$HOME/.bun/bin` installs automatically; it does not install missing tools
+or create shims.
 
 ## Quality gates
 
@@ -263,16 +257,16 @@ gates before commit:
 ### Formatting
 
 ```bash
-make check-fmt
+netsuke build check-fmt
 ```
 
 Validates that all Rust code is formatted per `rustfmt` conventions. Run
-`make fmt` to apply formatting fixes.
+`netsuke build fmt` to apply formatting fixes.
 
 ### Lint
 
 ```bash
-make lint
+netsuke build lint
 ```
 
 Executes Clippy with strict warnings (`-D warnings`) and the repository's
@@ -290,7 +284,7 @@ Key enforced lints:
 ### Tests
 
 ```bash
-make test
+netsuke build test
 ```
 
 Runs `cargo nextest run` (if available, otherwise `cargo test`) plus
@@ -316,8 +310,8 @@ tests cover:
 ### Documentation
 
 ```bash
-make markdownlint  # Lint Markdown files
-make nixie         # Validate Mermaid diagrams
+netsuke build markdownlint  # Lint Markdown files
+netsuke build nixie         # Validate Mermaid diagrams
 ```
 
 Markdown files must pass `markdownlint` and any embedded Mermaid diagrams must

--- a/docs/execplans/adopt-netsuke.md
+++ b/docs/execplans/adopt-netsuke.md
@@ -135,6 +135,8 @@ record the conflict in `Decision Log`, and ask for direction.
 - [x] 2026-05-02: Inspect
   `leynos/agent-helper-scripts/hooks/post-turn-quality-stop-hook.py` and
   document the external hook changes needed for Netsuke-native quality gates.
+- [x] 2026-05-02: Address CI runtime failure `markdownlint-cli2: not found` by
+  installing Bun and `markdownlint-cli2` via GitHub Actions.
 
 ## Surprises & Discoveries
 
@@ -161,6 +163,9 @@ record the conflict in `Decision Log`, and ask for direction.
   directly. It runs its own Rust coverage scripts through `cargo llvm-cov`, so
   the CI migration can keep CodeScene coverage upload intact while replacing
   direct Make invocations with Netsuke.
+- 2026-05-02: `netsuke build markdownlint` in CI failed because
+  `markdownlint-cli2` was missing from PATH; that gap is now addressed by
+  Bun-based install steps before Netsuke invocations.
 - 2026-05-02: `make fmt` now invokes Netsuke and runs, but Markdown formatting
   fails because `docs/netsuke-users-guide.md` contains long lines that
   `markdownlint --fix` reports and cannot automatically repair.
@@ -210,6 +215,9 @@ record the conflict in `Decision Log`, and ask for direction.
   `leynos/agent-helper-scripts`, while this pull request belongs to
   `leynos/actix-v2a`. Keeping the requirement in this ExecPlan lets the
   follow-up be implemented in the owning repository.
+- Decision: Install `markdownlint-cli2` in CI through Bun with `oven-sh/setup-bun`
+  and `bun install -g markdownlint-cli2`. Rationale: the Netsuke Markdown lint
+  step depends on that binary and is not guaranteed present on GitHub runners.
 
 ## Outcomes & Retrospective
 
@@ -218,6 +226,8 @@ Netsuke-first developer documentation, and CI steps that install Netsuke from
 the pinned GitHub source revision before running Netsuke gates. The Netsuke
 manifest, format check, lint, test, Markdown lint, Mermaid validation, and
 Makefile compatibility gates passed.
+CI now installs Bun and `markdownlint-cli2` explicitly so the Markdown gate no
+longer fails with `markdownlint-cli2: not found` during Netsuke execution.
 
 After approval to exceed the initial file-count tolerance,
 `docs/netsuke-users-guide.md` was wrapped narrowly, `make fmt` passed, and the

--- a/docs/execplans/adopt-netsuke.md
+++ b/docs/execplans/adopt-netsuke.md
@@ -1,0 +1,317 @@
+# Adopt Netsuke as the Repository Build Driver
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+This repository currently uses GNU Make through the root `Makefile` and the
+GitHub Actions workflow at `.github/workflows/ci.yml`. The goal is to pilot
+Netsuke as the primary build driver for this simple Rust repository while
+dogfooding Netsuke before package-manager distribution is available. After this
+change, a developer can run `netsuke build check-fmt`, `netsuke build lint`,
+and `netsuke build test` from the repository root and receive the same quality
+gate behaviour currently exposed by `make check-fmt`, `make lint`, and
+`make test`.
+
+Success is observable in two places. Locally, the Netsuke commands pass and
+produce the same effective Cargo, Markdown, and Mermaid checks as the existing
+Makefile. In CI, `.github/workflows/ci.yml` installs Netsuke from
+`https://github.com/leynos/netsuke/` source, installs Ninja, and invokes
+Netsuke for repository gates instead of invoking `make` directly. This is a
+dogfooding pilot, so the plan keeps rollback straightforward and captures any
+Netsuke limitations discovered while translating the existing Makefile targets.
+
+## Constraints
+
+- Read and follow `AGENTS.md` before implementation. This plan was drafted from
+  the repository instructions embedded in the task prompt and must be checked
+  against the actual file again before execution.
+- Use `docs/netsuke-users-guide.md` as the local Netsuke reference for manifest
+  structure, command-line behaviour, configuration, and diagnostics.
+- Install Netsuke from source in CI using the GitHub repository, not from a
+  Debian package, `cargo-binstall`, or crates.io metadata.
+- Keep the pilot suitable for demonstrating that Netsuke can replace `gnumake`
+  in a simple repository. Do not add a bespoke task runner, shell framework, or
+  wrapper script unless a documented Netsuke limitation makes it necessary.
+- Preserve the existing quality gates: Rust formatting, Rustdoc and Clippy
+  linting, Whitaker when available, tests including doctests, Markdown linting,
+  and Mermaid validation.
+- Do not change the public Rust API as part of this build-tooling migration.
+- Do not introduce new Rust crate dependencies to `Cargo.toml`.
+- Do not run format, lint, or test commands in parallel. The repository relies
+  on shared build caching, and sequential execution is required.
+- Capture long validation command output through `tee` into `/tmp`, using
+  branch-specific log names.
+- Keep documentation in en-GB Oxford spelling and wrap Markdown paragraphs at
+  80 columns.
+- Do not remove the `Makefile` until Netsuke has passed locally and in CI, and
+  until the rollback story is accepted. During the pilot, retaining the Makefile
+  as a compatibility shim is allowed.
+
+If satisfying the objective requires violating a constraint, stop immediately,
+record the conflict in `Decision Log`, and ask for direction.
+
+## Tolerances (exception triggers)
+
+- Scope: if implementation requires changes to more than five repository files
+  or more than 250 net lines outside generated lock/build artefacts, stop and
+  escalate.
+- Interface: if any Rust public API signature must change, stop and escalate.
+- Dependencies: if any new project dependency must be added to `Cargo.toml`,
+  stop and escalate.
+- CI: if replacing the coverage step requires removing CodeScene upload or
+  changing coverage format from `lcov`, stop and present options.
+- Tooling: if Netsuke cannot express an existing Makefile target without a
+  wrapper script longer than 40 lines, stop and document the limitation.
+- Iterations: if a gate still fails after two focused fixes, stop and document
+  the failing command, log path, and options.
+- Ambiguity: if there are multiple credible interpretations of "alternative to
+  gnumake" that materially affect whether the Makefile remains, stop and ask.
+
+## Risks
+
+- Risk: Netsuke may not support Make-style conditional execution cleanly for
+  the `test` target's "use nextest if installed, otherwise cargo test" logic.
+  Severity: medium. Likelihood: medium. Mitigation: encode the conditional in
+  a small `script:` action and keep it directly equivalent to the current
+  Makefile recipe; escalate if this becomes a larger shell wrapper.
+- Risk: GitHub's Ubuntu runner may not have Ninja installed. Severity: medium.
+  Likelihood: medium. Mitigation: add an explicit `apt-get install
+  ninja-build` CI step before invoking Netsuke.
+- Risk: `cargo install --git https://github.com/leynos/netsuke/ netsuke
+  --locked` may fail if upstream lockfile or Rust toolchain requirements drift.
+  Severity: medium. Likelihood: low. Mitigation: pin the install to a reviewed
+  Netsuke revision for the pilot, document the revision, and update it
+  deliberately when testing newer Netsuke.
+- Risk: The shared coverage action in `.github/workflows/ci.yml` may hide an
+  internal `make` call. Severity: medium. Likelihood: unknown. Mitigation:
+  inspect its documented inputs or source before finalizing CI; if it invokes
+  Make, either configure it to use the Netsuke test command or replace it with
+  an explicit coverage command that still uploads `lcov.info`.
+- Risk: Markdown formatting tools may not be installed in every local
+  environment. Severity: low. Likelihood: medium. Mitigation: preserve the
+  current Makefile's `PATH` discovery behaviour in the Netsuke manifest and
+  keep failure messages from the underlying tools visible.
+
+## Progress
+
+- [x] 2026-05-02: Create the initial draft plan on branch `adopt-netsuke`.
+- [x] 2026-05-02: Inspect the current `Makefile`, `.github/workflows/ci.yml`,
+  `docs/developers-guide.md`, and `docs/netsuke-users-guide.md`.
+- [x] 2026-05-02: Confirm upstream Netsuke source metadata from
+  `https://github.com/leynos/netsuke/`; the package name is `netsuke`, current
+  `HEAD` during drafting was `2fe314a58d7311758640b3daa086c401d79838cf`, and
+  the crate declares Rust `1.89.0`.
+- [ ] Await explicit approval before executing the implementation phase.
+- [ ] Add a repository `Netsukefile` that reproduces current Makefile targets.
+- [ ] Update developer documentation to describe Netsuke-first usage.
+- [ ] Update CI to install Netsuke from GitHub source and run Netsuke gates.
+- [ ] Validate formatting, linting, tests, Markdown linting, and Mermaid
+  validation through Netsuke.
+- [ ] Commit each completed, gated change atomically.
+
+## Surprises & Discoveries
+
+- 2026-05-02: The current CI only calls `make` directly for `check-fmt` and
+  `lint`. Tests and coverage are delegated to
+  `leynos/shared-actions/.github/actions/generate-coverage`, so implementation
+  must check whether that shared action invokes `make` internally before
+  claiming CI is fully Make-free.
+- 2026-05-02: The Makefile already contains compatibility work for reduced
+  `PATH` environments by prepending `$HOME/.cargo/bin`, `$HOME/.bun/bin`, and
+  `$HOME/.local/bin`. The Netsuke manifest must preserve this behaviour.
+
+## Decision Log
+
+- Decision: Treat this as a Netsuke-first pilot rather than deleting Makefile
+  support immediately.
+  Rationale: The user asked for adoption "as an alternative to `gnumake`" and
+  identified this as a dogfooding pilot. Keeping Makefile compatibility during
+  the first Netsuke migration reduces rollback risk while still proving that
+  Netsuke can drive the repository gates.
+- Decision: Install Netsuke in CI with Cargo from GitHub source and pin the
+  pilot to a reviewed revision.
+  Rationale: The user explicitly rejected Debian packages and `cargo-binstall`
+  metadata until the pilot has demonstrated replacement value. Pinning avoids
+  unrelated upstream Netsuke movement breaking this repository's CI.
+- Decision: Model repository gates as Netsuke `actions`, not file-producing
+  `targets`.
+  Rationale: The current Makefile gates are phony commands that validate the
+  working tree rather than producing durable artefacts. Netsuke's `actions:`
+  section maps directly to that behaviour.
+
+## Outcomes & Retrospective
+
+This section is intentionally empty in the draft. During implementation, record
+what changed, which gates passed, which Netsuke behaviours worked well, and
+which gaps should feed back into Netsuke packaging or documentation before the
+project provides Debian packages or `cargo-binstall` metadata.
+
+## Repository orientation
+
+The current build-tooling surface is small:
+
+- `Makefile` defines `check-fmt`, `lint`, `test`, `fmt`, `markdownlint`,
+  `nixie`, `build`, `release`, `clean`, `typecheck`, `all`, and `help`.
+- `.github/workflows/ci.yml` runs on pull requests and manual dispatch. It
+  checks out the repository, sets up Rust, runs `make check-fmt`, runs
+  Markdown lint through a GitHub Action, runs `make lint`, generates coverage
+  through a shared action, and uploads coverage to CodeScene when configured.
+- `docs/developers-guide.md` documents Makefile-based build tooling and must
+  be updated so developers know that Netsuke is the preferred driver during
+  the pilot.
+- `docs/netsuke-users-guide.md` documents the manifest format. Important
+  concepts for this migration are `actions:` for phony tasks, `script:` for
+  multi-line shell actions, `defaults:` for what runs when `netsuke` is invoked
+  without targets, and `netsuke manifest` for inspecting the generated Ninja
+  file without executing it.
+
+## Implementation plan
+
+First, create `Netsukefile` in the repository root. Use
+`netsuke_version: "1.0.0"` and define shared variables for the tool paths and
+flags currently centralised in the Makefile:
+
+```yaml
+vars:
+  prepend_path: "{{ env('HOME') }}/.cargo/bin:{{ env('HOME') }}/.bun/bin:{{ env('HOME') }}/.local/bin"
+  cargo: "{{ env('CARGO', 'cargo') }}"
+  rust_flags: "-D warnings"
+  rustdoc_flags: "-D warnings"
+  cargo_flags: "--all-targets --all-features"
+```
+
+Use `actions:` for the repository gates. Each action should use a `script:`
+block so shell conditionals remain readable. Preserve the current command
+semantics:
+
+- `check-fmt` runs `cargo fmt --all -- --check`.
+- `lint` runs `cargo doc --no-deps`, `cargo clippy --all-targets
+  --all-features -- -D warnings`, and runs Whitaker only when it is found on
+  `PATH`.
+- `test` detects `cargo nextest --version`; if present, it runs
+  `cargo nextest run --all-targets --all-features` and then
+  `cargo test --doc --workspace --all-features`; otherwise it runs
+  `cargo test --all-targets --all-features`.
+- `fmt` runs `cargo +nightly fmt --all` and `mdformat-all`.
+- `markdownlint` runs `markdownlint-cli2 '**/*.md'`.
+- `nixie` runs `nixie --no-sandbox`.
+- `typecheck` runs `cargo check --all-targets --all-features`.
+- `clean` runs `cargo clean`.
+- `all` runs the same gate sequence as today's Makefile: `check-fmt`, `lint`,
+  and `test`.
+
+Set `defaults:` to `["all"]` only if the implementation confirms that running
+`netsuke` without arguments should execute the full gate suite. If that is too
+expensive for day-to-day use, set no default and document explicit target
+usage instead. This is a product decision for the pilot; if uncertain, escalate
+before choosing.
+
+Second, keep or adapt `Makefile` as a compatibility shim. The preferred pilot
+shape is for `make check-fmt` and related targets to delegate to
+`netsuke build check-fmt` once Netsuke is available. If this creates a
+bootstrap problem for environments that have Make but not Netsuke, leave the
+Makefile recipes intact and document Netsuke as the primary path instead. Do
+not delete the Makefile in the first implementation unless explicitly
+approved.
+
+Third, update `.github/workflows/ci.yml`. After the Rust setup step, install
+Ninja and install Netsuke from source:
+
+```yaml
+- name: Install Ninja
+  run: sudo apt-get update && sudo apt-get install -y ninja-build
+- name: Install Netsuke
+  run: >-
+    cargo install --git https://github.com/leynos/netsuke.git
+    --rev 2fe314a58d7311758640b3daa086c401d79838cf
+    netsuke --locked
+- name: Show Netsuke version
+  run: netsuke --version
+```
+
+Replace direct `make check-fmt` and `make lint` invocations with
+`netsuke build check-fmt` and `netsuke build lint`. Add a Netsuke-driven test
+step unless the coverage action is confirmed to run tests without Make and with
+equivalent coverage. If the shared coverage action invokes `make`, replace or
+configure it so CI remains Netsuke-first while still producing `lcov.info` for
+the existing CodeScene upload step.
+
+Fourth, update documentation. In `docs/developers-guide.md`, change the build
+tooling section to describe Netsuke as the preferred driver, include the source
+install command for the pilot, keep a short compatibility note for Makefile
+users if the Makefile remains, and update gate examples from `make ...` to
+`netsuke build ...`. Also update any roadmap or contributor references that
+would otherwise instruct contributors to use Make for the same gates. Do not
+bulk-rewrite historical ExecPlans.
+
+Fifth, validate the generated Ninja manifest before running expensive gates:
+
+```bash
+set -o pipefail && netsuke manifest - 2>&1 | tee /tmp/manifest-actix-v2a-adopt-netsuke.out
+```
+
+The command should exit successfully and print a Ninja file containing build
+edges for the declared actions. If this fails, fix the `Netsukefile` before
+running any gate.
+
+## Validation plan
+
+Run validation sequentially and capture logs in `/tmp`:
+
+```bash
+set -o pipefail && netsuke build check-fmt 2>&1 | tee /tmp/check-fmt-actix-v2a-adopt-netsuke.out
+set -o pipefail && netsuke build lint 2>&1 | tee /tmp/lint-actix-v2a-adopt-netsuke.out
+set -o pipefail && netsuke build test 2>&1 | tee /tmp/test-actix-v2a-adopt-netsuke.out
+set -o pipefail && netsuke build markdownlint 2>&1 | tee /tmp/markdownlint-actix-v2a-adopt-netsuke.out
+set -o pipefail && netsuke build nixie 2>&1 | tee /tmp/nixie-actix-v2a-adopt-netsuke.out
+```
+
+For documentation-only commits, at minimum run:
+
+```bash
+set -o pipefail && make markdownlint 2>&1 | tee /tmp/markdownlint-actix-v2a-adopt-netsuke-plan.out
+set -o pipefail && make nixie 2>&1 | tee /tmp/nixie-actix-v2a-adopt-netsuke-plan.out
+```
+
+For the final implementation commit, also run the legacy Makefile gates if the
+Makefile remains as a compatibility path:
+
+```bash
+set -o pipefail && make check-fmt 2>&1 | tee /tmp/make-check-fmt-actix-v2a-adopt-netsuke.out
+set -o pipefail && make lint 2>&1 | tee /tmp/make-lint-actix-v2a-adopt-netsuke.out
+set -o pipefail && make test 2>&1 | tee /tmp/make-test-actix-v2a-adopt-netsuke.out
+```
+
+Expected success:
+
+- `netsuke manifest -` exits with status 0.
+- `netsuke build check-fmt` reports no Rust formatting drift.
+- `netsuke build lint` builds Rustdoc without warnings, runs Clippy with
+  warnings denied, and either runs Whitaker or reports the existing
+  "whitaker not found" skip message.
+- `netsuke build test` runs the full workspace test suite and doctests.
+- `netsuke build markdownlint` and `netsuke build nixie` pass after
+  documentation updates.
+- GitHub Actions shows the workflow installing Netsuke from source and running
+  Netsuke commands for the repository gates.
+
+## Rollback plan
+
+If Netsuke cannot drive the gates within the tolerances above, leave the
+existing Makefile and CI Make calls intact, remove any incomplete `Netsukefile`
+changes, and record the Netsuke limitation in `Surprises & Discoveries` and
+`Decision Log`. If only CI installation is unstable, keep the local Netsuke
+manifest and continue using Make in CI until the Netsuke revision or install
+method is fixed. Do not remove coverage upload unless explicitly approved.
+
+## Approval gate
+
+This plan is in draft. Do not implement the `Netsukefile`, CI workflow, or
+developer documentation changes until the plan is explicitly approved or
+revised by the user.

--- a/docs/execplans/adopt-netsuke.md
+++ b/docs/execplans/adopt-netsuke.md
@@ -77,9 +77,9 @@ record the conflict in `Decision Log`, and ask for direction.
 
 - Risk: Netsuke may not support Make-style conditional execution cleanly for
   the `test` target's "use nextest if installed, otherwise cargo test" logic.
-  Severity: medium. Likelihood: medium. Mitigation: encode the conditional in a
-  small `script:` action and keep it directly equivalent to the current
-  Makefile recipe; escalate if this becomes a larger shell wrapper.
+  Severity: medium. Likelihood: medium. Mitigation: keep the conditional in a
+  `command:` action using `sh -e -c` and preserve the current Makefile recipe;
+  escalate only if this grows beyond a concise shell block.
 - Risk: GitHub's Ubuntu runner may not have Ninja installed. Severity: medium.
   Likelihood: medium. Mitigation: add an explicit `apt-get install ninja-build`
   CI step before invoking Netsuke.
@@ -517,6 +517,4 @@ method is fixed. Do not remove coverage upload unless explicitly approved.
 
 ## Approval gate
 
-This plan is in draft. Do not implement the `Netsukefile`, CI workflow, or
-developer documentation changes until the plan is explicitly approved or
-revised by the user.
+Completed in this branch and represented in the current pull request state.

--- a/docs/execplans/adopt-netsuke.md
+++ b/docs/execplans/adopt-netsuke.md
@@ -132,6 +132,9 @@ record the conflict in `Decision Log`, and ask for direction.
 - [x] 2026-05-02: Rerun final gates: `netsuke manifest -`, `make check-fmt`,
   `make markdownlint`, `make nixie`, `make lint`, and `make test`.
 - [x] 2026-05-02: Prepare the gated implementation change for commit.
+- [x] 2026-05-02: Inspect
+  `leynos/agent-helper-scripts/hooks/post-turn-quality-stop-hook.py` and
+  document the external hook changes needed for Netsuke-native quality gates.
 
 ## Surprises & Discoveries
 
@@ -161,6 +164,10 @@ record the conflict in `Decision Log`, and ask for direction.
 - 2026-05-02: `make fmt` now invokes Netsuke and runs, but Markdown formatting
   fails because `docs/netsuke-users-guide.md` contains long lines that
   `markdownlint --fix` reports and cannot automatically repair.
+- 2026-05-02: The external post-turn quality hook is Make-specific today. It
+  stores `make_targets_requested`, parses `make -qp`, runs grouped
+  `make --no-print-directory ...` commands, and reports "Requested make
+  targets" in its block output.
 
 ## Decision Log
 
@@ -198,6 +205,11 @@ record the conflict in `Decision Log`, and ask for direction.
   Rationale: The user approved continuing after the `make fmt` blocker was
   reported, so `docs/netsuke-users-guide.md` can be updated narrowly to satisfy
   Markdown formatting.
+- Decision: Document agent-helper-scripts changes here instead of editing the
+  external repository in this branch. Rationale: The requested script lives in
+  `leynos/agent-helper-scripts`, while this pull request belongs to
+  `leynos/actix-v2a`. Keeping the requirement in this ExecPlan lets the
+  follow-up be implemented in the owning repository.
 
 ## Outcomes & Retrospective
 
@@ -212,6 +224,118 @@ After approval to exceed the initial file-count tolerance,
 final Netsuke-driven Makefile gates passed. The migration is complete from the
 repository's perspective; CI must still prove the source install path on GitHub
 Actions.
+
+## Required agent-helper-scripts hook changes
+
+The stop hook at
+`https://github.com/leynos/agent-helper-scripts/blob/main/hooks/post-turn-quality-stop-hook.py`
+ must become build-driver aware before repositories can retire Makefile shims.
+The current script assumes Make at the data-model, discovery, execution, and
+reporting layers:
+
+- `CATS_TO_TARGETS` maps change categories to target names, but the surrounding
+  state names those values as Make targets.
+- `HookState` stores `make_targets_requested`, `make_targets_run`, and
+  `make_targets_skipped`.
+- `get_make_targets()` shells out to `make -qp --no-print-directory` and parses
+  Make's database output.
+- `run_make()` invokes `make --no-print-directory <targets...>`.
+- `evaluate_changes()` skips requested targets that are absent from the
+  Makefile.
+- `format_reason()` reports "Requested make targets", "Targets run", and
+  "Targets skipped (missing)".
+
+The follow-up in `agent-helper-scripts` should introduce a small build-driver
+abstraction rather than special-casing Netsuke throughout the hook. A minimal
+shape is enough:
+
+```python
+@dataclass(frozen=True)
+class BuildDriver:
+    name: str
+    executable: str
+    manifest: str
+
+    def list_targets(self, repo: Path) -> set[str]: ...
+    def run_targets(
+        self,
+        repo: Path,
+        kind: str,
+        targets: list[str],
+        max_out: int,
+    ) -> dict[str, Any]: ...
+```
+
+Discovery should prefer Netsuke when a root `Netsukefile` exists and `netsuke`
+is on `PATH`. It should fall back to Make when a `Makefile` exists or when
+Netsuke is absent. This preserves current behaviour for repositories that have
+not adopted Netsuke while allowing this repository to remove the compatibility
+shim later.
+
+Target enumeration for Netsuke should not parse arbitrary human output. Use one
+of these approaches, in order of preference:
+
+1. Add a Netsuke machine-readable target listing command upstream and call it
+   from the hook once available.
+2. Until that exists, run `netsuke manifest -` and parse generated Ninja
+   `build <target>:` lines for non-implicit targets. This is less ideal, but it
+   is deterministic enough for a stop-hook bridge.
+3. As a temporary fallback, assume the standard target names from
+   `CATS_TO_TARGETS` exist when `Netsukefile` is present, run them, and let
+   Netsuke report an unknown-target failure. This is noisier but still blocks
+   correctly.
+
+Execution should run one Netsuke process per target group, matching the current
+code and Markdown grouping:
+
+```python
+["netsuke", "build", *targets]
+```
+
+The hook must continue to split code and Markdown checks so Markdown-only
+changes run only `markdownlint`, and Rust changes run `check-fmt` and `lint`.
+If future repositories add TypeScript/Python Netsuke actions, the existing
+`python_ts` mapping can continue to request `check-fmt`, `lint`, and
+`typecheck`.
+
+The hook's state and output should be renamed from Make-specific wording to
+driver-neutral wording:
+
+- `make_targets_requested` -> `targets_requested`
+- `make_targets_run` -> `targets_run`
+- `make_targets_skipped` -> `targets_skipped`
+- "Requested make targets" -> "Requested build targets"
+- failed command strings should show either `netsuke build ...` or `make ...`
+  exactly as executed.
+
+The configuration surface should gain explicit overrides for gradual rollout:
+
+- `POST_TURN_BUILD_DRIVER=auto|netsuke|make`, defaulting to `auto`.
+- `POST_TURN_NETSUKE_BIN=/path/to/netsuke`, defaulting to `netsuke`.
+- `POST_TURN_MAKE_BIN=/path/to/make`, defaulting to `make`.
+
+When `POST_TURN_BUILD_DRIVER=netsuke`, the hook should block with a clear error
+if `Netsukefile` is missing or `netsuke` is unavailable. When the value is
+`auto`, missing Netsuke should fall back to Make if Make is available. When no
+supported driver is available and checks are required, the hook should block
+with an actionable message.
+
+The hook tests in `agent-helper-scripts` should cover:
+
+- Netsuke is selected when both `Netsukefile` and `Makefile` exist.
+- Make is selected when only `Makefile` exists.
+- `POST_TURN_BUILD_DRIVER=make` forces Make even when `Netsukefile` exists.
+- `POST_TURN_BUILD_DRIVER=netsuke` blocks if Netsuke is missing.
+- Markdown-only changes invoke `netsuke build markdownlint`.
+- Rust changes invoke `netsuke build check-fmt lint`.
+- Python/TypeScript changes invoke `netsuke build check-fmt lint typecheck`.
+- Failure output uses driver-neutral labels and includes the exact failed
+  command.
+- `POST_TURN_COMPUSH=1` behaviour is unchanged after successful Netsuke checks.
+
+Acceptance for the hook change is that this repository can delete the Makefile
+compatibility shim and still have the stop hook run the same quality gates
+through `netsuke build ...`.
 
 ## Repository orientation
 

--- a/docs/execplans/adopt-netsuke.md
+++ b/docs/execplans/adopt-netsuke.md
@@ -137,6 +137,8 @@ record the conflict in `Decision Log`, and ask for direction.
   document the external hook changes needed for Netsuke-native quality gates.
 - [x] 2026-05-02: Address CI runtime failure `markdownlint-cli2: not found` by
   installing Bun and `markdownlint-cli2` via GitHub Actions.
+- [x] 2026-05-03: Pin `oven-sh/setup-bun` and `markdownlint-cli2` in CI to
+  immutable versions for reproducible installs.
 - [x] 2026-05-03: Fix `typecheck` action to pass `RUSTFLAGS` in-process with
   the `cargo check` command so Netsuke enforces `-D warnings` consistently.
 
@@ -224,6 +226,11 @@ record the conflict in `Decision Log`, and ask for direction.
 - Decision: Install `markdownlint-cli2` in CI through Bun with `oven-sh/setup-bun`
   and `bun install -g markdownlint-cli2`. Rationale: the Netsuke Markdown lint
   step depends on that binary and is not guaranteed present on GitHub runners.
+- Decision: Pin the CI Bun setup action and markdownlint-cli2 package version to
+  fixed revisions (`oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6`
+  and
+  `markdownlint-cli2@0.22.1`). Rationale: reproducibility should be explicit for
+  dogfooding gates.
 - Decision: Keep Netsuke `typecheck` warning policy explicit by passing
   `RUSTFLAGS` directly in the `cargo check` command line. Rationale: separate
   shell variable assignment without export is equivalent to a no-op for child
@@ -364,17 +371,18 @@ The current build-tooling surface is small:
 - `Makefile` defines `check-fmt`, `lint`, `test`, `fmt`, `markdownlint`,
   `nixie`, `build`, `release`, `clean`, `typecheck`, `all`, and `help`.
 - `.github/workflows/ci.yml` runs on pull requests and manual dispatch. It
-  checks out the repository, sets up Rust, runs `make check-fmt`, runs Markdown
-  lint through a GitHub Action, runs `make lint`, generates coverage through a
-  shared action, and uploads coverage to CodeScene when configured.
+  checks out the repository, sets up Rust, installs Bun tools, installs Netsuke,
+  validates the `Netsukefile` manifest, then runs `netsuke build` gates for
+  format, Markdown linting, and linting, followed by shared coverage and
+  CodeScene upload steps.
 - `docs/developers-guide.md` documents Makefile-based build tooling and must
   be updated so developers know that Netsuke is the preferred driver during the
   pilot.
 - `docs/netsuke-users-guide.md` documents the manifest format. Important
-  concepts for this migration are `actions:` for phony tasks, `script:` for
-  multi-line shell actions, `defaults:` for what runs when `netsuke` is invoked
-  without targets, and `netsuke manifest` for inspecting the generated Ninja
-  file without executing it.
+  concepts for this migration are `actions:` for phony tasks, `command:` blocks
+  for multi-line shell execution, `defaults:` for what runs when `netsuke` is
+  invoked without targets, and `netsuke manifest` for inspecting the generated
+  Ninja file without executing it.
 
 ## Implementation plan
 
@@ -393,31 +401,22 @@ vars:
   cargo_flags: "--all-targets --all-features"
 ```
 
-Use `actions:` for the repository gates. Each action should use a `script:`
-block so shell conditionals remain readable. Preserve the current command
-semantics:
+Use `actions:` for the repository gates. Each action is a `command:` action that
+invokes `sh -e -c` and preserves the current behaviour:
 
-- `check-fmt` runs `cargo fmt --all -- --check`.
-- `lint` runs `cargo doc --no-deps`, `cargo clippy --all-targets
-  --all-features -- -D
-  warnings`, and runs Whitaker only when it is found on `PATH`.
-- `test` detects `cargo nextest --version`; if present, it runs
-  `cargo nextest run --all-targets --all-features` and then
-  `cargo test --doc --workspace --all-features`; otherwise it runs
-  `cargo test --all-targets --all-features`.
-- `fmt` runs `cargo +nightly fmt --all` and `mdformat-all`.
-- `markdownlint` runs `markdownlint-cli2 '**/*.md'`.
-- `nixie` runs `nixie --no-sandbox`.
-- `typecheck` runs `cargo check --all-targets --all-features`.
-- `clean` runs `cargo clean`.
-- `all` runs the same gate sequence as today's Makefile: `check-fmt`, `lint`,
-  and `test`.
+- `check-fmt` runs `netsuke build check-fmt`.
+- `lint` runs `netsuke build lint`.
+- `test` runs `netsuke build test` with `nextest` detection and fallback logic.
+- `fmt` runs `netsuke build fmt`.
+- `markdownlint` runs `netsuke build markdownlint`.
+- `nixie` runs `netsuke build nixie`.
+- `typecheck` runs `netsuke build typecheck`.
+- `clean` runs `netsuke build clean`.
+- `all` runs `netsuke build all`, where `defaults:` is defined to keep the same
+  behaviour as the Makefile's `all`.
 
-Set `defaults:` to `["all"]` only if the implementation confirms that running
-`netsuke` without arguments should execute the full gate suite. If that is too
-expensive for day-to-day use, set no default and document explicit target usage
-instead. This is a product decision for the pilot; if uncertain, escalate
-before choosing.
+Set `defaults:` to `["all"]` because the implementation already confirms
+`netsuke` without arguments should execute the full gate suite for this pilot.
 
 Second, keep or adapt `Makefile` as a compatibility shim. The preferred pilot
 shape is for `make check-fmt` and related targets to delegate to

--- a/docs/execplans/adopt-netsuke.md
+++ b/docs/execplans/adopt-netsuke.md
@@ -137,6 +137,8 @@ record the conflict in `Decision Log`, and ask for direction.
   document the external hook changes needed for Netsuke-native quality gates.
 - [x] 2026-05-02: Address CI runtime failure `markdownlint-cli2: not found` by
   installing Bun and `markdownlint-cli2` via GitHub Actions.
+- [x] 2026-05-03: Fix `typecheck` action to pass `RUSTFLAGS` in-process with
+  the `cargo check` command so Netsuke enforces `-D warnings` consistently.
 
 ## Surprises & Discoveries
 
@@ -173,6 +175,10 @@ record the conflict in `Decision Log`, and ask for direction.
   stores `make_targets_requested`, parses `make -qp`, runs grouped
   `make --no-print-directory ...` commands, and reports "Requested make
   targets" in its block output.
+- 2026-05-03: Netsuke `typecheck` was assigning `RUSTFLAGS` to a shell variable
+  without exporting it; the fixed action now invokes `cargo check` with the
+  environment assignment in-line, restoring the Makefile semantics and preventing
+  silent warning-only pass-through.
 
 ## Decision Log
 
@@ -218,6 +224,10 @@ record the conflict in `Decision Log`, and ask for direction.
 - Decision: Install `markdownlint-cli2` in CI through Bun with `oven-sh/setup-bun`
   and `bun install -g markdownlint-cli2`. Rationale: the Netsuke Markdown lint
   step depends on that binary and is not guaranteed present on GitHub runners.
+- Decision: Keep Netsuke `typecheck` warning policy explicit by passing
+  `RUSTFLAGS` directly in the `cargo check` command line. Rationale: separate
+  shell variable assignment without export is equivalent to a no-op for child
+  processes and can silently miss warnings that should fail CI.
 
 ## Outcomes & Retrospective
 

--- a/docs/execplans/adopt-netsuke.md
+++ b/docs/execplans/adopt-netsuke.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 ## Purpose / big picture
 
@@ -50,8 +50,8 @@ Netsuke limitations discovered while translating the existing Makefile targets.
 - Keep documentation in en-GB Oxford spelling and wrap Markdown paragraphs at
   80 columns.
 - Do not remove the `Makefile` until Netsuke has passed locally and in CI, and
-  until the rollback story is accepted. During the pilot, retaining the Makefile
-  as a compatibility shim is allowed.
+  until the rollback story is accepted. During the pilot, retaining the
+  Makefile as a compatibility shim is allowed.
 
 If satisfying the objective requires violating a constraint, stop immediately,
 record the conflict in `Decision Log`, and ask for direction.
@@ -77,17 +77,17 @@ record the conflict in `Decision Log`, and ask for direction.
 
 - Risk: Netsuke may not support Make-style conditional execution cleanly for
   the `test` target's "use nextest if installed, otherwise cargo test" logic.
-  Severity: medium. Likelihood: medium. Mitigation: encode the conditional in
-  a small `script:` action and keep it directly equivalent to the current
+  Severity: medium. Likelihood: medium. Mitigation: encode the conditional in a
+  small `script:` action and keep it directly equivalent to the current
   Makefile recipe; escalate if this becomes a larger shell wrapper.
 - Risk: GitHub's Ubuntu runner may not have Ninja installed. Severity: medium.
-  Likelihood: medium. Mitigation: add an explicit `apt-get install
-  ninja-build` CI step before invoking Netsuke.
-- Risk: `cargo install --git https://github.com/leynos/netsuke/ netsuke
-  --locked` may fail if upstream lockfile or Rust toolchain requirements drift.
-  Severity: medium. Likelihood: low. Mitigation: pin the install to a reviewed
-  Netsuke revision for the pilot, document the revision, and update it
-  deliberately when testing newer Netsuke.
+  Likelihood: medium. Mitigation: add an explicit `apt-get install ninja-build`
+  CI step before invoking Netsuke.
+- Risk: installing Netsuke from GitHub source with Cargo may fail if the
+  upstream lockfile or Rust toolchain requirements drift. Severity: medium.
+  Likelihood: low. Mitigation: pin the install to a reviewed Netsuke revision
+  for the pilot, document the revision, and update it deliberately when testing
+  newer Netsuke.
 - Risk: The shared coverage action in `.github/workflows/ci.yml` may hide an
   internal `make` call. Severity: medium. Likelihood: unknown. Mitigation:
   inspect its documented inputs or source before finalizing CI; if it invokes
@@ -107,13 +107,31 @@ record the conflict in `Decision Log`, and ask for direction.
   `https://github.com/leynos/netsuke/`; the package name is `netsuke`, current
   `HEAD` during drafting was `2fe314a58d7311758640b3daa086c401d79838cf`, and
   the crate declares Rust `1.89.0`.
-- [ ] Await explicit approval before executing the implementation phase.
-- [ ] Add a repository `Netsukefile` that reproduces current Makefile targets.
-- [ ] Update developer documentation to describe Netsuke-first usage.
-- [ ] Update CI to install Netsuke from GitHub source and run Netsuke gates.
-- [ ] Validate formatting, linting, tests, Markdown linting, and Mermaid
-  validation through Netsuke.
-- [ ] Commit each completed, gated change atomically.
+- [x] 2026-05-02: Receive explicit approval to proceed with implementation.
+- [x] 2026-05-02: Re-check upstream Netsuke `HEAD`; it remains
+  `2fe314a58d7311758640b3daa086c401d79838cf`.
+- [x] 2026-05-02: Add a repository `Netsukefile` that reproduces current
+  Makefile targets and validates with `netsuke manifest -`.
+- [x] 2026-05-02: Update developer documentation to describe Netsuke-first
+  usage and Makefile compatibility.
+- [x] 2026-05-02: Update CI to install Netsuke from GitHub source, install
+  Ninja, validate the manifest, and run Netsuke gates for format, Markdown, and
+  lint.
+- [x] 2026-05-02: Validate formatting, linting, tests, Markdown linting, and
+  Mermaid validation through Netsuke.
+- [x] 2026-05-02: Validate Makefile compatibility for `check-fmt`, `lint`,
+  `test`, `markdownlint`, and `nixie`; each target delegates to Netsuke.
+- [!] 2026-05-02: `make fmt` reached Markdown formatting and failed on
+  line-length issues in `docs/netsuke-users-guide.md`, which is outside the
+  implementation file budget in this plan. Implementation is paused for scope
+  approval before modifying a sixth file.
+- [x] 2026-05-02: Receive approval to exceed the five-file tolerance and fix
+  Markdown formatting issues in `docs/netsuke-users-guide.md`.
+- [x] 2026-05-02: Run `make fmt` successfully through Netsuke after wrapping
+  long Markdown lines.
+- [x] 2026-05-02: Rerun final gates: `netsuke manifest -`, `make check-fmt`,
+  `make markdownlint`, `make nixie`, `make lint`, and `make test`.
+- [x] 2026-05-02: Prepare the gated implementation change for commit.
 
 ## Surprises & Discoveries
 
@@ -125,32 +143,75 @@ record the conflict in `Decision Log`, and ask for direction.
 - 2026-05-02: The Makefile already contains compatibility work for reduced
   `PATH` environments by prepending `$HOME/.cargo/bin`, `$HOME/.bun/bin`, and
   `$HOME/.local/bin`. The Netsuke manifest must preserve this behaviour.
+- 2026-05-02: Netsuke requires a `targets:` key even for an action-only
+  repository manifest. The implemented manifest uses `targets: []`.
+- 2026-05-02: Netsuke `actions` are compiled as Ninja build edges, and an
+  action can use `sources:` to sequence other actions. The `all` action uses
+  this to run `check-fmt`, `lint`, and `test` before its own no-op command.
+- 2026-05-02: Shell variables in Netsuke scripts must be written with doubled
+  dollar signs, such as `$$PATH`, because the generated Ninja file treats `$`
+  as an escape marker.
+- 2026-05-02: Netsuke `script:` actions still produced Ninja `$` escaping
+  failures for this manifest. Switching to `command:` actions that invoke
+  `sh -e -c` preserved the shell behaviour and passed Ninja execution.
+- 2026-05-02: The shared `generate-coverage` action does not call Make
+  directly. It runs its own Rust coverage scripts through `cargo llvm-cov`, so
+  the CI migration can keep CodeScene coverage upload intact while replacing
+  direct Make invocations with Netsuke.
+- 2026-05-02: `make fmt` now invokes Netsuke and runs, but Markdown formatting
+  fails because `docs/netsuke-users-guide.md` contains long lines that
+  `markdownlint --fix` reports and cannot automatically repair.
 
 ## Decision Log
 
 - Decision: Treat this as a Netsuke-first pilot rather than deleting Makefile
-  support immediately.
-  Rationale: The user asked for adoption "as an alternative to `gnumake`" and
-  identified this as a dogfooding pilot. Keeping Makefile compatibility during
-  the first Netsuke migration reduces rollback risk while still proving that
-  Netsuke can drive the repository gates.
+  support immediately. Rationale: The user asked for adoption "as an
+  alternative to `gnumake`" and identified this as a dogfooding pilot. Keeping
+  Makefile compatibility during the first Netsuke migration reduces rollback
+  risk while still proving that Netsuke can drive the repository gates.
 - Decision: Install Netsuke in CI with Cargo from GitHub source and pin the
-  pilot to a reviewed revision.
-  Rationale: The user explicitly rejected Debian packages and `cargo-binstall`
-  metadata until the pilot has demonstrated replacement value. Pinning avoids
-  unrelated upstream Netsuke movement breaking this repository's CI.
+  pilot to a reviewed revision. Rationale: The user explicitly rejected Debian
+  packages and `cargo-binstall` metadata until the pilot has demonstrated
+  replacement value. Pinning avoids unrelated upstream Netsuke movement
+  breaking this repository's CI.
 - Decision: Model repository gates as Netsuke `actions`, not file-producing
-  `targets`.
-  Rationale: The current Makefile gates are phony commands that validate the
-  working tree rather than producing durable artefacts. Netsuke's `actions:`
-  section maps directly to that behaviour.
+  `targets`. Rationale: The current Makefile gates are phony commands that
+  validate the working tree rather than producing durable artefacts. Netsuke's
+  `actions:` section maps directly to that behaviour.
+- Decision: Keep the `Makefile` as a compatibility shim that delegates to
+  Netsuke. Rationale: This preserves existing local commands and hooks while
+  ensuring Netsuke is the actual build driver during the pilot.
+- Decision: Keep the existing shared coverage action in CI.
+  Rationale: The action does not invoke Make and still produces `lcov.info` for
+  the existing CodeScene upload step. Replacing it would add coverage risk
+  outside the Netsuke adoption objective.
+- Decision: Use `command:` actions with explicit `sh -e -c` invocations instead
+  of Netsuke `script:` actions for this pilot. Rationale: The current Netsuke
+  source rejects the generated Ninja file when script bodies contain shell
+  variables. `command:` actions accept doubled dollar signs and keep the
+  repository gate behaviour observable.
+- Decision: Pause before editing `docs/netsuke-users-guide.md`.
+  Rationale: Fixing `make fmt` requires touching a sixth file, which breaches
+  this plan's file-count tolerance. The implementation restored unrelated
+  formatter-only changes and now needs explicit approval to exceed scope.
+- Decision: Continue after explicit scope approval.
+  Rationale: The user approved continuing after the `make fmt` blocker was
+  reported, so `docs/netsuke-users-guide.md` can be updated narrowly to satisfy
+  Markdown formatting.
 
 ## Outcomes & Retrospective
 
-This section is intentionally empty in the draft. During implementation, record
-what changed, which gates passed, which Netsuke behaviours worked well, and
-which gaps should feed back into Netsuke packaging or documentation before the
-project provides Debian packages or `cargo-binstall` metadata.
+The repository now has a root `Netsukefile`, a Makefile compatibility shim,
+Netsuke-first developer documentation, and CI steps that install Netsuke from
+the pinned GitHub source revision before running Netsuke gates. The Netsuke
+manifest, format check, lint, test, Markdown lint, Mermaid validation, and
+Makefile compatibility gates passed.
+
+After approval to exceed the initial file-count tolerance,
+`docs/netsuke-users-guide.md` was wrapped narrowly, `make fmt` passed, and the
+final Netsuke-driven Makefile gates passed. The migration is complete from the
+repository's perspective; CI must still prove the source install path on GitHub
+Actions.
 
 ## Repository orientation
 
@@ -159,12 +220,12 @@ The current build-tooling surface is small:
 - `Makefile` defines `check-fmt`, `lint`, `test`, `fmt`, `markdownlint`,
   `nixie`, `build`, `release`, `clean`, `typecheck`, `all`, and `help`.
 - `.github/workflows/ci.yml` runs on pull requests and manual dispatch. It
-  checks out the repository, sets up Rust, runs `make check-fmt`, runs
-  Markdown lint through a GitHub Action, runs `make lint`, generates coverage
-  through a shared action, and uploads coverage to CodeScene when configured.
+  checks out the repository, sets up Rust, runs `make check-fmt`, runs Markdown
+  lint through a GitHub Action, runs `make lint`, generates coverage through a
+  shared action, and uploads coverage to CodeScene when configured.
 - `docs/developers-guide.md` documents Makefile-based build tooling and must
-  be updated so developers know that Netsuke is the preferred driver during
-  the pilot.
+  be updated so developers know that Netsuke is the preferred driver during the
+  pilot.
 - `docs/netsuke-users-guide.md` documents the manifest format. Important
   concepts for this migration are `actions:` for phony tasks, `script:` for
   multi-line shell actions, `defaults:` for what runs when `netsuke` is invoked
@@ -179,7 +240,9 @@ flags currently centralised in the Makefile:
 
 ```yaml
 vars:
-  prepend_path: "{{ env('HOME') }}/.cargo/bin:{{ env('HOME') }}/.bun/bin:{{ env('HOME') }}/.local/bin"
+  prepend_path: >
+    {{ env('HOME') }}/.cargo/bin:{{ env('HOME') }}/.bun/bin:
+    {{ env('HOME') }}/.local/bin
   cargo: "{{ env('CARGO', 'cargo') }}"
   rust_flags: "-D warnings"
   rustdoc_flags: "-D warnings"
@@ -192,8 +255,8 @@ semantics:
 
 - `check-fmt` runs `cargo fmt --all -- --check`.
 - `lint` runs `cargo doc --no-deps`, `cargo clippy --all-targets
-  --all-features -- -D warnings`, and runs Whitaker only when it is found on
-  `PATH`.
+  --all-features -- -D
+  warnings`, and runs Whitaker only when it is found on `PATH`.
 - `test` detects `cargo nextest --version`; if present, it runs
   `cargo nextest run --all-targets --all-features` and then
   `cargo test --doc --workspace --all-features`; otherwise it runs
@@ -208,8 +271,8 @@ semantics:
 
 Set `defaults:` to `["all"]` only if the implementation confirms that running
 `netsuke` without arguments should execute the full gate suite. If that is too
-expensive for day-to-day use, set no default and document explicit target
-usage instead. This is a product decision for the pilot; if uncertain, escalate
+expensive for day-to-day use, set no default and document explicit target usage
+instead. This is a product decision for the pilot; if uncertain, escalate
 before choosing.
 
 Second, keep or adapt `Makefile` as a compatibility shim. The preferred pilot
@@ -217,8 +280,7 @@ shape is for `make check-fmt` and related targets to delegate to
 `netsuke build check-fmt` once Netsuke is available. If this creates a
 bootstrap problem for environments that have Make but not Netsuke, leave the
 Makefile recipes intact and document Netsuke as the primary path instead. Do
-not delete the Makefile in the first implementation unless explicitly
-approved.
+not delete the Makefile in the first implementation unless explicitly approved.
 
 Third, update `.github/workflows/ci.yml`. After the Rust setup step, install
 Ninja and install Netsuke from source:
@@ -293,8 +355,8 @@ Expected success:
 - `netsuke manifest -` exits with status 0.
 - `netsuke build check-fmt` reports no Rust formatting drift.
 - `netsuke build lint` builds Rustdoc without warnings, runs Clippy with
-  warnings denied, and either runs Whitaker or reports the existing
-  "whitaker not found" skip message.
+  warnings denied, and either runs Whitaker or reports the existing "whitaker
+  not found" skip message.
 - `netsuke build test` runs the full workspace test suite and doctests.
 - `netsuke build markdownlint` and `netsuke build nixie` pass after
   documentation updates.

--- a/docs/netsuke-users-guide.md
+++ b/docs/netsuke-users-guide.md
@@ -1,0 +1,1239 @@
+# Netsuke User Guide
+
+## 1\. Introduction: What is Netsuke?
+
+Netsuke is a modern, declarative build system designed to be intuitive, fast,
+and safe. Think of it not just as a `make` replacement, but as a **build system
+compiler**. You describe your build process in a human-readable YAML manifest
+(`Netsukefile`), leveraging the power of Jinja templating for dynamic logic.
+Netsuke then compiles this high-level description into an optimized build plan
+executed by the high-performance [Ninja](https://ninja-build.org/ "null") build
+system.
+
+**Core Philosophy:**
+
+- **Declarative:** Define *what* you want to build, not *how* step-by-step.
+
+- **Dynamic where needed:** Use Jinja for variables, loops (`foreach`),
+  conditionals (`when`), file globbing (`glob`), and more.
+
+- **Static Execution Plan:** All dynamic logic is resolved *before*
+  execution, resulting in a static Ninja file for fast, reproducible builds.
+
+- **Safety First:** Automatic shell escaping prevents command injection
+  vulnerabilities.
+
+- **Fast Execution:** Leverages Ninja for efficient dependency tracking and
+  parallel execution.
+
+## 2\. Getting Started
+
+### Installation
+
+Netsuke is typically built from source using Cargo:
+
+```sh
+cargo build --release
+# The executable will be in target/release/netsuke
+
+```
+
+Refer to the project's `README.md` or release pages for pre-compiled binaries
+if available. Ensure the `ninja` executable is also installed and available in
+your system's `PATH`.
+
+### Basic Usage
+
+The primary way to use Netsuke is through its command-line interface (CLI). The
+default command is `build`.
+
+1. **Create a `Netsukefile`:** Define your build rules and targets in a YAML
+   file named `Netsukefile` in your project root.
+
+2. **Run Netsuke:** Execute the `netsuke` command.
+
+```sh
+netsuke # Builds default targets defined in Netsukefile
+netsuke build target_name another_target # Builds specific targets
+
+```
+
+If no `Netsukefile` is found, Netsuke will provide a helpful error message:
+
+```text
+Error: Manifest 'Netsukefile' not found in the current directory.
+help: Ensure the manifest exists or pass `--file` with the correct path.
+```
+
+A different manifest path can be specified using the `-f` or `--file` option:
+
+```sh
+netsuke -f path/to/manifest.yml
+```
+
+For a step-by-step introduction, see the [Quick Start guide](quickstart.md).
+
+## 3\. The Netsukefile Manifest
+
+The `Netsukefile` is a YAML file describing the build process.
+
+Netsuke targets YAML 1.2 and forbids duplicate keys in manifests. If the same
+mapping key appears more than once (even if a YAML parser would normally accept
+it with “last key wins” behaviour), Netsuke treats this as an error.
+
+### Top-Level Structure
+
+```yaml
+# Mandatory: Specifies the manifest format version
+netsuke_version: "1.0.0"
+
+# Optional: Global variables accessible throughout the manifest
+vars:
+  cc: gcc
+  src_dir: src
+
+# Optional: Reusable Jinja macros
+macros:
+  - signature: "compile_cmd(input, output)"
+    body: |
+      {{ cc }} -c {{ input }} -o {{ output }}
+
+# Optional: Reusable command templates
+rules:
+  - name: link
+    command: "{{ cc }} {{ ins }} -o {{ outs }}"
+
+# Optional: Phony targets often used for setup or meta-tasks
+# Implicitly phony: true, always: false
+actions:
+  - name: clean
+    command: "rm -rf build *.o"
+
+# Required: Defines the build targets (artefacts to produce)
+targets:
+  - name: build/main.o
+    # A target can define its command inline...
+    command: "{{ compile_cmd('src/main.c', 'build/main.o') }}"
+    sources: src/main.c
+
+  - name: my_app
+    # ...or reference a rule
+    rule: link
+    sources: build/main.o
+
+# Optional: Targets to build if none are specified on the command line
+defaults:
+  - my_app
+
+```
+
+### Key Sections Explained
+
+- `netsuke_version` (**Required**): Semantic version string (e.g., `"1.0.0"`)
+  indicating the manifest schema version. Parsed using `semver`.
+
+- `vars` (Optional): A mapping (dictionary) of global variables. Values can
+  be strings, numbers, booleans, or lists, accessible within Jinja expressions.
+
+- `macros` (Optional): A list of Jinja macro definitions. Each item has a
+  `signature` (e.g., `"my_macro(arg1, arg2='default')"` ) and a multi-line
+  `body`.
+
+- `rules` (Optional): A list of named, reusable command templates.
+
+- `targets` (**Required**): A list defining the primary build outputs (files
+  or logical targets).
+
+- `actions` (Optional): Similar to `targets`, but entries here are implicitly
+  treated as `phony: true` (meaning they don't necessarily correspond to a file
+  and should run when requested). Useful for tasks like `clean` or `test`.
+
+- `defaults` (Optional): A list of target names (from `targets` or `actions`)
+  to build when `netsuke` is run without specific targets.
+
+## 4\. Defining Rules
+
+Rules encapsulate reusable build commands or scripts.
+
+```yaml
+rules:
+  - name: compile # Unique identifier for the rule
+    # Recipe: Exactly one of 'command', 'script', or 'rule'
+    command: "{{ cc }} {{ cflags }} -c {{ ins }} -o {{ outs }}"
+    # Optional: Displayed during the build
+    description: "Compiling {{ outs }}"
+    # Optional: Ninja dependency file info (gcc or msvc format)
+    deps: gcc
+
+```
+
+- `name`: Unique string identifier.
+
+- `recipe`: The action to perform. Defined by one of:
+
+  - `command`: A single shell command string. May contain `{{ ins }}`
+    (space-separated inputs) and `{{ outs }}` (space-separated outputs). These
+    specific placeholders are substituted *after* Jinja rendering but *before*
+    hashing the action. All other Jinja interpolations happen first. The final
+    command must be parseable by `shlex` (POSIX mode).
+
+  - `script`: A multi-line script (using YAML `|`). If it starts with `#!`,
+    it's executed directly. Otherwise, it's run via `/bin/sh -e` (or PowerShell
+    on Windows) by default. Interpolated variables are automatically
+    shell-escaped unless `| raw` is used.
+
+  - `rule`: References another rule by name (less common within a rule
+    definition).
+
+- `description` (Optional): A user-friendly message printed by Ninja when
+  this rule runs. Can contain `{{ ins }}` / `{{ outs }}`.
+
+- `deps` (Optional): Specifies dependency file format (`gcc` or `msvc`) for
+  C/C++ header dependencies, generating Ninja's `depfile` and `deps` attributes.
+
+## 5\. Defining Targets and Actions
+
+Targets define *what* to build or *what action* to perform.
+
+```yaml
+targets:
+  # Example 1: Building an object file using a rule
+  - name: build/utils.o         # Output file(s). Can be a string or list.
+    rule: compile               # Rule to use (mutually exclusive with command/script)
+    sources: src/utils.c        # Input file(s). String or list.
+    deps:                       # Explicit dependencies (targets built before this one)
+      - build/utils.h
+    vars:                       # Target-local variables, override globals
+      cflags: "-O0 -g"
+
+  # Example 2: Linking an executable using an inline command
+  - name: my_app
+    command: "{{ cc }} build/main.o build/utils.o -o my_app"
+    sources:                    # Implicit dependencies derived from command/rule usage
+      - build/main.o
+      - build/utils.o
+    order_only_deps:            # Dependencies built before, but changes don't trigger rebuild
+      - build_directory         # e.g., Ensure 'build/' exists
+
+  # Example 3: A phony action (can also be in top-level 'actions:')
+  - name: package
+    phony: true                 # Doesn't represent a file, always considered out-of-date
+    command: "tar czf package.tar.gz my_app"
+    deps: my_app                # Depends on the 'my_app' target
+
+  # Example 4: A target that always runs
+  - name: timestamp
+    always: true                # Runs every time, regardless of inputs/outputs
+    command: "date > build/timestamp.txt"
+
+```
+
+- `name`: Output file path(s). Can be a string or a list (`StringOrList`).
+
+- `recipe`: How to build the target. Defined by one of `rule`, `command`, or
+  `script` (mutually exclusive).
+
+- `sources`: Input file path(s) (`StringOrList`). If a source matches another
+  target's `name`, an implicit dependency is created.
+
+- `deps` (Optional): Explicit target dependencies (`StringOrList`). Changes
+  trigger rebuilds.
+
+- `order_only_deps` (Optional): Dependencies that must run first but whose
+  changes don't trigger rebuilds (`StringOrList`). Maps to Ninja `||`.
+
+- `vars` (Optional): Target-specific variables that override global `vars`.
+
+- `phony` (Optional, default `false`): Treat target as logical, not a file.
+  Always out-of-date if requested.
+
+- `always` (Optional, default `false`): Re-run the command every time
+  `netsuke` is invoked, regardless of dependency changes.
+
+`StringOrList`: Fields like `name`, `sources`, `deps`, and `order_only_deps`
+accept either a single string or a YAML list of strings for convenience.
+
+## 6\. Jinja Templating in Netsuke
+
+Netsuke uses the [MiniJinja](https://docs.rs/minijinja "null") engine to add
+dynamic capabilities to your manifest.
+
+### Basic Syntax
+
+- Variables: `{{ my_variable }}`
+
+- Expressions: `{{ 1 + 1 }}`, `{{ sources | map('basename') }}`
+
+- Control Structures (within specific keys like `foreach`, `when`, or inside
+  `macros`): `{% if enable %}…{% endif %}`,
+  `{% for item in list %}…{% endfor %}`
+
+**Important:** Structural Jinja (`{% %}`) is generally **not** allowed directly
+within the YAML structure outside of `macros`. Logic should primarily be within
+string values or dedicated keys like `foreach` and `when`.
+
+### Processing Order
+
+Netsuke processes the manifest in stages:
+
+1. Initial YAML Parse: Load the raw file into an intermediate structure (like
+   `serde_json::Value`).
+
+2. Template Expansion (`foreach`, `when`): Evaluate `foreach` expressions to
+   generate multiple target definitions. The `item` (and optional `index`)
+   become available in the context. Evaluate `when` expressions to
+   conditionally include/exclude targets.
+
+3. Deserialisation to AST: Convert the expanded intermediate structure into
+   Netsuke's typed Rust structs (`NetsukeManifest`, `Target`, etc.).
+
+4. Final Rendering: Render Jinja expressions **only within string fields**
+   (like `command`, `description`, `name`, `sources` etc.) using the combined
+   context (globals + target vars + iteration vars).
+
+### `foreach` and `when`
+
+These keys enable generating multiple similar targets programmatically.
+
+```yaml
+targets:
+  # Generate a target for each .c file in src/
+  - foreach: glob('src/*.c')        # Jinja expression returning an iterable
+    # Only include if the filename isn't 'skip.c'
+    when: item | basename != 'skip.c'
+    # 'item' and 'index' (0-based) are available in the context
+    name: "build/{{ item | basename | with_suffix('.o') }}"
+    rule: compile
+    sources: "{{ item }}"
+    vars:
+      compile_flags: "-O{{ index + 1 }}" # Example using index
+
+```
+
+- `foreach`: A Jinja expression evaluating to a list (or any iterable). A
+  target definition will be generated for each item.
+
+- `when` (Optional): A Jinja expression evaluating to a boolean. If false,
+  the target generated for the current `item` is skipped.
+
+### User-defined Macros
+
+Define reusable Jinja logic in the top-level `macros` section.
+
+```yaml
+macros:
+  - signature: "cc_cmd(src, obj, flags='')" # Jinja macro signature
+    body: |                                # Multi-line body
+      {{ cc }} {{ flags }} -c {{ src | shell_escape }} -o {{ obj | shell_escape }}
+
+targets:
+  - name: build/main.o
+    command: "{{ cc_cmd('src/main.c', 'build/main.o', flags=cflags) }}"
+    sources: src/main.c
+
+```
+
+## 7\. Netsuke Standard Library (Stdlib)
+
+Netsuke provides a rich set of built-in Jinja functions, filters, and tests to
+simplify common build tasks. These are automatically available in your manifest
+templates.
+
+### Key Functions
+
+- `env(name, default=None)`: Reads an environment variable. Fails if `name`
+  is unset and no `default` is provided. Example: `{{ env('CC', 'gcc') }}`
+
+- `glob(pattern)`: Expands a filesystem glob pattern into a sorted list of
+  *files* (directories are excluded). Handles `*`, `**`, `?`, `[]`.
+  Case-sensitive. Example: `{{ glob('src/**/*.c') }}`
+
+- `fetch(url, cache=False)`: Downloads content from a URL. If `cache=True`,
+  caches the result in `.netsuke/fetch` within the workspace based on URL hash.
+  Enforces a configurable maximum response size (default 8 MiB); requests abort
+  with an error quoting the configured threshold when the limit is exceeded.
+  Cached downloads stream directly to disk and remove partial files on error.
+  Configure the limit with `StdlibConfig::with_fetch_max_response_bytes`. Marks
+  template as impure.
+
+- `now(offset=None)`: Returns the current time as a timezone-aware object
+  (defaults to UTC). `offset` can be '+HH:MM' or 'Z'. Exposes `.iso8601`,
+  `.unix_timestamp`, `.offset`.
+
+- `timedelta(...)`: Creates a duration object (e.g., for age comparisons).
+  Accepts `weeks`, `days`, `hours`, `minutes`, `seconds`, `milliseconds`,
+  `microseconds`, `nanoseconds`. Exposes `.iso8601`, `.seconds`, `.nanoseconds`.
+
+### Key Filters
+
+Apply filters using the pipe `|` operator: `{{ value | filter_name(args...) }}`
+
+**Path & File Filters:**
+
+- `basename`: `{{ 'path/to/file.txt' | basename }}` -> `"file.txt"`
+
+- `dirname`: `{{ 'path/to/file.txt' | dirname }}` -> `"path/to"`
+
+- `with_suffix(new_suffix, count=1, sep='.')`: Replaces the last `count`
+  dot-separated extensions. `{{ 'archive.tar.gz' | with_suffix('.zip', 2) }}`
+  -> `"archive.zip"`
+
+- `relative_to(base_path)`: Makes a path relative.
+  `{{ '/a/b/c' | relative_to('/a/b') }}` -> `"c"`
+
+- `realpath`: Canonicalizes path, resolving symlinks.
+
+- `expanduser`: Expands `~` to the home directory.
+
+- `contents(encoding='utf-8')`: Reads file content as a string.
+
+- `size`: File size in bytes.
+
+- `linecount`: Number of lines in a text file.
+
+- `hash(alg='sha256')`: Full hex digest of file content (supports
+  `sha256`, `sha512`; `md5`, `sha1` if `legacy-digests` feature enabled).
+
+- `digest(len=8, alg='sha256')`: Truncated hex digest.
+
+- `shell_escape`: **Crucial for security.** Safely quotes a string for use as
+  a single shell argument. *Use this whenever interpolating paths or variables
+  into commands unless you are certain they are safe.*
+
+**Collection Filters:**
+
+- `uniq`: Removes duplicate items from a list, preserving order.
+
+- `flatten`: Flattens a nested list. `{{ [[1], [2, 3]] | flatten }}` ->
+  `[1, 2, 3]`
+
+- `group_by(attribute)`: Groups items in a list of dicts/objects by an
+  attribute's value.
+
+- `map(attribute='...')` / `map('filter', ...)`: Applies attribute access or
+  another filter to each item in a list.
+
+- `filter(attribute='...')` / `filter('test', ...)`: Selects items based on
+  attribute value or a test function.
+
+- `join(sep)`: Joins list items into a string.
+
+- `sort`: Sorts list items.
+
+**Command Filters (Impure):**
+
+- `shell(command_string)`: Pipes the input value (string or bytes) as stdin
+  to `command_string` executed via the system shell (`sh -c` or `cmd /C`).
+  Returns stdout. **Marks the template as impure.** Example:
+  `{{ user_list | shell('grep admin') }}`. The captured stdout is limited to 1
+  MiB by default; configure a different budget with
+  `StdlibConfig::with_command_max_output_bytes`. Exceeding the limit raises an
+  `InvalidOperation` error that quotes the configured threshold. Templates can
+  pass an options mapping such as `{'mode': 'tempfile'}` to stream stdout into
+  a temporary file instead. The file path is returned to the template and
+  remains bounded by `StdlibConfig::with_command_max_stream_bytes` (default 64
+  MiB).
+
+- `grep(pattern, flags=None)`: Filters input lines matching `pattern`.
+  `flags` can be a string (e.g., `'-i'`) or list of strings. Implemented via
+  `shell`. Marks template as impure. The same output and streaming limits apply
+  when `grep` emits large result sets.
+
+**Executable Discovery (`which`):**
+
+- `which` filter/function: Resolves executables using the current `PATH`
+  without marking the template as impure. Example: `{{ 'clang++' | which }}`
+  returns the first matching binary; the function alias
+  `{{ which('clang++') }}` is available if piping would be awkward.
+- Keyword arguments:
+  - `all` (default `false`): Return every match, ordered by `PATH`.
+  - `canonical` (default `false`): Resolve symlinks and deduplicate entries by
+    their canonical path.
+  - `fresh` (default `false`): Bypass the resolver cache for this lookup while
+    keeping previous entries available for future renders.
+  - `cwd_mode` (`auto` | `always` | `never`, default `auto`): Control whether
+    empty `PATH` segments (and, on Windows, the implicit current-directory
+    search) are honoured. Use `"always"` to force the working directory into
+    the search order when `PATH` is empty.
+- Errors include actionable diagnostic codes such as
+  `netsuke::jinja::which::not_found` along with a preview of the scanned
+  `PATH`. Supplying unknown keyword arguments or invalid values raises
+  `netsuke::jinja::which::args`.
+
+**Impurity:** Filters like `shell` and functions like `fetch` interact with the
+outside world. Netsuke tracks this "impurity". Impure templates might affect
+caching or reproducibility analysis in future versions. Use impure helpers
+judiciously.
+
+### Key Tests
+
+Use tests with the `is` keyword: `{% if path is file %}`
+
+- `file`, `dir`, `symlink`: Checks filesystem object type (without following
+  links).
+
+- `readable`, `writable`, `executable`: Checks permissions for the current
+  user.
+
+- `absolute`, `relative`: Checks path type.
+
+## 8\. Command-Line Interface (CLI)
+
+Netsuke's CLI provides commands to manage your build.
+
+```text
+netsuke [OPTIONS] [COMMAND] [TARGETS...]
+
+```
+
+### Global Options
+
+- `-f, --file <FILE>`: Path to the `Netsukefile` (default: `Netsukefile`).
+
+- `-C, --directory <DIR>`: Change to directory `DIR` before doing anything.
+
+- `-j, --jobs <N>`: Set the number of parallel jobs Ninja should run
+  (default: Ninja's default).
+
+- `-v, --verbose`: Enable verbose diagnostic logging and completion timing
+  summaries.
+
+- `--locale <LOCALE>`: Localize CLI help and error messages (for example
+  `en-US` or `es-ES`).
+
+### Network Policy Options
+
+Netsuke's `fetch` helper is guarded by a configurable network policy. The
+policy is configured by these global options:
+
+- `--fetch-allow-scheme <SCHEME>`: Allow additional URL schemes beyond the
+  defaults.
+
+- `--fetch-allow-host <HOST>`: Allow the provided hostnames when default deny
+  is enabled (wildcards such as `*.example.com` are supported).
+
+- `--fetch-block-host <HOST>`: Always block the provided hostnames (wildcards
+  supported), even if they are allowlisted.
+
+- `--fetch-default-deny`: Deny all hosts by default and only permit the
+  allowlist.
+
+### Commands
+
+- `build` (default): Compiles the manifest and runs Ninja to build the
+  specified `TARGETS` (or the `defaults` if none are given).
+
+  - `--emit <FILE>`: Write the generated `build.ninja` file to `<FILE>` and
+    keep it, instead of using a temporary file. When `-C/--directory` is set,
+    relative `--emit` paths are resolved under `<DIR>`.
+
+- `manifest <FILE>`: Generates the `build.ninja` file and writes it to
+  `<FILE>` without executing Ninja. Use `-` to stream the generated Ninja file
+  to stdout (for example `netsuke manifest - | sed ...`). When `-C/--directory`
+  is set, relative manifest output paths are resolved under `<DIR>`.
+
+- `clean`: Removes build artefacts by running `ninja -t clean`. Requires
+  rules/targets to be properly configured for cleaning in Ninja (often via
+  `phony` targets).
+
+- `graph`: Generates the build dependency graph by running `ninja -t graph` on
+  the generated `build.ninja`, outputting DOT to stdout (suitable for
+  Graphviz). Future versions may support other formats like `--html`.
+
+### Configuration and Localization
+
+Netsuke layers configuration in this order, with later entries overriding
+earlier ones: defaults, configuration files, environment variables, and
+command-line flags.
+
+#### Configuration file discovery
+
+Configuration files are discovered using OrthoConfig. When
+`NETSUKE_CONFIG_PATH` is set, it points to a single file and bypasses all
+automatic discovery. Otherwise, Netsuke searches for configuration in three
+scopes:
+
+- **Project scope** — `.netsuke.toml` in the current working directory
+  (or the directory specified by `-C` / `--directory`).
+- **User scope** — user-specific locations:
+  - `$HOME/.netsuke.toml`
+  - `$XDG_CONFIG_HOME/netsuke/config.toml` (XDG (X Desktop Group); Unix;
+    defaults to `$HOME/.config`)
+  - `%APPDATA%\netsuke\config.toml` (Windows)
+  - `%LOCALAPPDATA%\netsuke\config.toml` (Windows)
+  - `$HOME/.config/netsuke/config.toml` (Unix fallback)
+- **System scope** — system-wide locations:
+  - Each entry in `$XDG_CONFIG_DIRS/netsuke/config.toml` (Unix; falls back
+    to `/etc/xdg/netsuke/config.toml`)
+
+Configuration precedence follows **project > user > system**: any field set in
+the project file overrides the same field from user or system files, user-scope
+settings override system-scope, and fields set only in lower-precedence files
+are still applied.
+
+#### Directory flag and project anchoring
+
+The `-C <DIR>` / `--directory <DIR>` flag re-anchors project-scope discovery to
+the specified directory instead of the current working directory. This is
+useful for build scripts and CI pipelines that invoke Netsuke from a different
+location:
+
+```sh
+netsuke -C /path/to/project build
+```
+
+With the flag, only `/path/to/project/.netsuke.toml` is considered for
+project-scope discovery; user-scope discovery is unaffected.
+
+#### Environment variables
+
+Environment variables use the `NETSUKE_` prefix (for example,
+`NETSUKE_JOBS=8`). Use `__` to separate nested keys when matching structured
+configuration.
+
+Use `--locale <LOCALE>`, `NETSUKE_LOCALE`, or a `locale = "..."` entry in a
+configuration file to select localized CLI copy and error messages. Locale
+precedence is: command-line flag, environment variable, configuration file,
+then the system default. The same locale applies to user-facing runtime
+diagnostics, including manifest parse failures, stdlib template errors, and
+runner failures. Spanish (`es-ES`) is included as a reference translation;
+unsupported locales fall back to English (`en-US`).
+
+For information on contributing translations, see the
+[Translator Guide](translators-guide.md).
+
+JSON diagnostics follow the same OrthoConfig layering:
+
+- CLI flag: `--diag-json`
+- Environment variable: `NETSUKE_DIAG_JSON=true|false`
+- Configuration file: `diag_json = true|false`
+
+The newer typed preference aliases use the same precedence chain:
+
+- `--colour-policy auto|always|never`
+- `NETSUKE_COLOUR_POLICY=auto|always|never`
+- `colour_policy = "auto" | "always" | "never"`
+- `--spinner-mode enabled|disabled`
+- `NETSUKE_SPINNER_MODE=enabled|disabled`
+- `spinner_mode = "enabled" | "disabled"`
+- `--output-format human|json`
+- `NETSUKE_OUTPUT_FORMAT=human|json`
+- `output_format = "human" | "json"`
+- `--default-target <TARGET>` (repeatable)
+- `NETSUKE_DEFAULT_TARGETS__0=<TARGET>` style environment entries
+- `default_targets = ["lint", "test"]`
+
+For startup failures that happen before configuration files can be loaded,
+Netsuke honours the CLI flag and environment variable immediately. A
+configuration file cannot request JSON for errors raised while that same file
+is being discovered or parsed.
+
+### Output streams
+
+Netsuke separates its output into two streams for scriptability:
+
+- **stderr**: Status messages, progress indicators, stage summaries, and
+  diagnostics
+- **stdout**: Subprocess output (for example, `ninja -t graph` produces DOT
+  graphs on stdout)
+
+This separation allows reliable piping and redirection:
+
+```bash
+# Capture build graph without status noise
+netsuke graph > build.dot
+
+# Capture progress log without build output
+netsuke build 2> progress.log
+
+# Suppress status messages entirely
+netsuke --progress false build
+```
+
+When using the `manifest` subcommand with `-` as the output path, the generated
+Ninja file streams to stdout while status messages remain on stderr:
+
+```bash
+# Pipe generated Ninja file for inspection
+netsuke manifest - | grep 'rule '
+```
+
+### JSON diagnostics mode
+
+Use `--diag-json` when a caller needs machine-readable diagnostics on `stderr`
+instead of the human-oriented text renderer.
+
+When JSON diagnostics are enabled:
+
+- Failing commands write exactly one JSON document to `stderr`.
+- Successful commands write nothing to `stderr`.
+- Progress lines, timing summaries, emoji prefixes, and tracing logs are
+  suppressed so `stderr` remains machine-readable.
+- `stdout` behaviour is unchanged. For example, `netsuke --diag-json manifest -`
+  still streams the generated Ninja file to `stdout`.
+
+The current schema version is `1`. The document shape is:
+
+- `schema_version`: Integer schema version for compatibility checks.
+- `generator`: Object containing `name` and `version`.
+- `diagnostics`: Array of diagnostic objects.
+
+Each diagnostic object contains:
+
+- `message`: Localized summary line.
+- `code`: Stable diagnostic code, or `null` when unavailable.
+- `severity`: One of `error`, `warning`, or `advice`.
+- `help`: Localized remediation hint, or `null`.
+- `url`: Optional documentation URL.
+- `causes`: Ordered error-cause chain.
+- `source`: Optional source descriptor currently containing `name`.
+- `primary_span`: The first labelled span, or `null`.
+- `labels`: All labelled spans with `label`, `offset`, `length`, `line`,
+  `column`, `end_line`, `end_column`, and `snippet`.
+- `related`: Nested diagnostics rendered using the same schema.
+
+Example:
+
+```json
+{
+  "schema_version": 1,
+  "generator": {
+    "name": "netsuke",
+    "version": "0.1.0"
+  },
+  "diagnostics": [
+    {
+      "message": "Manifest parse failed.",
+      "code": "netsuke::manifest::parse",
+      "severity": "error",
+      "help": "YAML does not permit tabs; use spaces for indentation.",
+      "url": null,
+      "causes": [
+        "YAML parse error at line 2, column 2: tabs disallowed within this context",
+        "tabs disallowed within this context (block indentation) at line 2, column 2"
+      ],
+      "source": {
+        "name": "Netsukefile"
+      },
+      "primary_span": {
+        "label": "invalid YAML",
+        "offset": 10,
+        "length": 1,
+        "line": 2,
+        "column": 2,
+        "end_line": 2,
+        "end_column": 2,
+        "snippet": "-"
+      },
+      "labels": [
+        {
+          "label": "invalid YAML",
+          "offset": 10,
+          "length": 1,
+          "line": 2,
+          "column": 2,
+          "end_line": 2,
+          "end_column": 2,
+          "snippet": "-"
+        }
+      ],
+      "related": []
+    }
+  ]
+}
+```
+
+### Accessible output mode
+
+Netsuke supports an accessible output mode that uses static, labelled status
+lines suitable for screen readers and dumb terminals.
+
+Accessible mode is auto-enabled when:
+
+- `TERM` is set to `dumb`
+- `NO_COLOR` is set (any value)
+
+Accessible mode can be forced on or off:
+
+- CLI flag: `--accessible true` or `--accessible false`
+- Environment variable: `NETSUKE_ACCESSIBLE=true`
+- Configuration file: `accessible = true`
+
+Explicit configuration always takes precedence over auto-detection, in either
+direction (`--accessible false` disables accessible mode even when `NO_COLOR`
+is set).
+
+When accessible mode is active, each pipeline stage produces a labelled status
+line on stderr:
+
+```text
+Stage 1/6: Reading manifest file
+Stage 2/6: Parsing YAML document
+Stage 3/6: Expanding template directives
+Stage 4/6: Deserializing and rendering manifest values
+Stage 5/6: Building and validating dependency graph
+Stage 6/6: Synthesizing Ninja plan and executing Build
+Task 1/2: cc -c src/a.c
+Task 2/2: cc -c src/b.c
+Build complete.
+```
+
+In standard mode, Netsuke uses `indicatif` stage summaries when progress is
+enabled. During Stage 6, Netsuke parses Ninja status lines (`[current/total]`)
+and emits task progress updates. When stdout is not a teletype terminal (TTY),
+task progress automatically falls back to textual updates, so continuous
+integration (CI) and redirected logs remain readable.
+
+When verbose mode is enabled, Netsuke appends a completion timing summary on
+stderr after a successful run:
+
+```text
+Build complete.
+Stage timing summary:
+- Stage 1/6: Reading manifest file: 12ms
+- Stage 2/6: Parsing YAML document: 4ms
+- Stage 3/6: Expanding template directives: 7ms
+- Stage 4/6: Deserializing and rendering manifest values: 6ms
+- Stage 5/6: Building and validating dependency graph: 3ms
+- Stage 6/6: Synthesizing Ninja plan and executing Build: 18ms
+Total pipeline time: 50ms
+```
+
+Without `--verbose`, timing lines are not emitted. Failed runs also suppress
+timing summary output, even when verbose mode is enabled.
+
+Progress output can be controlled via OrthoConfig layering:
+
+- CLI flag: `--progress true` or `--progress false`
+- Environment variable: `NETSUKE_PROGRESS=true|false`
+- Configuration file: `progress = true|false`
+- Typed alias: `--spinner-mode enabled|disabled`,
+  `NETSUKE_SPINNER_MODE=enabled|disabled`, or
+  `spinner_mode = "enabled" | "disabled"`
+
+When progress is disabled, Netsuke suppresses stage and task progress output in
+both standard and accessible modes. If verbose mode is enabled at the same
+time, only the completion timing summary remains visible on successful runs.
+When both the legacy and typed forms are present, `spinner_mode` takes
+precedence.
+
+### Theme and accessibility preferences
+
+Netsuke resolves a CLI theme through the same layered configuration model as
+its other user-facing preferences:
+
+- CLI flag: `--theme auto|unicode|ascii`
+- Environment variable: `NETSUKE_THEME=auto|unicode|ascii`
+- Configuration file: `theme = "auto" | "unicode" | "ascii"`
+
+Theme precedence is:
+
+1. Explicit `theme`
+2. Legacy `no_emoji = true`
+3. `NETSUKE_NO_EMOJI` present
+4. `NO_COLOR` present
+5. Output mode default (`unicode` for standard output, `ascii` for
+   accessible output)
+
+`auto` keeps the mode-sensitive default. `unicode` forces Unicode symbols even
+in accessible mode, while `ascii` forces ASCII-safe symbols everywhere.
+
+Colour policy is configured separately from theme selection:
+
+- CLI flag: `--colour-policy auto|always|never`
+- Environment variable: `NETSUKE_COLOUR_POLICY=auto|always|never`
+- Configuration file: `colour_policy = "auto" | "always" | "never"`
+
+`auto` preserves the current `NO_COLOR`-aware behaviour. `always` ignores
+`NO_COLOR` when deciding between standard and accessible presentation. `never`
+forces `NO_COLOR` behaviour internally, which also makes `auto` theme
+resolution choose ASCII-safe symbols.
+
+Netsuke still supports the legacy no-emoji compatibility flag for users who
+already rely on it:
+
+- CLI flag: `--no-emoji true`
+- Environment variable: `NETSUKE_NO_EMOJI` (any value, including empty)
+- Configuration file: `no_emoji = true`
+
+Only `--no-emoji true` acts as a hard override; `--no-emoji false` and omitting
+the flag both defer to environment variable detection. `NETSUKE_NO_EMOJI` uses
+presence-based semantics, so setting it to any value (including `"false"` or
+`"0"`) still selects the ASCII theme unless an explicit `theme` overrides it.
+
+In all output modes, Netsuke uses semantic text prefixes, so meaning is never
+conveyed solely by colour. The active theme swaps only the glyph set:
+
+- Unicode theme: `✖ Error:`, `⚠ Warning:`, `✔ Success:`, `ℹ Info:`,
+  `⏱ Timing:`
+- ASCII theme: `X Error:`, `! Warning:`, `+ Success:`, `i Info:`,
+  `T Timing:`
+
+### Default targets from configuration
+
+The manifest's `defaults:` list remains the final fallback when a build command
+does not name targets explicitly. Netsuke now supports a higher-precedence CLI
+configuration layer for that same decision:
+
+- CLI flag: `--default-target <TARGET>` (repeatable)
+- Environment variable: indexed `NETSUKE_DEFAULT_TARGETS__N`
+- Configuration file: `default_targets = ["hello", "test"]`
+
+Configured `default_targets` are appended across defaults, files, environment
+variables, and CLI flags. When `netsuke` or `netsuke build` is invoked without
+explicit positional targets, Netsuke uses `default_targets` first and falls
+back to the manifest's `defaults:` list only when the configured list is empty.
+
+These theme-specific stage, task, completion, and timing renderings are also
+guarded by snapshot regression tests so alignment and prefix stability stay
+pinned for both Unicode and ASCII output.
+
+### Exit Codes
+
+- `0`: Success.
+
+- Non-zero: Failure (e.g., manifest parsing error, template error, build
+  command failure).
+
+## 9\. Examples in Practice
+
+Refer to the `examples/` directory in the Netsuke repository for practical
+manifest files:
+
+- `basic_c.yml`: A simple C project compilation. Demonstrates
+  `vars`, `rules`, `targets`, and `defaults`.
+
+- `website.yml`: Builds a static website from Markdown files using Pandoc.
+  Shows `glob`, `foreach`, and path manipulation filters (`basename`,
+  `with_suffix`).
+
+- `photo_edit.yml`: Processes RAW photos with `darktable-cli` and creates a
+  gallery. Uses `glob`, `foreach`, and `actions`.
+
+- `visual_design.yml`: Rasterizes SVG files using Inkscape. Uses `env`
+  function with a default.
+
+- `writing.yml`: Compiles a multi-chapter book from Markdown to PDF via
+  LaTeX. Shows more complex dependencies and sorting of glob results.
+
+These examples illustrate how to combine Netsuke's features to manage different
+kinds of build workflows effectively.
+
+## 10\. Error Handling
+
+Netsuke aims for clear and actionable error messages.
+
+- **YAML Errors:** If `Netsukefile` is invalid YAML, `serde-saphyr` provides
+  location info (line, column). Netsuke may add hints for common issues (e.g.,
+  tabs vs spaces).
+
+- **Schema Errors:** If the YAML structure doesn't match the expected schema
+  (e.g., missing `targets`, unknown keys), errors indicate the structural
+  problem.
+
+- **Template Errors:** Jinja errors during `foreach`, `when`, or string
+  rendering include context (e.g., undefined variable, invalid filter usage)
+  and potentially location information.
+
+- **IR Validation Errors:** Errors found during graph construction (e.g.,
+  missing rules, duplicate outputs, circular dependencies) are reported before
+  execution.
+
+- **Build Failures:** If a command run by Ninja fails, Netsuke reports the
+  failure, typically showing the command's output/error streams captured by
+  Ninja.
+
+Use the `-v` flag for more detailed error context or internal logging.
+
+## 11\. Security Considerations
+
+- **Command Injection:** Netsuke automatically shell-escapes variables
+  interpolated into `command:` strings *unless* the `| raw` Jinja filter is
+  explicitly used. Avoid `| raw` unless you fully trust the variable's content.
+  File paths from `glob` or placeholders like `{{ ins }}` / `{{ outs }}` are
+  quoted safely.
+
+- **`script:` Execution:** Scripts run via the specified interpreter
+  (defaulting to `sh -e`). Ensure scripts handle inputs safely.
+
+- **Impure Functions/Filters:**
+  `env()`, `glob()`, `fetch()`, `shell()`, `grep()` interact with the
+  environment or network. Be mindful when using them with untrusted manifest
+  parts. Future versions might offer sandboxing options.
+
+Always review `Netsukefile` manifests, especially those from untrusted sources,
+before building.
+
+## 12\. Advanced usage
+
+This chapter covers features aimed at users who have mastered the basics and
+want to integrate Netsuke into more sophisticated workflows. These include
+utility subcommands (`clean`, `graph`, `manifest`), configuration file
+discovery and layering, and JSON diagnostics mode for programmatic consumption
+of Netsuke's output.
+
+### 12.1 The `clean` subcommand
+
+The `clean` subcommand removes build artefacts that Ninja tracked in its
+internal database. It delegates directly to `ninja -t clean`:
+
+```sh
+netsuke clean
+```
+
+This removes all output files declared in target `name:` fields that Ninja has
+built. Only file-producing targets (those with output files declared in their
+`name:` fields) are removed. Entries under the `actions` section are implicitly
+phony (treated as `{ phony: true, always: false }` by default) and are
+therefore ignored by `clean` since their names are not considered build
+artefacts.
+
+**Interaction with phony targets:** If a target outside the `actions` section
+is declared as `phony: true`, Ninja does not track it as a file, so `clean`
+ignores it as well.
+
+**Example workflow:**
+
+```sh
+# Build the project
+netsuke build
+
+# Remove all build outputs
+netsuke clean
+
+# Rebuild from scratch
+netsuke build
+```
+
+**Note:** Running `clean` in a workspace that has never been built (no
+`.ninja_log` exists) will either succeed as a no-op or report that no build
+state is available, depending on Ninja's behaviour.
+
+### 12.2 The `graph` subcommand
+
+The `graph` subcommand generates a Graphviz DOT representation of the build
+dependency graph:
+
+```sh
+netsuke graph > build.dot
+dot -Tpng build.dot -o build.png
+```
+
+This produces a visual diagram showing:
+
+- Nodes for each target and action.
+- Edges showing explicit dependencies (`sources:`, `deps:`).
+- Order-only dependencies (`order_only_deps:`).
+
+**Interpreting the output:**
+
+- Each node is labelled with the target or action name.
+- Directed edges (`->`) point from prerequisites to dependants.
+- Order-only dependencies are shown as dashed edges (if Graphviz is configured
+  to distinguish them).
+
+**Example workflow:**
+
+To understand why a particular target rebuilds when a file changes:
+
+```sh
+netsuke graph | grep -A5 -B5 my_target
+```
+
+This shows the subgraph around `my_target` and helps trace back to its
+dependencies.
+
+**Requirements:** The `graph` command requires a valid manifest. If the
+manifest is syntactically invalid or contains structural errors, `graph` will
+fail before rendering any DOT output.
+
+### 12.3 The `manifest` subcommand
+
+The `manifest` subcommand writes the generated Ninja build file to a specified
+location without invoking Ninja:
+
+```sh
+netsuke manifest out.ninja
+```
+
+This is useful for:
+
+- Inspecting the exact Ninja rules and build statements Netsuke generates.
+- Debugging template expansion or rule generation issues.
+- Integrating with tools that consume Ninja files directly.
+
+**Streaming to stdout:**
+
+Passing `-` as the path streams the manifest to stdout:
+
+```sh
+netsuke manifest - | less
+```
+
+This avoids creating a temporary file and is convenient for quick inspection.
+
+**Comparison with `--emit`:**
+
+The build command also supports `--emit <path>`, which writes the manifest and
+then invokes Ninja on it:
+
+```sh
+netsuke build --emit build.ninja
+```
+
+Use `manifest` to obtain the Ninja file *without* running the build, and
+`--emit` to obtain both the file and the build execution.
+
+### 12.4 Configuration layering
+
+Netsuke uses a layered precedence model where configuration sources are merged,
+with later sources overriding earlier ones. The precedence order (from lowest
+to highest) is:
+
+1. **Built-in defaults** — hard-coded fallback values.
+2. **Configuration files** (merged from multiple scopes, lowest first):
+   - **System** — `$XDG_CONFIG_DIRS/netsuke/config.toml` on Unix (defaults to
+     `/etc/xdg/netsuke/config.toml`).
+   - **User** — `$XDG_CONFIG_HOME/netsuke/config.toml` on Unix
+     (`~/.config/netsuke/config.toml` by default), `%APPDATA%\netsuke` and
+     `%LOCALAPPDATA%\netsuke` on Windows, or `~/.netsuke.toml`.
+   - **Project** — `.netsuke.toml` in the current working directory (or the
+     directory specified by `-C`).
+3. **Environment variables** — any variable with the `NETSUKE_` prefix
+   (e.g., `NETSUKE_VERBOSE`, `NETSUKE_COLOUR_POLICY`).
+4. **CLI flags** — explicit command-line options (e.g., `--verbose`,
+   `--colour-policy`).
+
+Multiple configuration files are merged (not a single-winner search), and each
+successive layer overrides values from earlier layers. Setting
+`NETSUKE_CONFIG_PATH` bypasses automatic file discovery and uses only the
+specified file. See Section 8 ("Configuration and Localization") for the full
+discovery model.
+
+**Configuration file format:**
+
+Configuration files are TOML. Supported keys match the CLI option names:
+
+```toml
+# .netsuke.toml
+verbose = true
+colour_policy = "always"
+spinner_mode = "enabled"
+theme = "unicode"
+default_targets = ["hello", "test"]
+```
+
+**Environment variables:**
+
+Environment variables use the `NETSUKE_` prefix and convert kebab-case option
+names to screaming snake case:
+
+- `--verbose` → `NETSUKE_VERBOSE=true`
+- `--colour-policy` → `NETSUKE_COLOUR_POLICY=always`
+- `--spinner-mode` → `NETSUKE_SPINNER_MODE=disabled`
+
+For nested fields or indexed lists, use double underscore separators:
+
+- `NETSUKE_DEFAULT_TARGETS__0=hello`
+- `NETSUKE_DEFAULT_TARGETS__1=test`
+
+**Example layering workflow:**
+
+Given a project configuration file:
+
+```toml
+# .netsuke.toml (project scope)
+verbose = true
+colour_policy = "auto"
+```
+
+Override `colour_policy` for a single invocation using an environment variable:
+
+```sh
+NETSUKE_COLOUR_POLICY=never netsuke build
+```
+
+Override both settings for a single invocation using CLI flags:
+
+```sh
+netsuke build --colour-policy always
+```
+
+**Precedence verification:**
+
+To verify which configuration values take effect, run your command with
+`--verbose`. The timing summary and diagnostic output confirm that verbose mode
+is active, for example:
+
+```sh
+netsuke --verbose build
+```
+
+If the timing summary appears, the verbose setting reached the binary — useful
+for confirming that a config file, environment variable, or CLI flag is being
+picked up as expected.
+
+### 12.5 JSON diagnostics
+
+Netsuke supports a JSON diagnostics mode for programmatic consumption of error
+messages and structured output. Enable it with:
+
+```sh
+netsuke --diag-json build
+```
+
+Or via the environment variable:
+
+```sh
+NETSUKE_OUTPUT_FORMAT=json netsuke build
+```
+
+**JSON diagnostics on error:**
+
+When a command fails, stderr contains a JSON envelope with structured error
+information:
+
+```json
+{
+  "schema_version": 1,
+  "generator": {
+    "name": "netsuke",
+    "version": "0.1.0"
+  },
+  "diagnostics": [
+    {
+      "severity": "error",
+      "code": "netsuke::runner::manifest_not_found",
+      "message": "Manifest 'Netsukefile' not found in the current directory.",
+      "help": "Ensure the manifest exists or pass `--file` with the correct path."
+    }
+  ]
+}
+```
+
+**Interaction with stdout:**
+
+When JSON diagnostics are enabled, stdout remains clean for machine-readable
+output (e.g., from `manifest -`). All diagnostic messages go to stderr in JSON
+format.
+
+**Interaction with `--verbose`:**
+
+Verbose logging is suppressed in JSON mode. The `--verbose` flag does not add
+tracing output when `--diag-json` is active, preventing pollution of the
+structured JSON stream.
+
+**Example workflow - CI integration:**
+
+In a continuous integration pipeline, parse Netsuke's JSON diagnostics to
+report structured failures:
+
+```sh
+netsuke --diag-json build 2>diagnostics.json
+if [ $? -ne 0 ]; then
+  jq '.schema_version, .generator.name, .generator.version, .diagnostics[0].code, .diagnostics[0].message' diagnostics.json
+fi
+```
+
+This allows the CI system to categorize errors by code and present actionable
+messages to developers.

--- a/docs/netsuke-users-guide.md
+++ b/docs/netsuke-users-guide.md
@@ -198,10 +198,13 @@ Targets define *what* to build or *what action* to perform.
 ```yaml
 targets:
   # Example 1: Building an object file using a rule
-  - name: build/utils.o         # Output file(s). Can be a string or list.
-    rule: compile               # Rule to use (mutually exclusive with command/script)
+  # Output file(s). Can be a string or list.
+  - name: build/utils.o
+    # Rule to use; mutually exclusive with command/script.
+    rule: compile
     sources: src/utils.c        # Input file(s). String or list.
-    deps:                       # Explicit dependencies (targets built before this one)
+    # Explicit dependencies built before this target.
+    deps:
       - build/utils.h
     vars:                       # Target-local variables, override globals
       cflags: "-O0 -g"
@@ -209,10 +212,12 @@ targets:
   # Example 2: Linking an executable using an inline command
   - name: my_app
     command: "{{ cc }} build/main.o build/utils.o -o my_app"
-    sources:                    # Implicit dependencies derived from command/rule usage
+    # Implicit dependencies derived from command/rule usage.
+    sources:
       - build/main.o
       - build/utils.o
-    order_only_deps:            # Dependencies built before, but changes don't trigger rebuild
+    # Dependencies built before, but changes don't trigger rebuilds.
+    order_only_deps:
       - build_directory         # e.g., Ensure 'build/' exists
 
   # Example 3: A phony action (can also be in top-level 'actions:')
@@ -324,7 +329,8 @@ Define reusable Jinja logic in the top-level `macros` section.
 macros:
   - signature: "cc_cmd(src, obj, flags='')" # Jinja macro signature
     body: |                                # Multi-line body
-      {{ cc }} {{ flags }} -c {{ src | shell_escape }} -o {{ obj | shell_escape }}
+      {{ cc }} {{ flags }} -c {{ src | shell_escape }} \
+        -o {{ obj | shell_escape }}
 
 targets:
   - name: build/main.o
@@ -710,7 +716,7 @@ Example:
       "url": null,
       "causes": [
         "YAML parse error at line 2, column 2: tabs disallowed within this context",
-        "tabs disallowed within this context (block indentation) at line 2, column 2"
+        "tabs disallowed within this context at line 2, column 2"
       ],
       "source": {
         "name": "Netsukefile"
@@ -1231,7 +1237,11 @@ report structured failures:
 ```sh
 netsuke --diag-json build 2>diagnostics.json
 if [ $? -ne 0 ]; then
-  jq '.schema_version, .generator.name, .generator.version, .diagnostics[0].code, .diagnostics[0].message' diagnostics.json
+  jq '.schema_version,
+    .generator.name,
+    .generator.version,
+    .diagnostics[0].code,
+    .diagnostics[0].message' diagnostics.json
 fi
 ```
 


### PR DESCRIPTION
## Summary

This branch adds the local Netsuke reference material and implements the dogfooding pilot for adopting Netsuke as the repository build driver. It adds a root `Netsukefile`, keeps the root `Makefile` as a compatibility shim that delegates to Netsuke, updates CI to install Netsuke from the pinned GitHub source revision, and refreshes developer documentation so contributors use Netsuke-first gate commands.

Execplan: [docs/execplans/adopt-netsuke.md](https://github.com/leynos/actix-v2a/blob/5b49335a03aff279cb862c902f1d899f78747f9d/docs/execplans/adopt-netsuke.md)

## Review walkthrough

- Start with [Netsukefile](https://github.com/leynos/actix-v2a/blob/5b49335a03aff279cb862c902f1d899f78747f9d/Netsukefile) to review the Netsuke actions that mirror the existing repository gates.
- Then review [Makefile](https://github.com/leynos/actix-v2a/blob/5b49335a03aff279cb862c902f1d899f78747f9d/Makefile) to confirm Make remains only as a compatibility shim over Netsuke.
- Check [.github/workflows/ci.yml](https://github.com/leynos/actix-v2a/blob/5b49335a03aff279cb862c902f1d899f78747f9d/.github/workflows/ci.yml) for the source install of Netsuke, Ninja setup, manifest validation, and Netsuke-driven gates.
- Review [docs/developers-guide.md](https://github.com/leynos/actix-v2a/blob/5b49335a03aff279cb862c902f1d899f78747f9d/docs/developers-guide.md) for the user-facing build-tooling instructions.
- Finish with [docs/execplans/adopt-netsuke.md](https://github.com/leynos/actix-v2a/blob/5b49335a03aff279cb862c902f1d899f78747f9d/docs/execplans/adopt-netsuke.md#required-agent-helper-scripts-hook-changes) for the documented `agent-helper-scripts` hook follow-up needed before the Makefile shim can be removed.

## Validation

- `netsuke manifest -`: passed.
- `make fmt`: passed.
- `make check-fmt`: passed.
- `make markdownlint`: passed.
- `make nixie`: passed.
- `make lint`: passed.
- `make test`: passed, including 160 nextest tests and 26 doctests.

## Notes

The implementation keeps the shared coverage action in CI because inspection showed that it does not invoke Make directly and still produces the existing `lcov.info` artefact for CodeScene upload. The plan records the Netsuke `script:` dollar-escaping issue discovered during implementation and uses `command:` actions with explicit `sh -e -c` invocations for this pilot.

The latest update documents the required changes to `leynos/agent-helper-scripts/hooks/post-turn-quality-stop-hook.py`: add build-driver discovery, prefer Netsuke when `Netsukefile` exists, keep Make fallback, rename Make-specific hook state/output, add rollout environment variables, and cover Netsuke execution in hook tests.