### PR TITLE
Add SSE property tests (#18)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+.ninja_log
 **/*.rs.bk
 *.swp
 *.swo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,7 @@ dependencies = [
  "base64",
  "hex",
  "insta",
+ "proptest",
  "rstest",
  "rstest-bdd",
  "rstest-bdd-macros",
@@ -265,6 +266,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +285,21 @@ checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -1273,6 +1295,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,6 +1460,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,6 +1532,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -1699,6 +1764,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -2234,6 +2311,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unic-langid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2371,6 +2454,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ uuid = { version = "1", features = ["serde", "v4"] }
 
 [dev-dependencies]
 insta = "1.47.2"
+proptest = "1.11"
 rstest = "0.26.1"
 rstest-bdd = "0.5.0"
 rstest-bdd-macros = { version = "0.5.0", features = ["strict-compile-time-validation"] }

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -309,6 +309,20 @@ tests cover:
 - Conversion traits (`AsRef<str>`, `Display`, `From`, `TryFrom`)
 - Error mapping to API error envelope
 
+### Testing dependencies
+
+Test-only dependencies live under `[dev-dependencies]` in `Cargo.toml`.
+Approved testing libraries are:
+
+- `rstest` for fixtures and named parameterized examples.
+- `rstest-bdd` and `rstest-bdd-macros` for downstream-facing behavioural
+  scenarios where Gherkin structure clarifies the contract.
+- `proptest` for compact invariants that should hold across generated input
+  spaces, such as validation, parsing, normalization, and idempotence.
+- `insta` for snapshot coverage of stable rendered output, such as error
+  display text and OpenAPI schema JSON.
+- `tracing-test` for assertions over emitted tracing spans and events.
+
 ### Documentation
 
 ```bash

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -368,7 +368,7 @@ without forbidden bytes are valid" or "applying this header policy twice leaves
 one canonical header". Property tests should:
 
 - use narrow strategies that match the invariant under test;
-- keep generated collection sizes bounded so `make test` remains fast;
+- keep generated collection sizes bounded so `netsuke build test` remains fast;
 - use `prop_assert!` and `prop_assert_eq!` for failures that shrink clearly;
 - avoid returning `Result` from the generated test body unless the property
   genuinely needs fallible setup outside the assertion path; and
@@ -378,8 +378,9 @@ one canonical header". Property tests should:
 Current SSE examples are:
 
 - `sse::event_id::tests::arbitrary_byte_validation_matches_spec`, which checks
-  `EventId::try_from(String)` over arbitrary byte vectors that decode as
-  UTF-8.
+  `EventId::try_from(String)` over arbitrary byte vectors converted to a
+  `String` with lossy UTF-8 decoding (`String::from_utf8_lossy`). This does not
+  filter out invalid-UTF-8 inputs before calling `EventId::try_from(String)`.
 - `sse::cache_control::tests::apply_event_stream_cache_control_is_idempotent_over_arbitrary_headers`,
   which checks cache-control canonicalization over generated header vectors.
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -302,6 +302,8 @@ tests cover:
 - Data and comment newline normalization, including blank lines and trailing
   newlines
 - Cache-control helper behaviour, replacement semantics, and determinism
+- Property tests for `EventId` forbidden-byte validation and cache-control
+  idempotence
 - Heartbeat policy defaults, override validation, and heartbeat frame output
 - Standard `stream_reset` event output and constant alignment
 - Conversion traits (`AsRef<str>`, `Display`, `From`, `TryFrom`)
@@ -351,6 +353,35 @@ fn new_rejects_identifier_containing_line_feed(#[case] input: &str) {
 
 Avoid underscore-prefixed label parameters in rstest cases (triggers
 `used_underscore_binding` lint).
+
+### Property tests
+
+Use `proptest` when a helper has a compact invariant that should hold across a
+large input space, especially for parsing, validation, normalization, and
+idempotent mutation. Keep property tests beside the helper they exercise, in
+the same module-local `#[cfg(test)] mod tests` block as the related
+example-based coverage.
+
+Prefer `rstest` for named edge cases that document specific examples. Prefer
+`proptest` when the important claim is universal, such as "all UTF-8 strings
+without forbidden bytes are valid" or "applying this header policy twice leaves
+one canonical header". Property tests should:
+
+- use narrow strategies that match the invariant under test;
+- keep generated collection sizes bounded so `make test` remains fast;
+- use `prop_assert!` and `prop_assert_eq!` for failures that shrink clearly;
+- avoid returning `Result` from the generated test body unless the property
+  genuinely needs fallible setup outside the assertion path; and
+- preserve hand-written regression tests for named boundary cases that are easy
+  for reviewers to read.
+
+Current SSE examples are:
+
+- `sse::event_id::tests::arbitrary_byte_validation_matches_spec`, which checks
+  `EventId::try_from(String)` over arbitrary byte vectors that decode as
+  UTF-8.
+- `sse::cache_control::tests::apply_event_stream_cache_control_is_idempotent_over_arbitrary_headers`,
+  which checks cache-control canonicalization over generated header vectors.
 
 ### Behavioural tests
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -386,7 +386,7 @@ one canonical header". Property tests should:
 - use `prop_assert!` and `prop_assert_eq!` for failures that shrink clearly;
 - avoid returning `Result` from the generated test body unless the property
   genuinely needs fallible setup outside the assertion path; and
-- preserve hand-written regression tests for named boundary cases that are easy
+- preserve handwritten regression tests for named boundary cases that are easy
   for reviewers to read.
 
 Current SSE examples are:

--- a/src/sse/cache_control.rs
+++ b/src/sse/cache_control.rs
@@ -56,6 +56,12 @@ mod tests {
     };
     use crate::SseHeader;
 
+    /// Generate SSE header strategies for cache-control idempotence tests.
+    ///
+    /// The strategy mixes arbitrary header names with common `Cache-Control`
+    /// casing variants and arbitrary string values, so the property test can
+    /// prove canonical cache-control replacement without losing unrelated
+    /// headers.
     fn arbitrary_sse_header() -> impl Strategy<Value = SseHeader> {
         let arbitrary_name = any::<String>();
         let cache_control_name = prop_oneof![

--- a/src/sse/cache_control.rs
+++ b/src/sse/cache_control.rs
@@ -47,12 +47,30 @@ pub fn apply_event_stream_cache_control(headers: &mut Vec<SseHeader>) {
 mod tests {
     //! Regression coverage for event-stream cache-control helpers.
 
+    use proptest::prelude::*;
+
     use super::{
         CACHE_CONTROL_HEADER,
         EVENT_STREAM_CACHE_CONTROL,
         apply_event_stream_cache_control,
     };
     use crate::SseHeader;
+
+    fn arbitrary_sse_header() -> impl Strategy<Value = SseHeader> {
+        let arbitrary_name = any::<String>();
+        let cache_control_name = prop_oneof![
+            Just(CACHE_CONTROL_HEADER.to_owned()),
+            Just("cache-control".to_owned()),
+            Just("CACHE-CONTROL".to_owned()),
+            Just("Cache-control".to_owned()),
+        ];
+
+        (
+            prop_oneof![arbitrary_name, cache_control_name],
+            any::<String>(),
+        )
+            .prop_map(|(name, value)| SseHeader::new(name, value))
+    }
 
     #[test]
     fn apply_event_stream_cache_control_sets_expected_value() {
@@ -109,5 +127,39 @@ mod tests {
                 .value(),
             EVENT_STREAM_CACHE_CONTROL
         );
+    }
+
+    proptest! {
+        #[test]
+        fn apply_event_stream_cache_control_is_idempotent_over_arbitrary_headers(
+            mut headers in prop::collection::vec(arbitrary_sse_header(), 0..20),
+        ) {
+            let unrelated_headers: Vec<_> = headers
+                .iter()
+                .filter(|header| !header.has_name(CACHE_CONTROL_HEADER))
+                .cloned()
+                .collect();
+
+            apply_event_stream_cache_control(&mut headers);
+            apply_event_stream_cache_control(&mut headers);
+
+            let cache_headers: Vec<_> = headers
+                .iter()
+                .filter(|header| header.has_name(CACHE_CONTROL_HEADER))
+                .collect();
+            prop_assert_eq!(cache_headers.len(), 1);
+
+            if let Some(cache_header) = cache_headers.first() {
+                prop_assert_eq!(cache_header.name(), CACHE_CONTROL_HEADER);
+                prop_assert_eq!(cache_header.value(), EVENT_STREAM_CACHE_CONTROL);
+            }
+
+            let retained_unrelated_headers: Vec<_> = headers
+                .iter()
+                .filter(|header| !header.has_name(CACHE_CONTROL_HEADER))
+                .cloned()
+                .collect();
+            prop_assert_eq!(retained_unrelated_headers, unrelated_headers);
+        }
     }
 }

--- a/src/sse/event_id.rs
+++ b/src/sse/event_id.rs
@@ -217,22 +217,21 @@ mod tests {
     proptest! {
         #[test]
         fn arbitrary_byte_validation_matches_spec(input_bytes in prop::collection::vec(any::<u8>(), 0..128)) {
-            if let Ok(input) = String::from_utf8(input_bytes) {
-                let result = EventId::try_from(input.clone());
+            let input = String::from_utf8_lossy(&input_bytes).into_owned();
+            let result = EventId::try_from(input.clone());
 
-                if input.is_empty() {
-                    prop_assert_eq!(result, Err(EventIdValidationError::Empty));
-                } else if input
-                    .as_bytes()
-                    .iter()
-                    .any(|byte| matches!(byte, b'\n' | b'\r' | b'\0'))
-                {
-                    prop_assert_eq!(result, Err(EventIdValidationError::ForbiddenCharacter));
-                } else {
-                    prop_assert!(result.is_ok());
-                    if let Ok(id) = result {
-                        prop_assert_eq!(id.as_str(), input.as_str());
-                    }
+            if input.is_empty() {
+                prop_assert_eq!(result, Err(EventIdValidationError::Empty));
+            } else if input
+                .as_bytes()
+                .iter()
+                .any(|byte| matches!(byte, b'\n' | b'\r' | b'\0'))
+            {
+                prop_assert_eq!(result, Err(EventIdValidationError::ForbiddenCharacter));
+            } else {
+                prop_assert!(result.is_ok());
+                if let Ok(id) = result {
+                    prop_assert_eq!(id.as_str(), input.as_str());
                 }
             }
         }

--- a/src/sse/event_id.rs
+++ b/src/sse/event_id.rs
@@ -120,6 +120,7 @@ impl TryFrom<String> for EventId {
 mod tests {
     //! Regression coverage for SSE event identifier validation.
 
+    use proptest::prelude::*;
     use rstest::rstest;
 
     use super::{EventId, EventIdValidationError};
@@ -211,6 +212,30 @@ mod tests {
         let id = EventId::try_from("evt-123".to_owned()).expect("should validate");
 
         assert_eq!(id.as_str(), "evt-123");
+    }
+
+    proptest! {
+        #[test]
+        fn arbitrary_byte_validation_matches_spec(input_bytes in prop::collection::vec(any::<u8>(), 0..128)) {
+            if let Ok(input) = String::from_utf8(input_bytes) {
+                let result = EventId::try_from(input.clone());
+
+                if input.is_empty() {
+                    prop_assert_eq!(result, Err(EventIdValidationError::Empty));
+                } else if input
+                    .as_bytes()
+                    .iter()
+                    .any(|byte| matches!(byte, b'\n' | b'\r' | b'\0'))
+                {
+                    prop_assert_eq!(result, Err(EventIdValidationError::ForbiddenCharacter));
+                } else {
+                    prop_assert!(result.is_ok());
+                    if let Ok(id) = result {
+                        prop_assert_eq!(id.as_str(), input.as_str());
+                    }
+                }
+            }
+        }
     }
 
     #[rstest]

--- a/src/sse/event_id.rs
+++ b/src/sse/event_id.rs
@@ -125,6 +125,27 @@ mod tests {
 
     use super::{EventId, EventIdValidationError};
 
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum EventIdInputKind {
+        Empty,
+        ContainsForbiddenByte,
+        Valid,
+    }
+
+    fn classify_event_id_input(input: &str) -> EventIdInputKind {
+        if input.is_empty() {
+            EventIdInputKind::Empty
+        } else if input
+            .as_bytes()
+            .iter()
+            .any(|byte| matches!(byte, b'\n' | b'\r' | b'\0'))
+        {
+            EventIdInputKind::ContainsForbiddenByte
+        } else {
+            EventIdInputKind::Valid
+        }
+    }
+
     #[test]
     fn new_accepts_simple_ascii_identifier() {
         let id = EventId::new("evt-001").expect("simple ASCII identifier should validate");
@@ -220,17 +241,15 @@ mod tests {
             let input = String::from_utf8_lossy(&input_bytes).into_owned();
             let result = EventId::try_from(input.clone());
 
-            if input.is_empty() {
-                prop_assert_eq!(result, Err(EventIdValidationError::Empty));
-            } else if input
-                .as_bytes()
-                .iter()
-                .any(|byte| matches!(byte, b'\n' | b'\r' | b'\0'))
-            {
-                prop_assert_eq!(result, Err(EventIdValidationError::ForbiddenCharacter));
-            } else {
-                prop_assert!(result.is_ok());
-                if let Ok(id) = result {
+            match classify_event_id_input(&input) {
+                EventIdInputKind::Empty => {
+                    prop_assert_eq!(result, Err(EventIdValidationError::Empty));
+                }
+                EventIdInputKind::ContainsForbiddenByte => {
+                    prop_assert_eq!(result, Err(EventIdValidationError::ForbiddenCharacter));
+                }
+                EventIdInputKind::Valid => {
+                    let id = result.expect("valid input should be accepted");
                     prop_assert_eq!(id.as_str(), input.as_str());
                 }
             }


### PR DESCRIPTION
## Summary

This branch adds `proptest` coverage for the shared SSE invariants identified during PR #11 review. It adds the dev-dependency, locks the generated dependency graph, and covers `EventId::try_from(String)` validation plus cache-control idempotence over generated inputs.

Closes #18.

## Review walkthrough

- Start with [Cargo.toml](https://github.com/leynos/actix-v2a/blob/issue-18-tests-for-eventid-validation-and-cache-control-idempotence/Cargo.toml) and [Cargo.lock](https://github.com/leynos/actix-v2a/blob/issue-18-tests-for-eventid-validation-and-cache-control-idempotence/Cargo.lock) to review the `proptest` dependency addition.
- Then review [src/sse/event_id.rs](https://github.com/leynos/actix-v2a/blob/issue-18-tests-for-eventid-validation-and-cache-control-idempotence/src/sse/event_id.rs) for the generated byte-input validation property.
- Finish with [src/sse/cache_control.rs](https://github.com/leynos/actix-v2a/blob/issue-18-tests-for-eventid-validation-and-cache-control-idempotence/src/sse/cache_control.rs) for the cache-control idempotence property over arbitrary header vectors.

## Validation

- `make check-fmt`: passed
- `make lint`: passed
- `make test`: passed; nextest ran 162 tests and doctests ran 26 tests
- `make nixie`: passed

## Summary by Sourcery

Add property-based tests for SSE event ID validation and cache-control behavior using proptest.

Enhancements:
- Introduce proptest as a dev-dependency and update the lockfile to support property-based testing.

Tests:
- Add proptest-based property test ensuring EventId::try_from(String) enforces empty and forbidden-character constraints across arbitrary byte inputs.
- Add proptest-based property test verifying apply_event_stream_cache_control is idempotent and preserves non-cache-control headers over arbitrary header vectors.