### PR TITLE
Update documentation after the SSE module lands (1.2.2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,15 +214,15 @@ project:
 ### Dependency Management
 
 - **Mandate caret requirements for all dependencies.** All crate versions
-  specified in `Cargo.toml` must use SemVer-compatible caret requirements
-  (e.g., `some-crate = "1.2.3"`). This is Cargo's default and allows for safe,
+  specified in `Cargo.toml` must use SemVer-compatible caret requirements (e.g.,
+   `some-crate = "1.2.3"`). This is Cargo's default and allows for safe,
   non-breaking updates to minor and patch versions while preventing breaking
   changes from new major versions. This approach is critical for ensuring build
   stability and reproducibility.
 - **Prohibit unstable version specifiers.** The use of wildcard (`*`) or
   open-ended inequality (`>=`) version requirements is strictly forbidden as
-  they introduce unacceptable risk and unpredictability. Tilde requirements
-  (`~`) should only be used where a dependency must be locked to patch-level
+  they introduce unacceptable risk and unpredictability. Tilde requirements (
+  `~`) should only be used where a dependency must be locked to patch-level
   updates for a specific, documented reason.
 
 ### Error Handling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,7 +220,7 @@ project:
   changes from new major versions. This approach is critical for ensuring build
   stability and reproducibility.
 - **Prohibit unstable version specifiers.** The use of wildcard (`*`) or
-  open-ended inequality (`>=`), version requirements is strictly forbidden as
+  open-ended inequality (`>=`) version requirements is strictly forbidden as
   they introduce unacceptable risk and unpredictability. Tilde requirements (
   `~`) should only be used where a dependency must be locked to patch-level
   updates for a specific, documented reason.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,7 +220,7 @@ project:
   changes from new major versions. This approach is critical for ensuring build
   stability and reproducibility.
 - **Prohibit unstable version specifiers.** The use of wildcard (`*`) or
-  open-ended inequality (`>=`) version requirements is strictly forbidden as
+  open-ended inequality (`>=`), version requirements is strictly forbidden as
   they introduce unacceptable risk and unpredictability. Tilde requirements (
   `~`) should only be used where a dependency must be locked to patch-level
   updates for a specific, documented reason.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ dependencies = [
  "sha2",
  "thiserror 2.0.18",
  "tracing",
- "tracing-test",
+ "tracing-subscriber",
  "url",
  "utoipa",
  "uuid",
@@ -2252,27 +2252,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "tracing-test"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
-dependencies = [
- "tracing-core",
- "tracing-subscriber",
- "tracing-test-macro",
-]
-
-[[package]]
-name = "tracing-test-macro"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
-dependencies = [
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ proptest = "1.11"
 rstest = "0.26.1"
 rstest-bdd = "0.5.0"
 rstest-bdd-macros = { version = "0.5.0", features = ["strict-compile-time-validation"] }
-tracing-test = "0.2.6"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/docs/adr-001-shared-sse-wire-contract-for-wildside-and-corbusier.md
+++ b/docs/adr-001-shared-sse-wire-contract-for-wildside-and-corbusier.md
@@ -13,9 +13,9 @@ Proposed.
 `actix-v2a` is being positioned as the shared home for reusable version 2a
 Actix components. During planning for the Wildside import, reusable source was
 confirmed for pagination, idempotency, the common API error envelope, and
-OpenAPI wrappers in `../wildside/backend` (canonical upstream:
-`https://github.com/leynos/wildside`). The same planning pass did not find a
-reusable Server-Sent Events (SSE) helper module in that checkout.
+OpenAPI wrappers in the canonical upstream Wildside repository at
+`https://github.com/leynos/wildside`. The same planning pass did not find a
+reusable Server-Sent Events (SSE) helper module in that source.
 
 At the same time, Corbusier already has explicit SSE expectations in its
 canonical upstream repository, `https://github.com/leynos/corbusier`. Its API

--- a/docs/adr-001-shared-sse-wire-contract-for-wildside-and-corbusier.md
+++ b/docs/adr-001-shared-sse-wire-contract-for-wildside-and-corbusier.md
@@ -14,12 +14,12 @@ Proposed.
 Actix components. During planning for the Wildside import, reusable source was
 confirmed for pagination, idempotency, the common API error envelope, and
 OpenAPI wrappers in the canonical upstream Wildside repository at
-`https://github.com/leynos/wildside`. The same planning pass did not find a
-reusable Server-Sent Events (SSE) helper module in that source.
+`https://github.com/example-org/wildside`. The same planning pass did not find
+a reusable Server-Sent Events (SSE) helper module in that source.
 
 At the same time, Corbusier already has explicit SSE expectations in its
-canonical upstream repository, `https://github.com/leynos/corbusier`. Its API
-design documents require stable event identifiers, reconnection through the
+canonical upstream repository, `https://github.com/example-org/corbusier`. Its
+API design documents require stable event identifiers, reconnection through the
 `Last-Event-ID` header, replay-aware semantics, and event-stream endpoints that
 work with browser `EventSource` clients.
 

--- a/docs/complexity-antipatterns-and-refactoring-strategies.md
+++ b/docs/complexity-antipatterns-and-refactoring-strategies.md
@@ -36,10 +36,11 @@ challenges.
 Cyclomatic Complexity, developed by Thomas J. McCabe, Sr. in 1976, is a
 quantitative measure of the number of linearly independent paths through a
 program's source code.[^3] It essentially quantifies the structural complexity
-of a program by counting decision points that can affect the execution flow.[
-^4] This metric is computed using the control-flow graph of the program, where
-nodes represent indivisible groups of commands, and directed edges connect
-nodes if one command can immediately follow another.[^3]
+of a program by counting decision points that can affect the execution flow.
+Reference [^4] covers that framing. This metric is computed using the
+control-flow graph of the program, where nodes represent indivisible groups of
+commands, and directed edges connect nodes if one command can immediately
+follow another.[^3]
 
 Cyclomatic Complexity is often expressed with the formula M=E−N+2P, where E is
 the number of edges, N is the number of nodes, and P is the number of connected
@@ -219,8 +220,8 @@ The impact of this antipattern is significant:
   manipulated across these logical chunks.[^2]
 
 - **Higher Defect Rates:** The heavy tax on working memory and the risk of
-  feature entanglement contribute to a higher likelihood of introducing bugs.[
-  ^9]
+  feature entanglement contribute to a higher likelihood of introducing bugs.
+  CodeScene's Bumpy Road discussion covers this risk.[^9]
 
 - **Impeded Evolvability:** Adding new features or adapting to changing
   requirements becomes a daunting task, as the existing complex structure
@@ -429,8 +430,8 @@ state (queries).[^14] Commands are task-based and should represent specific
 business intentions (e.g.,
 
 `BookHotelRoomCommand` rather than `SetReservationStatusCommand`).[^14] Queries
-never alter data and return Data Transfer Objects optimized for display needs.[
-^14]
+never alter data and return Data Transfer Objects optimized for display needs.
+Reference [^14] covers that CQRS distinction.
 
 While Command Query Responsibility Segregation operates at a higher
 architectural level than a single Bumpy Road method, the principles are
@@ -648,25 +649,26 @@ programming.[^25] This paradigm shift can significantly reduce cognitive
 complexity by abstracting away low-level control flow and state management.
 
 When developers write declarative code, they operate at a higher level of
-abstraction, allowing them to reason about the program's intent more directly.[
-^25] This often leads to more concise, readable, and maintainable code because
-the "noise" of explicit iteration, temporary variables, and manual state
-updates is minimized.[^25] Many declarative approaches also inherently favour
-immutability, reduce side effects, and encourage deterministic behaviour—common
-culprits for bugs and increased cognitive load in imperative code.[^26]
+abstraction, allowing them to reason about the program's intent more directly.
+Reference [^25] covers this benefit. This often leads to more concise,
+readable, and maintainable code because the "noise" of explicit iteration,
+temporary variables, and manual state updates is minimized.[^25] Many
+declarative approaches also inherently favour immutability, reduce side
+effects, and encourage deterministic behaviour—common culprits for bugs and
+increased cognitive load in imperative code.[^26]
 
 Examples include using Structured Query Language for database queries—
 specifying the desired dataset rather than the retrieval algorithm[^34]—or
 employing functional programming constructs like `map`, `filter`, and `reduce`
 on collections instead of writing explicit loops. Refactoring imperative code
 to a declarative style can start small, perhaps by converting a loop that
-filters and transforms a list into a chain of `filter` and `map` operations.[
-^26] The broader adoption of declarative approaches in areas like UI
-development (e.g., React) and data querying signifies an industry trend towards
-managing complexity by raising abstraction levels. However, the effectiveness
-of declarative programming relies on well-designed underlying abstractions; a
-poorly designed declarative layer might not successfully hide complexity or
-could introduce its own.[^27]
+filters and transforms a list into a chain of `filter` and `map` operations.
+Reference [^26] covers that refactoring style. The broader adoption of
+declarative approaches in areas like UI development (e.g., React) and data
+querying signifies an industry trend towards managing complexity by raising
+abstraction levels. However, the effectiveness of declarative programming
+relies on well-designed underlying abstractions; a poorly designed declarative
+layer might not successfully hide complexity or could introduce its own.[^27]
 
 #### 3. Employing dispatcher and command patterns
 
@@ -682,8 +684,8 @@ the object that knows how to perform it. Instead of a large conditional
 checking a type and then executing logic, different command objects can be
 instantiated based on the type, and then their `execute()` method is called.
 This promotes the Single Responsibility Principle, as each command class
-handles a single action, making the system easier to test, extend, and evolve.[
-^29]
+handles a single action, making the system easier to test, extend, and evolve.
+Reference [^29] covers the Command pattern.
 
 The **Dispatcher pattern** often works in conjunction with the Command pattern.
 A dispatcher is a central component that receives requests (which could be

--- a/docs/complexity-antipatterns-and-refactoring-strategies.md
+++ b/docs/complexity-antipatterns-and-refactoring-strategies.md
@@ -36,18 +36,18 @@ challenges.
 Cyclomatic Complexity, developed by Thomas J. McCabe, Sr. in 1976, is a
 quantitative measure of the number of linearly independent paths through a
 program's source code.[^3] It essentially quantifies the structural complexity
-of a program by counting decision points that can affect the execution
-flow.[^4] This metric is computed using the control-flow graph of the program,
-where nodes represent indivisible groups of commands, and directed edges
-connect nodes if one command can immediately follow another.[^3]
+of a program by counting decision points that can affect the execution flow.[
+^4] This metric is computed using the control-flow graph of the program, where
+nodes represent indivisible groups of commands, and directed edges connect
+nodes if one command can immediately follow another.[^3]
 
 Cyclomatic Complexity is often expressed with the formula M=E−N+2P, where E is
 the number of edges, N is the number of nodes, and P is the number of connected
 components (typically 1 for a single program or method).[^3] A simpler
 formulation applies to a single subroutine:
 
-M = number of decision points + 1, where decision points include constructs
-like `if` statements and conditional loops.[^3]
+M = number of decision points + 1, where decision points include constructs like
+ `if` statements and conditional loops.[^3]
 
 Thresholds and Implications:
 
@@ -219,8 +219,8 @@ The impact of this antipattern is significant:
   manipulated across these logical chunks.[^2]
 
 - **Higher Defect Rates:** The heavy tax on working memory and the risk of
-  feature entanglement contribute to a higher likelihood of introducing
-  bugs.[^9]
+  feature entanglement contribute to a higher likelihood of introducing bugs.[
+  ^9]
 
 - **Impeded Evolvability:** Adding new features or adapting to changing
   requirements becomes a daunting task, as the existing complex structure
@@ -429,8 +429,8 @@ state (queries).[^14] Commands are task-based and should represent specific
 business intentions (e.g.,
 
 `BookHotelRoomCommand` rather than `SetReservationStatusCommand`).[^14] Queries
-never alter data and return Data Transfer Objects optimized for display
-needs.[^14]
+never alter data and return Data Transfer Objects optimized for display needs.[
+^14]
 
 While Command Query Responsibility Segregation operates at a higher
 architectural level than a single Bumpy Road method, the principles are
@@ -648,26 +648,25 @@ programming.[^25] This paradigm shift can significantly reduce cognitive
 complexity by abstracting away low-level control flow and state management.
 
 When developers write declarative code, they operate at a higher level of
-abstraction, allowing them to reason about the program's intent more
-directly.[^25] This often leads to more concise, readable, and maintainable
-code because the "noise" of explicit iteration, temporary variables, and manual
-state updates is minimized.[^25] Many declarative approaches also inherently
-favour immutability, reduce side effects, and encourage deterministic
-behaviour—common culprits for bugs and increased cognitive load in imperative
-code.[^26]
+abstraction, allowing them to reason about the program's intent more directly.[
+^25] This often leads to more concise, readable, and maintainable code because
+the "noise" of explicit iteration, temporary variables, and manual state
+updates is minimized.[^25] Many declarative approaches also inherently favour
+immutability, reduce side effects, and encourage deterministic behaviour—common
+culprits for bugs and increased cognitive load in imperative code.[^26]
 
 Examples include using Structured Query Language for database queries—
 specifying the desired dataset rather than the retrieval algorithm[^34]—or
 employing functional programming constructs like `map`, `filter`, and `reduce`
 on collections instead of writing explicit loops. Refactoring imperative code
 to a declarative style can start small, perhaps by converting a loop that
-filters and transforms a list into a chain of `filter` and `map`
-operations.[^26] The broader adoption of declarative approaches in areas like
-UI development (e.g., React) and data querying signifies an industry trend
-towards managing complexity by raising abstraction levels. However, the
-effectiveness of declarative programming relies on well-designed underlying
-abstractions; a poorly designed declarative layer might not successfully hide
-complexity or could introduce its own.[^27]
+filters and transforms a list into a chain of `filter` and `map` operations.[
+^26] The broader adoption of declarative approaches in areas like UI
+development (e.g., React) and data querying signifies an industry trend towards
+managing complexity by raising abstraction levels. However, the effectiveness
+of declarative programming relies on well-designed underlying abstractions; a
+poorly designed declarative layer might not successfully hide complexity or
+could introduce its own.[^27]
 
 #### 3. Employing dispatcher and command patterns
 
@@ -683,8 +682,8 @@ the object that knows how to perform it. Instead of a large conditional
 checking a type and then executing logic, different command objects can be
 instantiated based on the type, and then their `execute()` method is called.
 This promotes the Single Responsibility Principle, as each command class
-handles a single action, making the system easier to test, extend, and
-evolve.[^29]
+handles a single action, making the system easier to test, extend, and evolve.[
+^29]
 
 The **Dispatcher pattern** often works in conjunction with the Command pattern.
 A dispatcher is a central component that receives requests (which could be

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -53,3 +53,7 @@
     module](execplans/1-2-1-unit-and-integration-tests-for-the-shared-sse-module.md):
     execution plan for proving the shared SSE wire contract with unit and
     downstream-facing integration coverage (task 1.2.1).
+  - [Update documentation after the SSE module
+    lands](execplans/1-2-2-update-documentation-after-sse-module-lands.md):
+    draft execution plan for closing the shared SSE documentation loop and
+    scrubbing implementation-time path references (task 1.2.2).

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -35,8 +35,8 @@
     and retrospective for porting Wildside commit `9d6b7655` pagination
     documentation hardening and invariant tests into `actix-v2a`.
   - [Import components from Wildside](execplans/import-components-from-wildside.md):
-    draft plan for extracting shared HTTP and API primitives from
-    `../wildside/backend` into this crate.
+    completed plan and retrospective for extracting shared HTTP and API
+    primitives from Wildside into this crate.
   - [Implement SSE identifier and replay cursor
     helpers](execplans/1-1-1-implement-sse-identifier-and-replay-cursor-helpers.md):
     execution plan for validated SSE event identifiers and `Last-Event-ID`
@@ -55,5 +55,5 @@
     downstream-facing integration coverage (task 1.2.1).
   - [Update documentation after the SSE module
     lands](execplans/1-2-2-update-documentation-after-sse-module-lands.md):
-    draft execution plan for closing the shared SSE documentation loop and
+    execution plan for closing the shared SSE documentation loop and
     scrubbing implementation-time path references (task 1.2.2).

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -228,7 +228,7 @@ Netsuke before running repository gates:
 
 ```bash
 sudo dnf install ninja-build
-cargo install --git https://github.com/leynos/netsuke.git \
+cargo install --git https://github.com/example-org/netsuke.git \
   --rev 2fe314a58d7311758640b3daa086c401d79838cf \
   netsuke --locked
 ```

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -346,11 +346,11 @@ Approved testing libraries are:
   spaces, such as validation, parsing, normalization, and idempotence.
 - `insta` for snapshot coverage of stable rendered output, such as error
   display text and OpenAPI schema JSON.
-- `tracing-subscriber` (with the `env-filter` feature) for composable tracing
-  subscriber layers used in integration and behavioural tests.
-- `tests/support/sse_trace_buffer.rs` provides a `BufferLayer` and `LogBuffer`
-  abstraction that captures per-scenario tracing events into a `World`-owned
-  buffer, avoiding reliance on `tracing-test`'s internal API.
+- `tracing-subscriber` (with the `env-filter` feature) provides composable
+  tracing subscriber layers used in integration and behavioural tests.
+- `tests/support/sse_trace_buffer.rs` provides `BufferLayer` and `LogBuffer`,
+  which capture per-scenario tracing events into a `World`-owned buffer,
+  removing the dependency on `tracing-test`'s internal API.
 
 ### Documentation
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -346,7 +346,11 @@ Approved testing libraries are:
   spaces, such as validation, parsing, normalization, and idempotence.
 - `insta` for snapshot coverage of stable rendered output, such as error
   display text and OpenAPI schema JSON.
-- `tracing-test` for assertions over emitted tracing spans and events.
+- `tracing-subscriber` (with the `env-filter` feature) for composable tracing
+  subscriber layers used in integration and behavioural tests.
+- `tests/support/sse_trace_buffer.rs` provides a `BufferLayer` and `LogBuffer`
+  abstraction that captures per-scenario tracing events into a `World`-owned
+  buffer, avoiding reliance on `tracing-test`'s internal API.
 
 ### Documentation
 

--- a/docs/execplans/1-1-1-implement-sse-identifier-and-replay-cursor-helpers.md
+++ b/docs/execplans/1-1-1-implement-sse-identifier-and-replay-cursor-helpers.md
@@ -1,21 +1,19 @@
 # Implement validated SSE event identifier and replay cursor helpers
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+ `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETE
 
 ## Purpose / big picture
 
-`actix-v2a` is the shared Actix component library for the v2a web stack.
-[Architecture Decision Record (ADR) 001][adr-001] defines a wire-only
-Server-Sent Events (SSE) contract that both Wildside and Corbusier can adopt
-without surrendering control of their own event stores or stream routing. This
-plan delivers the first concrete piece of that contract: validated event
-identifiers for SSE `id:` lines and a replay cursor type that parses the
-`Last-Event-ID` request header.
+`actix-v2a` is the shared Actix component library for the v2a web stack. [ADR
+001][adr-001] defines a wire-only Server-Sent Events (SSE) contract that both
+Wildside and Corbusier can adopt without surrendering control of their own
+event stores or stream routing. This plan delivers the first concrete piece of
+that contract: validated event identifiers for SSE `id:` lines and a replay
+cursor type that parses the `Last-Event-ID` request header.
 
 After this change, downstream services gain two capabilities:
 
@@ -186,8 +184,8 @@ escalation rather than improvisation.
 
 Task 1.1.1 delivered validated SSE event identifiers and replay cursor helpers
 with all quality gates passing. Key learnings: (1) separating header-specific
-errors (`ReplayCursorError`) from identifier content errors
-(`EventIdValidationError`) improved API clarity and followed existing patterns;
+errors (`ReplayCursorError`) from identifier content errors (
+`EventIdValidationError`) improved API clarity and followed existing patterns;
 (2) optimizing `TryFrom<String>` to avoid allocation reinforced zero-copy
 principles; (3) UTF-8 decoding via `std::str::from_utf8` instead of
 `HeaderValue::to_str` fixed rejection of valid Unicode identifiers. Follow-up:

--- a/docs/execplans/1-1-2-sse-frame-and-cache-header-helpers.md
+++ b/docs/execplans/1-1-2-sse-frame-and-cache-header-helpers.md
@@ -1,20 +1,19 @@
 # Implement SSE frame and cache-header helpers
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+ `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETED
 
 ## Purpose / big picture
 
 `actix-v2a` already exposes the first slice of the shared Server-Sent Events
-(SSE) contract from [Architecture Decision Record (ADR) 001][adr-001]:
-validated `EventId` values and `Last-Event-ID` replay cursor parsing. Roadmap
-task 1.1.2 is the next delivery unit in that contract. It adds the wire helpers
-that downstream applications need to emit browser-compatible SSE frames and to
-mark live event-stream responses as non-reusable by intermediaries.
+(SSE) contract from [Architecture Decision Record (ADR) 001][adr-001]: validated
+ `EventId` values and `Last-Event-ID` replay cursor parsing. Roadmap task 1.1.2
+is the next delivery unit in that contract. It adds the wire helpers that
+downstream applications need to emit browser-compatible SSE frames and to mark
+live event-stream responses as non-reusable by intermediaries.
 
 After this change, downstream services should be able to do three things
 without reimplementing wire details:
@@ -66,8 +65,8 @@ Success is observable when:
 - Public Rust interfaces require Rustdoc comments with examples, and every
   module file requires a module-level `//!` comment.
 - New code must satisfy the repository lint posture, including deny-level
-  Clippy rules such as `expect_used`, `unwrap_used`, `cognitive_complexity`,
-  and `missing_const_for_fn`.
+  Clippy rules such as `expect_used`, `unwrap_used`, `cognitive_complexity`, and
+   `missing_const_for_fn`.
 - File size must remain below the repository guidance of 400 lines per file.
 - Tests must use `rstest` fixtures and parameterized cases where they improve
   clarity. `rstest-bdd` should be used only where scenario structure adds real

--- a/docs/execplans/1-1-3-shared-heartbeat-and-stream-reset-helpers.md
+++ b/docs/execplans/1-1-3-shared-heartbeat-and-stream-reset-helpers.md
@@ -1,9 +1,8 @@
 # Implement shared heartbeat and stream_reset helpers
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+ `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETED
 
@@ -70,8 +69,8 @@ Success is observable when:
 - Public Rust interfaces require Rustdoc comments with examples, and every
   module file requires a module-level `//!` comment.
 - New code must satisfy the repository lint posture, including deny-level
-  Clippy rules such as `expect_used`, `unwrap_used`, `missing_const_for_fn`,
-  and `cognitive_complexity`.
+  Clippy rules such as `expect_used`, `unwrap_used`, `missing_const_for_fn`, and
+   `cognitive_complexity`.
 - File size must remain below the repository guidance of 400 lines per file.
 - Tests must use `rstest` fixtures and parameterized cases where they improve
   clarity. `rstest-bdd` should be used only where scenario structure adds real

--- a/docs/execplans/1-2-1-unit-and-integration-tests-for-the-shared-sse-module.md
+++ b/docs/execplans/1-2-1-unit-and-integration-tests-for-the-shared-sse-module.md
@@ -1,9 +1,8 @@
 # Add unit and integration tests for the shared SSE module
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+ `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETE
 
@@ -26,10 +25,10 @@ two forms of evidence:
 
 Success is observable when all roadmap-mandated behaviours are proven:
 identifier validation, `Last-Event-ID` parsing, frame formatting, cache
-headers, heartbeat output, and `stream_reset` output. It is also observable
-when `make check-fmt`, `make lint`, and `make test` pass with the new coverage,
-and when `docs/roadmap.md` marks task 1.2.1 done only after the implementation
-is complete.
+headers, heartbeat output, and `stream_reset` output. It is also observable when
+ `make check-fmt`, `make lint`, and `make test` pass with the new coverage, and
+when `docs/roadmap.md` marks task 1.2.1 done only after the implementation is
+complete.
 
 This plan was approved before implementation began.
 
@@ -81,12 +80,12 @@ This plan was approved before implementation began.
 ### Property-based testing
 
 Property-based testing (for example, `proptest`) for `EventId` byte-validation
-exhaustiveness and `apply_event_stream_cache_control` idempotence over
-arbitrary `Vec<SseHeader>` state is **out of scope for this plan**. The
-discrete `rstest` parameterized cases cover the specified forbidden-byte set
-(`\n`, `\r`, `\0`) and the empty-string guard; idempotence is verified over
-hand-crafted initial states (empty, single pre-existing entry, multiple
-entries). Exhaustive property coverage is tracked in
+exhaustiveness and `apply_event_stream_cache_control` idempotence over arbitrary
+ `Vec<SseHeader>` state is **out of scope for this plan**. The discrete
+`rstest` parameterized cases cover the specified forbidden-byte set (`\n`, `\r`,
+ `\0`) and the empty-string guard; idempotence is verified over hand-crafted
+initial states (empty, single pre-existing entry, multiple entries). Exhaustive
+property coverage is tracked in
 [issue `#18`](https://github.com/leynos/actix-v2a/issues/18) and deferred to a
 subsequent PR.
 

--- a/docs/execplans/1-2-1-unit-and-integration-tests-for-the-shared-sse-module.md
+++ b/docs/execplans/1-2-1-unit-and-integration-tests-for-the-shared-sse-module.md
@@ -86,8 +86,8 @@ exhaustiveness and `apply_event_stream_cache_control` idempotence over arbitrary
  `\0`) and the empty-string guard; idempotence is verified over hand-crafted
 initial states (empty, single pre-existing entry, multiple entries). Exhaustive
 property coverage is tracked in
-[issue `#18`](https://github.com/leynos/actix-v2a/issues/18) and deferred to a
-subsequent PR.
+[issue `#18`](https://github.com/example-org/actix-v2a/issues/18) and deferred
+to a subsequent PR.
 
 ## Tolerances (exception triggers)
 

--- a/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md
+++ b/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md
@@ -178,8 +178,8 @@ Use this shared path sweep helper anywhere this plan says to run the path sweep:
 ```bash
 path_sweep() {
   LOCAL_WILDSIDE_PATH='../wildside'/'backend'
-  LOCAL_HOME_PREFIX='/home'/'leynos'
-  LOCAL_PROJECTS_PREFIX='/data/leynos'/'Projects'
+  LOCAL_HOME_PREFIX='/home'/'user'
+  LOCAL_PROJECTS_PREFIX='/home'/'user'/'Projects'
   LOCAL_WORKTREE_SEGMENT='work''trees'
   PATH_PATTERN="${LOCAL_PROJECTS_PREFIX}|${LOCAL_WILDSIDE_PATH}"
   PATH_PATTERN="${PATH_PATTERN}|${LOCAL_HOME_PREFIX}|${LOCAL_WORKTREE_SEGMENT}"
@@ -451,7 +451,7 @@ tolerances above. Silence is not approval.
   diff after a recoverable rate-limit wait; it completed with zero findings.
 - [x] 2026-05-20: Committed the closure edits as `f134e2d`, pushed to the
   remote branch, and updated draft pull request #30 at
-  <https://github.com/leynos/actix-v2a/pull/30>.
+  <https://github.com/example-org/actix-v2a/pull/30>.
 
 ## Surprises & Discoveries
 

--- a/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md
+++ b/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md
@@ -448,7 +448,19 @@ tolerances above. Silence is not approval.
 - [x] 2026-05-20: Passed the first documentation gate set:
   `make fmt`, `make markdownlint`, and `make nixie`, with logs under `/tmp`
   using the branch-specific filenames from this plan.
-- [ ] 2026-05-20: Commit the first documentation-closure milestone.
+- [x] 2026-05-20: Committed the first documentation-closure milestone as
+  `90c7dc1` (`Normalize SSE documentation provenance`).
+- [x] 2026-05-20: Passed the full repository gate set:
+  `make check-fmt`, `make lint`, and `make test`, with branch-specific logs
+  under `/tmp`. The test gate ran 162 nextest tests and 26 doctests.
+- [x] 2026-05-20: Marked `docs/execplans/import-components-from-wildside.md`
+  complete and marked roadmap task 1.2.2 done after the full gate set passed.
+- [x] 2026-05-20: Passed the final documentation gate set after the roadmap and
+  import-plan closure edits: `make fmt`, `make markdownlint`, and `make nixie`.
+- [x] 2026-05-20: Re-ran `coderabbit review --agent` for the final closure
+  diff after a recoverable rate-limit wait; it completed with zero findings.
+- [ ] 2026-05-20: Commit the closure edits, push, and update the draft pull
+  request.
 
 ## Surprises & Discoveries
 
@@ -498,6 +510,12 @@ tolerances above. Silence is not approval.
 Not started. This section must be updated during implementation and completed
 only after the documentation closure, validation gates, CodeRabbit review,
 roadmap update, push, and draft pull request are complete.
+
+Interim outcome: the documentation closure work has scrubbed the configured
+environment-specific path patterns from `docs` and `README.md`, recorded the
+landed SSE helper sequence in the Wildside import plan, and marked roadmap task
+1.2.2 done after the documentation and full Rust gate sets passed. Final push
+and pull request updates remain before this plan can be marked complete.
 
 ## External references
 

--- a/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md
+++ b/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md
@@ -4,7 +4,7 @@ This ExecPlan (execution plan) is a living document. The sections `Constraints`,
  `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
 and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: DRAFT
+Status: IN PROGRESS
 
 ## Purpose / big picture
 
@@ -27,8 +27,8 @@ Success is observable when:
 
 1. `docs/execplans/import-components-from-wildside.md` records that the shared
    SSE milestone is complete and that its path-cleanup milestone was executed.
-2. Environment-specific references such as `../wildside/backend` no longer
-   appear in normative sections of public or maintainer documentation.
+2. Environment-specific references such as sibling Wildside checkout paths no
+   longer appear in normative sections of public or maintainer documentation.
 3. `docs/contents.md` indexes this plan and uses canonical upstream wording for
    Wildside provenance.
 4. `docs/roadmap.md` marks task 1.2.2 done only after the documentation
@@ -53,9 +53,9 @@ This plan must be approved before implementation begins.
 - Keep provenance, but remove machine-specific and checkout-specific paths from
   normative prose. Prefer canonical upstream repository URLs, repository
   relative paths inside this crate, or short prose descriptions.
-- Local path references such as `../wildside/backend` are allowed only in a
-  clearly labelled historical or planning-time provenance section, and only if
-  removing them would make the old plan less intelligible.
+- Local sibling-checkout path references are allowed only in a clearly labelled
+  historical or planning-time provenance section, and only if removing them
+  would make the old plan less intelligible.
 - Keep `docs/users-guide.md` changes conditional. Update it only if the closure
   audit finds public API wording, examples, or behaviour summaries that no
   longer match the landed SSE helpers.
@@ -180,8 +180,12 @@ Start by checking the branch and the current documentation state:
 ```bash
 git branch --show-current
 git status --short --branch
-PATH_PATTERN='/data/leynos/Projects|\\.\\./wildside/backend'
-PATH_PATTERN="${PATH_PATTERN}|/home/leynos|worktrees"
+LOCAL_WILDSIDE_PATH='../wildside'/'backend'
+LOCAL_HOME_PREFIX='/home'/'leynos'
+LOCAL_PROJECTS_PREFIX='/data/leynos'/'Projects'
+LOCAL_WORKTREE_SEGMENT='work''trees'
+PATH_PATTERN="${LOCAL_PROJECTS_PREFIX}|${LOCAL_WILDSIDE_PATH}"
+PATH_PATTERN="${PATH_PATTERN}|${LOCAL_HOME_PREFIX}|${LOCAL_WORKTREE_SEGMENT}"
 SSE_PATTERN='1\\.2\\.2|SSE|Server-Sent|Last-Event-ID|stream_reset|heartbeat'
 rg -n "${PATH_PATTERN}" docs README.md
 rg -n "${SSE_PATTERN}" \
@@ -217,7 +221,7 @@ Required edits:
 2. Update `Purpose / big picture`, `Repository orientation`, `Constraints`,
    `Tolerances`, `Risks`, milestone text, and outcomes so normative references
    use canonical upstream Wildside wording or repository-relative paths instead
-   of `../wildside/backend`.
+   of local Wildside checkout paths.
 3. Add or update a clearly labelled planning-time provenance note if any local
    sibling-checkout paths must remain for historical intelligibility.
 4. Add a dated `Progress` entry for roadmap task 1.2.2 beginning and later for
@@ -233,8 +237,12 @@ Required edits:
 Run the path sweep after editing this file:
 
 ```bash
-PATH_PATTERN='/data/leynos/Projects|\\.\\./wildside/backend'
-PATH_PATTERN="${PATH_PATTERN}|/home/leynos|worktrees"
+LOCAL_WILDSIDE_PATH='../wildside'/'backend'
+LOCAL_HOME_PREFIX='/home'/'leynos'
+LOCAL_PROJECTS_PREFIX='/data/leynos'/'Projects'
+LOCAL_WORKTREE_SEGMENT='work''trees'
+PATH_PATTERN="${LOCAL_PROJECTS_PREFIX}|${LOCAL_WILDSIDE_PATH}"
+PATH_PATTERN="${PATH_PATTERN}|${LOCAL_HOME_PREFIX}|${LOCAL_WORKTREE_SEGMENT}"
 rg -n "${PATH_PATTERN}" docs/execplans/import-components-from-wildside.md
 ```
 
@@ -274,8 +282,12 @@ SSE module that should import Actix Web types.
 Run the broad path sweep:
 
 ```bash
-PATH_PATTERN='/data/leynos/Projects|\\.\\./wildside/backend'
-PATH_PATTERN="${PATH_PATTERN}|/home/leynos|worktrees"
+LOCAL_WILDSIDE_PATH='../wildside'/'backend'
+LOCAL_HOME_PREFIX='/home'/'leynos'
+LOCAL_PROJECTS_PREFIX='/data/leynos'/'Projects'
+LOCAL_WORKTREE_SEGMENT='work''trees'
+PATH_PATTERN="${LOCAL_PROJECTS_PREFIX}|${LOCAL_WILDSIDE_PATH}"
+PATH_PATTERN="${PATH_PATTERN}|${LOCAL_HOME_PREFIX}|${LOCAL_WORKTREE_SEGMENT}"
 rg -n "${PATH_PATTERN}" docs README.md
 ```
 
@@ -336,8 +348,12 @@ Run the minimal final confirmation:
 
 ```bash
 git diff --check
-PATH_PATTERN='/data/leynos/Projects|\\.\\./wildside/backend'
-PATH_PATTERN="${PATH_PATTERN}|/home/leynos|worktrees"
+LOCAL_WILDSIDE_PATH='../wildside'/'backend'
+LOCAL_HOME_PREFIX='/home'/'leynos'
+LOCAL_PROJECTS_PREFIX='/data/leynos'/'Projects'
+LOCAL_WORKTREE_SEGMENT='work''trees'
+PATH_PATTERN="${LOCAL_PROJECTS_PREFIX}|${LOCAL_WILDSIDE_PATH}"
+PATH_PATTERN="${PATH_PATTERN}|${LOCAL_HOME_PREFIX}|${LOCAL_WORKTREE_SEGMENT}"
 rg -n "${PATH_PATTERN}" docs README.md
 ```
 
@@ -413,8 +429,26 @@ tolerances above. Silence is not approval.
 - [x] 2026-05-19: Used Firecrawl to review current SSE protocol and prior-art
   references: WHATWG HTML Server-Sent Events and the `actix-sse` docs.rs page.
 - [x] 2026-05-19: Drafted this execution plan.
-- [ ] Await explicit user approval before implementing the documentation
-  closure work.
+- [x] 2026-05-20: Received explicit user approval to proceed with
+  implementation from this plan.
+- [x] 2026-05-20: Reconfirmed the branch name and clean upstream-tracking work
+  tree before editing.
+- [x] 2026-05-20: Re-ran the closure audit. The only required guide-facing
+  changes are in `docs/execplans/import-components-from-wildside.md`, this
+  plan, and the roadmap; `docs/users-guide.md` and `docs/developers-guide.md`
+  already describe the landed SSE helper boundary accurately.
+- [x] 2026-05-20: Normalized the old Wildside import plan's provenance
+  wording, recorded SSE closure progress, updated ADR 001 and
+  `docs/contents.md`, and scrubbed the stale absolute worktree path from
+  `docs/execplans/portwildsidepagination.md`.
+- [x] 2026-05-20: Ran the path sweep over `docs` and `README.md`; it returned
+  no hits for the configured environment-specific path patterns.
+- [x] 2026-05-20: Ran `coderabbit review --agent` for the first
+  documentation-closure milestone; it completed with zero findings.
+- [x] 2026-05-20: Passed the first documentation gate set:
+  `make fmt`, `make markdownlint`, and `make nixie`, with logs under `/tmp`
+  using the branch-specific filenames from this plan.
+- [ ] 2026-05-20: Commit the first documentation-closure milestone.
 
 ## Surprises & Discoveries
 
@@ -422,8 +456,8 @@ tolerances above. Silence is not approval.
   documentation in `docs/users-guide.md` and `docs/developers-guide.md`, so
   task 1.2.2 should avoid rewriting those guides unless the closure audit finds
   concrete drift.
-- 2026-05-19: `docs/execplans/import-components-from-wildside.md` still has
-  many `../wildside/backend` references in normative sections even though its
+- 2026-05-19: `docs/execplans/import-components-from-wildside.md` still had
+  many local Wildside checkout references in normative sections even though its
   own Milestone 6 says those paths should be removed before closure.
 - 2026-05-19: The import plan's outcomes already claim Milestone 6 shipped, but
   the file is still `Status: IN PROGRESS` and still contains unscoped local
@@ -432,6 +466,10 @@ tolerances above. Silence is not approval.
 - 2026-05-19: No separate SSE design document exists under `docs/`; ADR 001
   plus the user's and developer's guides carry the current design and usage
   documentation.
+- 2026-05-20: The broad path sweep found an unrelated absolute worktree path in
+  `docs/execplans/portwildsidepagination.md`. It was part of an orientation
+  transcript, not SSE content, but it still violated the completed
+  documentation-set cleanup requirement.
 
 ## Decision Log
 
@@ -449,6 +487,11 @@ tolerances above. Silence is not approval.
 - 2026-05-19: Use WHATWG HTML as the protocol reference and `actix-sse` as
   ecosystem prior art only. Rationale: ADR 001 remains the source of truth for
   this crate's deliberately narrower wire-helper contract.
+- 2026-05-20: Scrub environment-specific path references from the final
+  documentation set, not only from the SSE and Wildside import documents.
+  Rationale: the roadmap item names the execplan closing milestone, and that
+  milestone requires the finished documentation set to avoid implementation
+  machine paths.
 
 ## Outcomes & Retrospective
 

--- a/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md
+++ b/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md
@@ -1,0 +1,464 @@
+# Update documentation after the SSE module lands
+
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+ `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+Roadmap task 1.2.2 closes the documentation loop for the shared Server-Sent
+Events (SSE) helper work from Architecture Decision Record (ADR) 001. The code
+and contract-proof tasks have already landed in the earlier roadmap sequence:
+tasks 1.1.1 through 1.1.3 built the shared wire-helper surface, and task 1.2.1
+proved the contract with unit and behavioural coverage.
+
+This task does not implement new SSE behaviour. It records the completed SSE
+milestone in the older Wildside import execution plan, removes implementation
+time environment-specific path references from finished documentation, updates
+the documentation index and roadmap, and validates the final documentation set.
+After this change, a maintainer should be able to read the documentation
+without seeing sibling-checkout paths presented as normative references, while
+still preserving enough provenance to understand where the imported Wildside
+work came from.
+
+Success is observable when:
+
+1. `docs/execplans/import-components-from-wildside.md` records that the shared
+   SSE milestone is complete and that its path-cleanup milestone was executed.
+2. Environment-specific references such as `../wildside/backend` no longer
+   appear in normative sections of public or maintainer documentation.
+3. `docs/contents.md` indexes this plan and uses canonical upstream wording for
+   Wildside provenance.
+4. `docs/roadmap.md` marks task 1.2.2 done only after the documentation
+   closure and validation evidence are in place.
+5. `make fmt`, `make markdownlint`, `make nixie`, `make check-fmt`,
+   `make lint`, and `make test` pass with logs captured through `tee`.
+
+This plan must be approved before implementation begins.
+
+## Constraints
+
+- Do not implement new SSE functionality in this task. The implementation
+  scope is documentation, living-plan maintenance, validation evidence, branch
+  publishing, and pull request preparation.
+- Preserve the wire-only boundary from ADR 001. Documentation must not imply
+  that `actix-v2a` owns event-store persistence, stream routing, authorization,
+  heartbeat scheduling, or application payload schemata.
+- Treat ADR 001 as the normative shared SSE wire contract unless the
+  implementation pass discovers an actual conflict. If the closure task changes
+  any contract claim, update ADR 001 in the same commit and record the decision
+  in this plan.
+- Keep provenance, but remove machine-specific and checkout-specific paths from
+  normative prose. Prefer canonical upstream repository URLs, repository
+  relative paths inside this crate, or short prose descriptions.
+- Local path references such as `../wildside/backend` are allowed only in a
+  clearly labelled historical or planning-time provenance section, and only if
+  removing them would make the old plan less intelligible.
+- Keep `docs/users-guide.md` changes conditional. Update it only if the closure
+  audit finds public API wording, examples, or behaviour summaries that no
+  longer match the landed SSE helpers.
+- Keep `docs/developers-guide.md` changes conditional. Update it only if the
+  closure audit finds maintainer-facing module, testing, or quality-gate
+  guidance that no longer matches the landed SSE work.
+- Use `leta` for code navigation if implementation discovers a need to inspect
+  Rust symbols. Use ordinary text search for Markdown phrase audits and path
+  reference sweeps.
+- Use the `rust-router` skill only to route unexpected Rust-facing findings.
+  The expected task is documentation-only, so no follow-on Rust language skill
+  is expected unless code changes become unavoidable.
+- Use the `hexagonal-architecture` skill as a boundary checklist, not as a
+  mandate to reorganize files. The documentation should keep domain and adapter
+  concerns separated where it describes the SSE helper surface.
+- Signpost the relevant documentation for implementers:
+  `docs/roadmap.md`, `docs/execplans/import-components-from-wildside.md`,
+  `docs/adr-001-shared-sse-wire-contract-for-wildside-and-corbusier.md`,
+  `docs/contents.md`, `docs/users-guide.md`, `docs/developers-guide.md`,
+  `docs/documentation-style-guide.md`,
+  `docs/rust-testing-with-rstest-fixtures.md`,
+  `docs/reliable-testing-in-rust-via-dependency-injection.md`,
+  `docs/rust-doctest-dry-guide.md`, and
+  `docs/complexity-antipatterns-and-refactoring-strategies.md`.
+- Run repository gates sequentially. Do not run formatting, linting, or tests
+  in parallel.
+- Capture long command output with `tee` under `/tmp`, using the current branch
+  name in the log filename.
+- Use `coderabbit review --agent` after each major implementation milestone
+  that produces reviewable documentation changes, and clear all actionable
+  concerns before moving to the next milestone.
+- Commit small, focused changes after their relevant gates pass. Do not commit
+  changes that fail the required gates.
+
+## Tolerances
+
+- Scope: if implementation requires non-documentation Rust code changes, stop
+  and request approval before continuing. Narrow doctest or example fixes in
+  documentation count as documentation changes; library code changes do not.
+- Contract drift: if ADR 001, `docs/users-guide.md`, `docs/developers-guide.md`,
+  and the landed `src/sse/` API disagree on an observable behaviour, stop after
+  recording the conflict and ask which document or implementation should be
+  authoritative.
+- Path cleanup: after the scrub pass, the path sweep command shown in
+  Milestone 1 must show zero hits outside explicitly labelled planning-time
+  provenance notes. Any remaining unlabelled hit blocks closure.
+- Historical preservation: if removing local paths would erase important
+  import provenance from the Wildside plan, move the reference into an
+  explicitly labelled provenance section rather than deleting it silently.
+- Documentation gates: if `make fmt`, `make markdownlint`, or `make nixie`
+  fails on changed documentation, fix the documentation before continuing.
+- Full gates: if `make check-fmt`, `make lint`, or `make test` fails because
+  of this branch's changes, fix the branch. If a failure is demonstrably
+  unrelated and pre-existing, record the evidence and ask for direction before
+  marking the roadmap item done.
+- CodeRabbit: if `coderabbit review --agent` reports actionable concerns,
+  address them or record why they are false positives before proceeding.
+- Iterations: if the same gate or CodeRabbit concern remains unresolved after
+  three focused fix attempts, stop and document the blocker in the Decision Log.
+
+## Risks
+
+- Risk: over-scrubbing the Wildside import plan removes useful provenance.
+  Severity: medium. Likelihood: medium. Mitigation: replace normative local
+  paths with canonical upstream references, and keep any necessary local
+  checkout detail only in a labelled historical section.
+- Risk: the roadmap could be checked off while the older import plan remains
+  stale. Severity: medium. Likelihood: medium. Mitigation: make roadmap
+  completion the final documentation edit, after the import plan, contents
+  index, path sweep, gates, and CodeRabbit review are complete.
+- Risk: documentation says the SSE module is broader than it is. Severity:
+  high. Likelihood: low. Mitigation: use ADR 001, the user guide, and the
+  developer guide to preserve the wire-helper boundary and explicitly exclude
+  event-store, routing, authorization, and scheduling logic.
+- Risk: a documentation-only task may skip Rust validation and miss doctest or
+  lint drift introduced by edited examples. Severity: medium. Likelihood: low.
+  Mitigation: run the documentation gates required by the roadmap and the full
+  Rust gates requested for this feature before final commit.
+- Risk: external protocol references change over time. Severity: low.
+  Likelihood: medium. Mitigation: cite stable primary or ecosystem references
+  only for context, not as a replacement for ADR 001. The useful references for
+  this plan are the WHATWG HTML Server-Sent Events section and the `actix-sse`
+  docs.rs page as prior art for Actix-facing SSE helpers.
+
+## Repository orientation
+
+The current repository already contains the landed SSE helper module under
+`src/sse/`, with crate-root re-exports in `src/lib.rs`. The public guide in
+`docs/users-guide.md` documents `EventId`, `ReplayCursor`, `Last-Event-ID`
+header extraction, frame rendering, heartbeat helpers, `stream_reset`, and live
+event-stream cache headers. The maintainer guide in `docs/developers-guide.md`
+documents the `src/sse/` module layout, framework adapter boundary, and the
+current `rstest`, `rstest-bdd`, and `proptest` testing split.
+
+The older import plan at `docs/execplans/import-components-from-wildside.md` is
+still marked `Status: IN PROGRESS`. It contains the historical milestones that
+imported pagination, idempotency, shared error handling, OpenAPI fragments, and
+the initial SSE contract decision. Its Milestone 6 already requires a final
+documentation scrub for environment-specific paths. Roadmap item 1.2.2 is the
+task that should execute that clean-up and then close the plan honestly.
+
+ADR 001 remains the normative SSE contract. It says that `actix-v2a` provides
+wire-only helpers for browser-compatible Server-Sent Events, including
+validated identifiers, `Last-Event-ID` parsing, frame rendering, cache headers,
+a configurable heartbeat policy with a 20-second default, and the standard
+`stream_reset` event. It also says that application event stores, retention
+policies, authorization, and endpoint routing remain outside this crate.
+
+External context gathered during planning confirms two useful reference points:
+the WHATWG HTML specification defines the `text/event-stream` format, the
+`Last-Event-ID` header, UTF-8 decoding, field processing, and comment
+heartbeats; the `actix-sse` crate demonstrates prior art for Actix Web SSE
+responders while also reinforcing that this crate deliberately stops short of
+owning responder lifecycle.
+
+## Implementation plan
+
+### Milestone 1: audit the documentation closure surface
+
+Start by checking the branch and the current documentation state:
+
+```bash
+git branch --show-current
+git status --short --branch
+PATH_PATTERN='/data/leynos/Projects|\\.\\./wildside/backend'
+PATH_PATTERN="${PATH_PATTERN}|/home/leynos|worktrees"
+SSE_PATTERN='1\\.2\\.2|SSE|Server-Sent|Last-Event-ID|stream_reset|heartbeat'
+rg -n "${PATH_PATTERN}" docs README.md
+rg -n "${SSE_PATTERN}" \
+  docs/roadmap.md docs/contents.md docs/execplans \
+  docs/users-guide.md docs/developers-guide.md
+```
+
+Read these files before editing:
+
+- `docs/roadmap.md`
+- `docs/execplans/import-components-from-wildside.md`
+- `docs/adr-001-shared-sse-wire-contract-for-wildside-and-corbusier.md`
+- `docs/contents.md`
+- `docs/users-guide.md`
+- `docs/developers-guide.md`
+- `docs/documentation-style-guide.md`
+
+The milestone is complete when this plan's `Progress` section records the audit
+findings and the path-reference sweep has a known baseline. Do not mark roadmap
+task 1.2.2 done in this milestone.
+
+### Milestone 2: update the Wildside import plan
+
+Edit `docs/execplans/import-components-from-wildside.md` so it reflects the
+current completed state without pretending the historical implementation path
+never existed.
+
+Required edits:
+
+1. Change `Status: IN PROGRESS` to `Status: COMPLETE` only when the remaining
+   documentation closure work is actually complete. During this milestone,
+   leave it as `IN PROGRESS` until the path scrub and gates have passed.
+2. Update `Purpose / big picture`, `Repository orientation`, `Constraints`,
+   `Tolerances`, `Risks`, milestone text, and outcomes so normative references
+   use canonical upstream Wildside wording or repository-relative paths instead
+   of `../wildside/backend`.
+3. Add or update a clearly labelled planning-time provenance note if any local
+   sibling-checkout paths must remain for historical intelligibility.
+4. Add a dated `Progress` entry for roadmap task 1.2.2 beginning and later for
+   completion.
+5. Add a `Decision Log` entry that states the path-normalization rule:
+   canonical upstream URLs for provenance, repository-relative paths for this
+   crate, and labelled historical notes for any remaining local checkout
+   references.
+6. Update `Outcomes & Retrospective` to state that the SSE roadmap sequence
+   from 1.1.1 through 1.2.1 has landed, and that task 1.2.2 closed the
+   documentation and path-cleanup loop.
+
+Run the path sweep after editing this file:
+
+```bash
+PATH_PATTERN='/data/leynos/Projects|\\.\\./wildside/backend'
+PATH_PATTERN="${PATH_PATTERN}|/home/leynos|worktrees"
+rg -n "${PATH_PATTERN}" docs/execplans/import-components-from-wildside.md
+```
+
+The milestone is complete when the import plan accurately records the SSE
+completion state and contains no unlabelled environment-specific paths.
+
+Run CodeRabbit for this milestone after the import-plan edit is staged or
+otherwise reviewable:
+
+```bash
+coderabbit review --agent
+```
+
+Address actionable feedback before continuing.
+
+### Milestone 3: update the documentation index and contract-adjacent docs
+
+Edit `docs/contents.md` so it indexes this new plan and replaces any
+implementation-time Wildside path wording with canonical upstream phrasing.
+Keep the existing SSE execplan entries stable and add an entry for
+`docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md`.
+
+Review ADR 001. Edit it only if its context still presents a local checkout
+path as normative or if the closure audit finds a contract statement that no
+longer matches the landed module. The expected edit, if needed, is a wording
+change from local checkout language to canonical upstream Wildside provenance.
+
+Review `docs/users-guide.md`. Edit it only if public API examples or behaviour
+summaries are stale. If edited, keep examples aligned with the crate-root
+exports and the existing SSE helpers.
+
+Review `docs/developers-guide.md`. Edit it only if the internal module layout,
+test suite description, validation guidance, or boundary language is stale. If
+edited, keep the framework adapter rule explicit: `actix_adapter` is the only
+SSE module that should import Actix Web types.
+
+Run the broad path sweep:
+
+```bash
+PATH_PATTERN='/data/leynos/Projects|\\.\\./wildside/backend'
+PATH_PATTERN="${PATH_PATTERN}|/home/leynos|worktrees"
+rg -n "${PATH_PATTERN}" docs README.md
+```
+
+The milestone is complete when all changed documentation is internally
+consistent, this execplan is discoverable from `docs/contents.md`, and the path
+sweep has no unlabelled implementation-time references.
+
+Run CodeRabbit again:
+
+```bash
+coderabbit review --agent
+```
+
+Address actionable feedback before continuing.
+
+### Milestone 4: validate documentation and full repository gates
+
+Run all required gates sequentially with `tee` logs. Use the branch name in the
+log filenames, so results are easy to find after context compaction:
+
+```bash
+BRANCH=1-2-2-update-documentation-after-sse-module-lands
+set -o pipefail && make fmt | tee "/tmp/fmt-actix-v2a-${BRANCH}.out"
+set -o pipefail && make markdownlint \
+  | tee "/tmp/markdownlint-actix-v2a-${BRANCH}.out"
+set -o pipefail && make nixie | tee "/tmp/nixie-actix-v2a-${BRANCH}.out"
+set -o pipefail && make check-fmt \
+  | tee "/tmp/check-fmt-actix-v2a-${BRANCH}.out"
+set -o pipefail && make lint | tee "/tmp/lint-actix-v2a-${BRANCH}.out"
+set -o pipefail && make test | tee "/tmp/test-actix-v2a-${BRANCH}.out"
+```
+
+Expected results:
+
+- `make fmt` completes and leaves no unintended formatting changes.
+- `make markdownlint` passes on the documentation set.
+- `make nixie` passes all Mermaid validation.
+- `make check-fmt` reports no Rust formatting drift.
+- `make lint` passes Clippy, Rustdoc, and repository lint policy.
+- `make test` passes unit, behavioural, property, integration, and doctest
+  coverage already present in the repository.
+
+If any gate changes files, inspect the diff, record the change in `Progress`,
+and rerun the affected gate before moving on.
+
+### Milestone 5: mark roadmap completion and close the branch
+
+After Milestones 2 through 4 are complete and CodeRabbit has no unresolved
+actionable concerns, make the final documentation edits:
+
+1. Set `Status: COMPLETE` in
+   `docs/execplans/import-components-from-wildside.md` if not already done.
+2. Add final gate evidence to that plan and to this plan's `Progress` and
+   `Outcomes & Retrospective` sections.
+3. Mark roadmap task 1.2.2 done in `docs/roadmap.md`.
+
+Run the minimal final confirmation:
+
+```bash
+git diff --check
+PATH_PATTERN='/data/leynos/Projects|\\.\\./wildside/backend'
+PATH_PATTERN="${PATH_PATTERN}|/home/leynos|worktrees"
+rg -n "${PATH_PATTERN}" docs README.md
+```
+
+If the final roadmap edit or status update touches Markdown formatting, rerun:
+
+```bash
+BRANCH=1-2-2-update-documentation-after-sse-module-lands
+set -o pipefail && make fmt | tee "/tmp/fmt-actix-v2a-${BRANCH}.out"
+set -o pipefail && make markdownlint \
+  | tee "/tmp/markdownlint-actix-v2a-${BRANCH}.out"
+set -o pipefail && make nixie | tee "/tmp/nixie-actix-v2a-${BRANCH}.out"
+```
+
+Commit using the `commit-message` skill's file-based `git commit -F` workflow.
+Push the branch with upstream tracking:
+
+```bash
+git push -u origin 1-2-2-update-documentation-after-sse-module-lands
+```
+
+Create or update a draft pull request. The title must include the roadmap item
+number as `(1.2.2)`, and the summary must mention this execplan document. The
+description must include a `## References` section containing the Lody session
+link produced from:
+
+```bash
+echo ${LODY_SESSION_ID}
+```
+
+## Validation and evidence capture
+
+The implementation must record the exact gate outcomes in this plan and in the
+Wildside import plan where relevant. Use `/tmp` only for logs and scratch
+output. Do not use `/tmp` as a build target.
+
+The required validation suite for the completed feature is:
+
+- `make fmt`
+- `make markdownlint`
+- `make nixie`
+- `make check-fmt`
+- `make lint`
+- `make test`
+- `coderabbit review --agent`
+- `git diff --check`
+- the environment-specific path sweep shown in Milestone 1
+
+The expected final path sweep output is empty, unless this plan or the import
+plan contains a clearly labelled planning-time provenance note. Any allowed hit
+must be recorded in `Decision Log` with the reason it remains.
+
+## Approval gates
+
+Implementation must not begin until all of these are true:
+
+1. The user explicitly approves this plan.
+2. The branch is named `1-2-2-update-documentation-after-sse-module-lands`.
+3. The plan PR is open as a draft for review.
+
+After approval, implementation proceeds milestone by milestone within the
+tolerances above. Silence is not approval.
+
+## Progress
+
+- [x] 2026-05-19: Loaded the `leta`, `rust-router`, `execplans`,
+  `firecrawl-mcp`, `commit-message`, `pr-creation`, and
+  `hexagonal-architecture` skills needed for this planning task.
+- [x] 2026-05-19: Created the Leta workspace for this repository.
+- [x] 2026-05-19: Confirmed the starting branch was not `main` and renamed it
+  to `1-2-2-update-documentation-after-sse-module-lands`.
+- [x] 2026-05-19: Used a Wyvern agent team to inspect the roadmap, import
+  plan, ADR, contents index, user guide, and developer guide for planning gaps.
+- [x] 2026-05-19: Used Firecrawl to review current SSE protocol and prior-art
+  references: WHATWG HTML Server-Sent Events and the `actix-sse` docs.rs page.
+- [x] 2026-05-19: Drafted this execution plan.
+- [ ] Await explicit user approval before implementing the documentation
+  closure work.
+
+## Surprises & Discoveries
+
+- 2026-05-19: The landed repository already has public and maintainer SSE
+  documentation in `docs/users-guide.md` and `docs/developers-guide.md`, so
+  task 1.2.2 should avoid rewriting those guides unless the closure audit finds
+  concrete drift.
+- 2026-05-19: `docs/execplans/import-components-from-wildside.md` still has
+  many `../wildside/backend` references in normative sections even though its
+  own Milestone 6 says those paths should be removed before closure.
+- 2026-05-19: The import plan's outcomes already claim Milestone 6 shipped, but
+  the file is still `Status: IN PROGRESS` and still contains unscoped local
+  path references. The implementation must reconcile that inconsistency rather
+  than simply checking the roadmap box.
+- 2026-05-19: No separate SSE design document exists under `docs/`; ADR 001
+  plus the user's and developer's guides carry the current design and usage
+  documentation.
+
+## Decision Log
+
+- 2026-05-19: Treat task 1.2.2 as documentation closure, not as functional SSE
+  work. Rationale: roadmap tasks 1.1.1 through 1.2.1 already built and proved
+  the helper surface, while 1.2.2 names plan and documentation updates.
+- 2026-05-19: Keep remaining local checkout paths only as explicitly labelled
+  historical provenance if needed. Rationale: the old import plan should remain
+  intelligible, but finished documentation should not depend on one developer's
+  sibling directory layout.
+- 2026-05-19: Include the full Rust gate suite in the implementation plan even
+  though the expected change is documentation-only. Rationale: the user asked
+  for `make check-fmt`, `make lint`, and `make test` to succeed, and edited
+  Rust examples or doctests can affect those gates.
+- 2026-05-19: Use WHATWG HTML as the protocol reference and `actix-sse` as
+  ecosystem prior art only. Rationale: ADR 001 remains the source of truth for
+  this crate's deliberately narrower wire-helper contract.
+
+## Outcomes & Retrospective
+
+Not started. This section must be updated during implementation and completed
+only after the documentation closure, validation gates, CodeRabbit review,
+roadmap update, push, and draft pull request are complete.
+
+## External references
+
+- WHATWG HTML Standard, Server-sent events:
+  <https://html.spec.whatwg.org/multipage/server-sent-events.html>
+- `actix-sse` crate documentation on docs.rs:
+  <https://docs.rs/actix-sse/latest/actix_sse/>

--- a/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md
+++ b/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md
@@ -150,12 +150,13 @@ event-stream cache headers. The maintainer guide in `docs/developers-guide.md`
 documents the `src/sse/` module layout, framework adapter boundary, and the
 current `rstest`, `rstest-bdd`, and `proptest` testing split.
 
-The older import plan at `docs/execplans/import-components-from-wildside.md` is
-still marked `Status: IN PROGRESS`. It contains the historical milestones that
-imported pagination, idempotency, shared error handling, OpenAPI fragments, and
-the initial SSE contract decision. Its Milestone 6 already requires a final
-documentation scrub for environment-specific paths. Roadmap item 1.2.2 is the
-task that should execute that clean-up and then close the plan honestly.
+The older import plan at `docs/execplans/import-components-from-wildside.md`
+was marked `Status: IN PROGRESS` when this task began. It contains the
+historical milestones that imported pagination, idempotency, shared error
+handling, OpenAPI fragments, and the initial SSE contract decision. Its
+Milestone 6 already required a final documentation scrub for
+environment-specific paths. Roadmap item 1.2.2 executed that clean-up and
+closed the plan honestly.
 
 ADR 001 remains the normative SSE contract. It says that `actix-v2a` provides
 wire-only helpers for browser-compatible Server-Sent Events, including

--- a/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md
+++ b/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md
@@ -173,6 +173,20 @@ owning responder lifecycle.
 
 ## Implementation plan
 
+Use this shared path sweep helper anywhere this plan says to run the path sweep:
+
+```bash
+path_sweep() {
+  LOCAL_WILDSIDE_PATH='../wildside'/'backend'
+  LOCAL_HOME_PREFIX='/home'/'leynos'
+  LOCAL_PROJECTS_PREFIX='/data/leynos'/'Projects'
+  LOCAL_WORKTREE_SEGMENT='work''trees'
+  PATH_PATTERN="${LOCAL_PROJECTS_PREFIX}|${LOCAL_WILDSIDE_PATH}"
+  PATH_PATTERN="${PATH_PATTERN}|${LOCAL_HOME_PREFIX}|${LOCAL_WORKTREE_SEGMENT}"
+  rg -n "${PATH_PATTERN}" "$@"
+}
+```
+
 ### Milestone 1: audit the documentation closure surface
 
 Start by checking the branch and the current documentation state:
@@ -180,14 +194,8 @@ Start by checking the branch and the current documentation state:
 ```bash
 git branch --show-current
 git status --short --branch
-LOCAL_WILDSIDE_PATH='../wildside'/'backend'
-LOCAL_HOME_PREFIX='/home'/'leynos'
-LOCAL_PROJECTS_PREFIX='/data/leynos'/'Projects'
-LOCAL_WORKTREE_SEGMENT='work''trees'
-PATH_PATTERN="${LOCAL_PROJECTS_PREFIX}|${LOCAL_WILDSIDE_PATH}"
-PATH_PATTERN="${PATH_PATTERN}|${LOCAL_HOME_PREFIX}|${LOCAL_WORKTREE_SEGMENT}"
 SSE_PATTERN='1\\.2\\.2|SSE|Server-Sent|Last-Event-ID|stream_reset|heartbeat'
-rg -n "${PATH_PATTERN}" docs README.md
+path_sweep docs README.md
 rg -n "${SSE_PATTERN}" \
   docs/roadmap.md docs/contents.md docs/execplans \
   docs/users-guide.md docs/developers-guide.md
@@ -237,13 +245,7 @@ Required edits:
 Run the path sweep after editing this file:
 
 ```bash
-LOCAL_WILDSIDE_PATH='../wildside'/'backend'
-LOCAL_HOME_PREFIX='/home'/'leynos'
-LOCAL_PROJECTS_PREFIX='/data/leynos'/'Projects'
-LOCAL_WORKTREE_SEGMENT='work''trees'
-PATH_PATTERN="${LOCAL_PROJECTS_PREFIX}|${LOCAL_WILDSIDE_PATH}"
-PATH_PATTERN="${PATH_PATTERN}|${LOCAL_HOME_PREFIX}|${LOCAL_WORKTREE_SEGMENT}"
-rg -n "${PATH_PATTERN}" docs/execplans/import-components-from-wildside.md
+path_sweep docs/execplans/import-components-from-wildside.md
 ```
 
 The milestone is complete when the import plan accurately records the SSE
@@ -282,13 +284,7 @@ SSE module that should import Actix Web types.
 Run the broad path sweep:
 
 ```bash
-LOCAL_WILDSIDE_PATH='../wildside'/'backend'
-LOCAL_HOME_PREFIX='/home'/'leynos'
-LOCAL_PROJECTS_PREFIX='/data/leynos'/'Projects'
-LOCAL_WORKTREE_SEGMENT='work''trees'
-PATH_PATTERN="${LOCAL_PROJECTS_PREFIX}|${LOCAL_WILDSIDE_PATH}"
-PATH_PATTERN="${PATH_PATTERN}|${LOCAL_HOME_PREFIX}|${LOCAL_WORKTREE_SEGMENT}"
-rg -n "${PATH_PATTERN}" docs README.md
+path_sweep docs README.md
 ```
 
 The milestone is complete when all changed documentation is internally
@@ -348,13 +344,7 @@ Run the minimal final confirmation:
 
 ```bash
 git diff --check
-LOCAL_WILDSIDE_PATH='../wildside'/'backend'
-LOCAL_HOME_PREFIX='/home'/'leynos'
-LOCAL_PROJECTS_PREFIX='/data/leynos'/'Projects'
-LOCAL_WORKTREE_SEGMENT='work''trees'
-PATH_PATTERN="${LOCAL_PROJECTS_PREFIX}|${LOCAL_WILDSIDE_PATH}"
-PATH_PATTERN="${PATH_PATTERN}|${LOCAL_HOME_PREFIX}|${LOCAL_WORKTREE_SEGMENT}"
-rg -n "${PATH_PATTERN}" docs README.md
+path_sweep docs README.md
 ```
 
 If the final roadmap edit or status update touches Markdown formatting, rerun:
@@ -459,9 +449,9 @@ tolerances above. Silence is not approval.
   import-plan closure edits: `make fmt`, `make markdownlint`, and `make nixie`.
 - [x] 2026-05-20: Re-ran `coderabbit review --agent` for the final closure
   diff after a recoverable rate-limit wait; it completed with zero findings.
-- [x] 2026-05-20: Committed the closure edits as `f134e2d` (`Close SSE
-  documentation roadmap item`), pushed the branch to `origin
-  `, and updated draft pull request #30 at <https://github.com/leynos/actix-v2a/pull/30>.
+- [x] 2026-05-20: Committed the closure edits as `f134e2d`, pushed to the
+  remote branch, and updated draft pull request #30 at
+  <https://github.com/leynos/actix-v2a/pull/30>.
 
 ## Surprises & Discoveries
 
@@ -507,10 +497,6 @@ tolerances above. Silence is not approval.
   machine paths.
 
 ## Outcomes & Retrospective
-
-Not started. This section must be updated during implementation and completed
-only after the documentation closure, validation gates, CodeRabbit review,
-roadmap update, push, and draft pull request are complete.
 
 Completed outcome: the documentation closure work scrubbed the configured
 environment-specific path patterns from `docs` and `README.md`, recorded the

--- a/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md
+++ b/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md
@@ -4,7 +4,7 @@ This ExecPlan (execution plan) is a living document. The sections `Constraints`,
  `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
 and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: IN PROGRESS
+Status: COMPLETE
 
 ## Purpose / big picture
 
@@ -459,8 +459,9 @@ tolerances above. Silence is not approval.
   import-plan closure edits: `make fmt`, `make markdownlint`, and `make nixie`.
 - [x] 2026-05-20: Re-ran `coderabbit review --agent` for the final closure
   diff after a recoverable rate-limit wait; it completed with zero findings.
-- [ ] 2026-05-20: Commit the closure edits, push, and update the draft pull
-  request.
+- [x] 2026-05-20: Committed the closure edits as `f134e2d` (`Close SSE
+  documentation roadmap item`), pushed the branch to `origin
+  `, and updated draft pull request #30 at <https://github.com/leynos/actix-v2a/pull/30>.
 
 ## Surprises & Discoveries
 
@@ -511,11 +512,19 @@ Not started. This section must be updated during implementation and completed
 only after the documentation closure, validation gates, CodeRabbit review,
 roadmap update, push, and draft pull request are complete.
 
-Interim outcome: the documentation closure work has scrubbed the configured
+Completed outcome: the documentation closure work scrubbed the configured
 environment-specific path patterns from `docs` and `README.md`, recorded the
-landed SSE helper sequence in the Wildside import plan, and marked roadmap task
-1.2.2 done after the documentation and full Rust gate sets passed. Final push
-and pull request updates remain before this plan can be marked complete.
+landed SSE helper sequence in the Wildside import plan, marked roadmap task
+1.2.2 done, and updated draft pull request #30 for reviewer inspection. The
+work stayed documentation-only; `docs/users-guide.md` and
+`docs/developers-guide.md` did not need changes because their landed SSE helper
+sections already matched the current crate boundary.
+
+Validation passed with branch-specific logs under `/tmp`: `make fmt`,
+`make markdownlint`, `make nixie`, `make check-fmt`, `make lint`, and
+`make test`. The test gate ran 162 nextest tests and 26 doctests. CodeRabbit
+reported zero findings for the first documentation milestone and zero findings
+for the final closure diff after a recoverable rate-limit wait.
 
 ## External references
 

--- a/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md
+++ b/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md
@@ -1,9 +1,8 @@
 # Update documentation after the SSE module lands
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. Keep `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` up to date as work proceeds.
 
 Status: COMPLETE
 

--- a/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md
+++ b/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md
@@ -1,8 +1,9 @@
 # Update documentation after the SSE module lands
 
-This ExecPlan (execution plan) is a living document. The sections `Constraints`,
- `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
-and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
 
 Status: COMPLETE
 
@@ -92,7 +93,7 @@ This plan must be approved before implementation begins.
 
 ## Tolerances
 
-- Scope: if implementation requires non-documentation Rust code changes, stop
+- Scope: if implementation requires non-documentation Rust code changes, stop,
   and request approval before continuing. Narrow doctest or example fixes in
   documentation count as documentation changes; library code changes do not.
 - Contract drift: if ADR 001, `docs/users-guide.md`, `docs/developers-guide.md`,

--- a/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md
+++ b/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md
@@ -150,13 +150,12 @@ event-stream cache headers. The maintainer guide in `docs/developers-guide.md`
 documents the `src/sse/` module layout, framework adapter boundary, and the
 current `rstest`, `rstest-bdd`, and `proptest` testing split.
 
-The older import plan at `docs/execplans/import-components-from-wildside.md`
-was marked `Status: IN PROGRESS` when this task began. It contains the
-historical milestones that imported pagination, idempotency, shared error
-handling, OpenAPI fragments, and the initial SSE contract decision. Its
-Milestone 6 already required a final documentation scrub for
-environment-specific paths. Roadmap item 1.2.2 executed that clean-up and
-closed the plan honestly.
+The older import plan at `docs/execplans/import-components-from-wildside.md` is
+still marked `Status: IN PROGRESS`. It contains the historical milestones that
+imported pagination, idempotency, shared error handling, OpenAPI fragments, and
+the initial SSE contract decision. Its Milestone 6 already requires a final
+documentation scrub for environment-specific paths. Roadmap item 1.2.2 is the
+task that should execute that clean-up and then close the plan honestly.
 
 ADR 001 remains the normative SSE contract. It says that `actix-v2a` provides
 wire-only helpers for browser-compatible Server-Sent Events, including

--- a/docs/execplans/adopt-netsuke.md
+++ b/docs/execplans/adopt-netsuke.md
@@ -20,7 +20,7 @@ gate behaviour currently exposed by `make check-fmt`, `make lint`, and
 Success is observable in two places. Locally, the Netsuke commands pass and
 produce the same effective Cargo, Markdown, and Mermaid checks as the existing
 Makefile. In CI, `.github/workflows/ci.yml` installs Netsuke from
-`https://github.com/leynos/netsuke/` source, installs Ninja, and invokes
+`https://github.com/example-org/netsuke/` source, installs Ninja, and invokes
 Netsuke for repository gates instead of invoking `make` directly. This is a
 dogfooding pilot, so the plan keeps rollback straightforward and captures any
 Netsuke limitations discovered while translating the existing Makefile targets.
@@ -103,9 +103,10 @@ record the conflict in `Decision Log`, and ask for direction.
 - [x] 2026-05-02: Inspect the current `Makefile`, `.github/workflows/ci.yml`,
   `docs/developers-guide.md`, and `docs/netsuke-users-guide.md`.
 - [x] 2026-05-02: Confirm upstream Netsuke source metadata from
-  `https://github.com/leynos/netsuke/`; the package name is `netsuke`, current
-  `HEAD` during drafting was `2fe314a58d7311758640b3daa086c401d79838cf`, and
-  the crate declares Rust `1.89.0`.
+  `https://github.com/example-org/netsuke/`; the package name is `netsuke`,
+  current `HEAD` during drafting was
+  `2fe314a58d7311758640b3daa086c401d79838cf`, and the crate declares Rust
+  `1.89.0`.
 - [x] 2026-05-02: Receive explicit approval to proceed with implementation.
 - [x] 2026-05-02: Re-check upstream Netsuke `HEAD`; it remains
   `2fe314a58d7311758640b3daa086c401d79838cf`.
@@ -132,7 +133,7 @@ record the conflict in `Decision Log`, and ask for direction.
   `make markdownlint`, `make nixie`, `make lint`, and `make test`.
 - [x] 2026-05-02: Prepare the gated implementation change for commit.
 - [x] 2026-05-02: Inspect
-  `leynos/agent-helper-scripts/hooks/post-turn-quality-stop-hook.py` and
+  `example-org/agent-helper-scripts/hooks/post-turn-quality-stop-hook.py` and
   document the external hook changes needed for Netsuke-native quality gates.
 - [x] 2026-05-02: Address CI runtime failure `markdownlint-cli2: not found` by
   installing Bun and `markdownlint-cli2` via GitHub Actions.
@@ -145,9 +146,9 @@ record the conflict in `Decision Log`, and ask for direction.
 
 - 2026-05-02: The current CI only calls `make` directly for `check-fmt` and
   `lint`. Tests and coverage are delegated to
-  `leynos/shared-actions/.github/actions/generate-coverage`, so implementation
-  must check whether that shared action invokes `make` internally before
-  claiming CI is fully Make-free.
+  `example-org/shared-actions/.github/actions/generate-coverage`, so
+  implementation must check whether that shared action invokes `make`
+  internally before claiming CI is fully Make-free.
 - 2026-05-02: The Makefile already contains compatibility work for reduced
   `PATH` environments by prepending `$HOME/.cargo/bin`, `$HOME/.bun/bin`, and
   `$HOME/.local/bin`. The Netsuke manifest must preserve this behaviour.
@@ -219,8 +220,8 @@ record the conflict in `Decision Log`, and ask for direction.
   Markdown formatting.
 - Decision: Document agent-helper-scripts changes here instead of editing the
   external repository in this branch. Rationale: The requested script lives in
-  `leynos/agent-helper-scripts`, while this pull request belongs to
-  `leynos/actix-v2a`. Keeping the requirement in this ExecPlan lets the
+  `example-org/agent-helper-scripts`, while this pull request belongs to
+  `example-org/actix-v2a`. Keeping the requirement in this ExecPlan lets the
   follow-up be implemented in the owning repository.
 - Decision: Install `markdownlint-cli2` in CI through Bun with
   `oven-sh/setup-bun` and `bun install -g markdownlint-cli2`. Rationale: the
@@ -254,7 +255,7 @@ Actions.
 ## Required agent-helper-scripts hook changes
 
 The stop hook at
-`https://github.com/leynos/agent-helper-scripts/blob/main/hooks/post-turn-quality-stop-hook.py`
+`https://github.com/example-org/agent-helper-scripts/blob/main/hooks/post-turn-quality-stop-hook.py`
  must become build-driver aware before repositories can retire Makefile shims.
 The current script assumes Make at the data-model, discovery, execution, and
 reporting layers:
@@ -432,7 +433,7 @@ Ninja and install Netsuke from source:
   run: sudo apt-get update && sudo apt-get install -y ninja-build
 - name: Install Netsuke
   run: >-
-    cargo install --git https://github.com/leynos/netsuke.git
+    cargo install --git https://github.com/example-org/netsuke.git
     --rev 2fe314a58d7311758640b3daa086c401d79838cf
     netsuke --locked
 - name: Show Netsuke version

--- a/docs/execplans/adopt-netsuke.md
+++ b/docs/execplans/adopt-netsuke.md
@@ -1,9 +1,8 @@
 # Adopt Netsuke as the Repository Build Driver
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+ `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETE
 
@@ -13,8 +12,8 @@ This repository currently uses GNU Make through the root `Makefile` and the
 GitHub Actions workflow at `.github/workflows/ci.yml`. The goal is to pilot
 Netsuke as the primary build driver for this simple Rust repository while
 dogfooding Netsuke before package-manager distribution is available. After this
-change, a developer can run `netsuke build check-fmt`, `netsuke build lint`,
-and `netsuke build test` from the repository root and receive the same quality
+change, a developer can run `netsuke build check-fmt`, `netsuke build lint`, and
+ `netsuke build test` from the repository root and receive the same quality
 gate behaviour currently exposed by `make check-fmt`, `make lint`, and
 `make test`.
 
@@ -179,8 +178,8 @@ record the conflict in `Decision Log`, and ask for direction.
   targets" in its block output.
 - 2026-05-03: Netsuke `typecheck` was assigning `RUSTFLAGS` to a shell variable
   without exporting it; the fixed action now invokes `cargo check` with the
-  environment assignment in-line, restoring the Makefile semantics and preventing
-  silent warning-only pass-through.
+  environment assignment in-line, restoring the Makefile semantics and
+  preventing silent warning-only pass-through.
 
 ## Decision Log
 
@@ -223,14 +222,14 @@ record the conflict in `Decision Log`, and ask for direction.
   `leynos/agent-helper-scripts`, while this pull request belongs to
   `leynos/actix-v2a`. Keeping the requirement in this ExecPlan lets the
   follow-up be implemented in the owning repository.
-- Decision: Install `markdownlint-cli2` in CI through Bun with `oven-sh/setup-bun`
-  and `bun install -g markdownlint-cli2`. Rationale: the Netsuke Markdown lint
-  step depends on that binary and is not guaranteed present on GitHub runners.
+- Decision: Install `markdownlint-cli2` in CI through Bun with
+  `oven-sh/setup-bun` and `bun install -g markdownlint-cli2`. Rationale: the
+  Netsuke Markdown lint step depends on that binary and is not guaranteed
+  present on GitHub runners.
 - Decision: Pin the CI Bun setup action and markdownlint-cli2 package version to
   fixed revisions (`oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6`
-  and
-  `markdownlint-cli2@0.22.1`). Rationale: reproducibility should be explicit for
-  dogfooding gates.
+  and `markdownlint-cli2@0.22.1`). Rationale: reproducibility should be
+  explicit for dogfooding gates.
 - Decision: Keep Netsuke `typecheck` warning policy explicit by passing
   `RUSTFLAGS` directly in the `cargo check` command line. Rationale: separate
   shell variable assignment without export is equivalent to a no-op for child
@@ -242,9 +241,9 @@ The repository now has a root `Netsukefile`, a Makefile compatibility shim,
 Netsuke-first developer documentation, and CI steps that install Netsuke from
 the pinned GitHub source revision before running Netsuke gates. The Netsuke
 manifest, format check, lint, test, Markdown lint, Mermaid validation, and
-Makefile compatibility gates passed.
-CI now installs Bun and `markdownlint-cli2` explicitly so the Markdown gate no
-longer fails with `markdownlint-cli2: not found` during Netsuke execution.
+Makefile compatibility gates passed. CI now installs Bun and
+`markdownlint-cli2` explicitly so the Markdown gate no longer fails with
+`markdownlint-cli2: not found` during Netsuke execution.
 
 After approval to exceed the initial file-count tolerance,
 `docs/netsuke-users-guide.md` was wrapped narrowly, `make fmt` passed, and the
@@ -371,10 +370,10 @@ The current build-tooling surface is small:
 - `Makefile` defines `check-fmt`, `lint`, `test`, `fmt`, `markdownlint`,
   `nixie`, `build`, `release`, `clean`, `typecheck`, `all`, and `help`.
 - `.github/workflows/ci.yml` runs on pull requests and manual dispatch. It
-  checks out the repository, sets up Rust, installs Bun tools, installs Netsuke,
-  validates the `Netsukefile` manifest, then runs `netsuke build` gates for
-  format, Markdown linting, and linting, followed by shared coverage and
-  CodeScene upload steps.
+  checks out the repository, sets up Rust, installs Bun tools, installs
+  Netsuke, validates the `Netsukefile` manifest, then runs `netsuke build`
+  gates for format, Markdown linting, and linting, followed by shared coverage
+  and CodeScene upload steps.
 - `docs/developers-guide.md` documents Makefile-based build tooling and must
   be updated so developers know that Netsuke is the preferred driver during the
   pilot.
@@ -401,8 +400,8 @@ vars:
   cargo_flags: "--all-targets --all-features"
 ```
 
-Use `actions:` for the repository gates. Each action is a `command:` action that
-invokes `sh -e -c` and preserves the current behaviour:
+Use `actions:` for the repository gates. Each action is a `command:` action
+that invokes `sh -e -c` and preserves the current behaviour:
 
 - `check-fmt` runs `netsuke build check-fmt`.
 - `lint` runs `netsuke build lint`.

--- a/docs/execplans/import-components-from-wildside.md
+++ b/docs/execplans/import-components-from-wildside.md
@@ -8,26 +8,27 @@ Status: IN PROGRESS
 
 ## Purpose / big picture
 
-`actix-v2a` currently contains only a stub library entrypoint, while
-`../wildside/backend` already has working implementations for cursor
-pagination, idempotency helpers, a shared JSON error envelope, and OpenAPI
-schema wrappers around that envelope. The goal of this plan is to extract the
-reusable parts of those features into `actix-v2a` so this repository becomes
-the common home for version 2a Actix components instead of each application
-re-implementing them.
+`actix-v2a` began as a stub library entrypoint, while the canonical Wildside
+upstream repository at `https://github.com/leynos/wildside` already carried
+working implementations for cursor pagination, idempotency helpers, a shared
+JSON error envelope, and OpenAPI schema wrappers around that envelope. The goal
+of this plan was to extract the reusable parts of those features into
+`actix-v2a` so this repository becomes the common home for version 2a Actix
+components instead of each application re-implementing them.
 
-The canonical upstream project is `https://github.com/leynos/wildside`, but for
-local development and source inspection the implementation source of truth for
-this plan is `../wildside/backend`.
+Planning used a local Wildside checkout as source material, but the completed
+documentation records provenance with canonical upstream repository wording and
+repository-relative paths rather than requiring a particular sibling directory
+layout.
 
 Success is observable in five ways:
 
 1. `src/lib.rs` exposes reusable modules for pagination, idempotency, shared
    error handling, `utoipa` OpenAPI fragments, and any approved Server-Sent
    Events (SSE) helpers.
-2. Tests copied or adapted from `../wildside/backend` prove cursor codec
-   behaviour, limit validation, idempotency parsing and replay semantics, and
-   error responder output.
+2. Tests copied or adapted from Wildside prove cursor codec behaviour, limit
+   validation, idempotency parsing and replay semantics, and error responder
+   output.
 3. The repository documentation contains this plan and an updated
    `docs/contents.md` entry so the work is discoverable.
 4. If SSE support is implemented, this repository carries an ADR that defines a
@@ -38,42 +39,37 @@ Success is observable in five ways:
 
 ## Repository orientation
 
-Today this repository is greenfield. `src/lib.rs` contains only a greeting
-stub, there is no `docs/execplans/` directory, and there are no existing
-modules for HTTP contracts, pagination, idempotency, or OpenAPI support.
-Because of that, implementation work should favour clean extraction over
-compatibility shims.
+At the start of this plan, this repository was greenfield. `src/lib.rs`
+contained only a greeting stub, there was no `docs/execplans/` directory, and
+there were no existing modules for HTTP contracts, pagination, idempotency, or
+OpenAPI support. Because of that, implementation work favoured clean extraction
+over compatibility shims.
 
-The Wildside source surface relevant to this plan is:
+The Wildside upstream source surface relevant to this plan was:
 
 - Pagination primitives:
-  `../wildside/backend/crates/pagination/src/lib.rs`,
-  `../wildside/backend/crates/pagination/src/cursor.rs`,
-  `../wildside/backend/crates/pagination/src/params.rs`, and
-  `../wildside/backend/crates/pagination/src/envelope.rs`.
+  `crates/pagination/src/lib.rs`, `crates/pagination/src/cursor.rs`,
+  `crates/pagination/src/params.rs`, and `crates/pagination/src/envelope.rs`.
 - Pagination tests:
-  `../wildside/backend/crates/pagination/tests/pagination_bdd.rs` and
-  `../wildside/backend/crates/pagination/tests/features/`.
+  `crates/pagination/tests/pagination_bdd.rs` and
+  `crates/pagination/tests/features/`.
 - Idempotency HTTP helpers:
-  `../wildside/backend/src/inbound/http/idempotency.rs`.
+  `src/inbound/http/idempotency.rs`.
 - Idempotency domain primitives:
-  `../wildside/backend/src/domain/idempotency/mod.rs`,
-  `../wildside/backend/src/domain/idempotency/key.rs`,
-  `../wildside/backend/src/domain/idempotency/payload.rs`,
-  `../wildside/backend/src/domain/idempotency/mutation_type.rs`, and
-  `../wildside/backend/src/domain/idempotency/record.rs`.
+  `src/domain/idempotency/mod.rs`, `src/domain/idempotency/key.rs`,
+  `src/domain/idempotency/payload.rs`,
+  `src/domain/idempotency/mutation_type.rs`, and
+  `src/domain/idempotency/record.rs`.
 - Shared error envelope and Actix mapping:
-  `../wildside/backend/src/domain/error.rs` and
-  `../wildside/backend/src/inbound/http/error.rs`.
+  `src/domain/error.rs` and `src/inbound/http/error.rs`.
 - OpenAPI schema wrappers:
-  `../wildside/backend/src/inbound/http/schemas.rs`,
-  `../wildside/backend/src/doc.rs`, and
-  `../wildside/backend/tests/openapi_schemas_bdd.rs`.
+  `src/inbound/http/schemas.rs`, `src/doc.rs`, and
+  `tests/openapi_schemas_bdd.rs`.
 
-No dedicated SSE helper module has been confirmed in this Wildside checkout.
-The only nearby source found during planning was WebSocket heartbeat handling in
- `../wildside/backend/src/inbound/ws/session.rs`, which is useful as design
-inspiration but is not itself an SSE helper that can be imported verbatim.
+No dedicated SSE helper module was confirmed in Wildside during the original
+planning pass. The only nearby source found then was WebSocket heartbeat
+handling in Wildside's `src/inbound/ws/session.rs`, which was useful as design
+inspiration but was not itself an SSE helper that could be imported verbatim.
 
 Corbusier already has documented SSE expectations in the canonical upstream
 repository `https://github.com/leynos/corbusier`, especially in
@@ -88,8 +84,8 @@ boundaries, and gates. The normative shared SSE wire contract belongs in the
 
 ## Constraints
 
-- Treat `../wildside/backend` as the implementation source to extract from, not
-  as a runtime dependency to couple against. The default execution path is to
+- Treat Wildside upstream as provenance for extracted reusable code, not as a
+  runtime dependency to couple against. The default execution path is to
   transplant or adapt reusable code into this crate rather than path-depending
   on the Wildside application crate.
 - Preserve the repository’s lint posture. New modules must keep module-level
@@ -100,9 +96,9 @@ boundaries, and gates. The normative shared SSE wire contract belongs in the
   persistence types after extraction.
 - Keep module files below the repository’s 400-line file-size guidance. If a
   direct port would exceed that, split by concern during extraction.
-- Do not invent SSE behaviour. If `../wildside/backend` does not contain a
-  reusable SSE helper contract, define the shared contract first in an ADR,
-  then stop before implementation of the SSE module until that ADR is approved.
+- Do not invent SSE behaviour. Because Wildside did not contain a reusable SSE
+  helper contract, define the shared contract first in an ADR, then stop before
+  implementation of the SSE module until that ADR is approved.
 - Treat the Wildside `utoipa` schema wrappers as in scope for the first
   implementation pass. The reusable target is shared schema fragments and
   related tests, not Wildside's full application-specific `ApiDoc` registration.
@@ -117,10 +113,9 @@ boundaries, and gates. The normative shared SSE wire contract belongs in the
 - Dependencies: adding the minimum dependency set implied by the Wildside
   sources is allowed, but any dependency beyond those directly justified by the
   imported modules requires escalation.
-- SSE source: if no authoritative SSE helper source is located in
-  `../wildside/backend` during implementation, do not improvise a production
-  contract. Draft or update the SSE ADR instead, then stop after recording the
-  discovery.
+- SSE source: if no authoritative SSE helper source is located in Wildside
+  during implementation, do not improvise a production contract. Draft or
+  update the SSE ADR instead, then stop after recording the discovery.
 - OpenAPI scope: if porting the shared `utoipa` fragments requires pulling in
   Wildside-specific endpoint registration or application data transfer objects
   (DTOs), stop and narrow the extraction back to reusable schema fragments only.
@@ -192,15 +187,14 @@ paths without reaching into implementation details.
 ### Milestone 1: establish the crate surface and pagination foundation
 
 Create the `src/pagination/` module tree by porting the Wildside pagination
-crate into this repository. Copy the transport-neutral code from
-`../wildside/backend/crates/pagination/src/` with only the adjustments needed
-to satisfy this repository’s lint rules, file-size limits, and public API paths.
+crate into this repository. Copy the transport-neutral code from Wildside's
+`crates/pagination/src/` with only the adjustments needed to satisfy this
+repository’s lint rules, file-size limits, and public API paths.
 
 Port the pagination tests next. Start with the Wildside behaviour-driven
-development (BDD) coverage in
-`../wildside/backend/crates/pagination/tests/pagination_bdd.rs` and the
-associated `features/` files. If the BDD harness proves heavier than this crate
-needs, keep the behavioural assertions but collapse them into standard
+development (BDD) coverage in `crates/pagination/tests/pagination_bdd.rs` and
+the associated `features/` files. If the BDD harness proves heavier than this
+crate needs, keep the behavioural assertions but collapse them into standard
 integration tests only after preserving the exact behaviours: opaque cursor
 round-tripping, direction-aware cursor decoding, limit defaulting and clamping,
 zero-limit rejection, and next/prev/self link generation that preserves
@@ -239,9 +233,9 @@ possible even if the full domain service remains application-specific.
 
 ### Milestone 3: extract the common API error envelope and Actix responders
 
-Create the shared error payload from `../wildside/backend/src/domain/error.rs`
-and the Actix mapping layer from
-`../wildside/backend/src/inbound/http/error.rs`. Keep the split explicit:
+Create the shared error payload from Wildside's `src/domain/error.rs` and the
+Actix mapping layer from Wildside's `src/inbound/http/error.rs`. Keep the split
+explicit:
 
 - a transport-agnostic error payload type and code enum;
 - an Actix adapter that maps codes to HTTP status codes, inserts any trace
@@ -266,10 +260,9 @@ Wildside:
 Do not port Wildside-specific endpoint registration from `src/doc.rs`; this
 crate should export fragments, not a complete application document.
 
-Copy or adapt the relevant tests from
-`../wildside/backend/tests/openapi_schemas_bdd.rs` so they verify the fragment
-schema names and JSON field constraints without depending on Wildside's full
-route set.
+Copy or adapt the relevant tests from Wildside's `tests/openapi_schemas_bdd.rs`
+so they verify the fragment schema names and JSON field constraints without
+depending on Wildside's full route set.
 
 ### Milestone 5: resolve the SSE helper question explicitly
 
@@ -278,11 +271,11 @@ already documents replay-aware SSE expectations, begin the SSE work by writing
 or confirming an ADR in this repository. The initial draft is expected to live
 at `docs/adr-001-shared-sse-wire-contract-for-wildside-and-corbusier.md`.
 
-Run one focused implementation-time discovery pass against
-`../wildside/backend` for reusable SSE code. The planning investigation did not
-confirm any helper module for event identifier formatting, replay cursor
-extraction from `Last-Event-ID`, cache-control defaults for event streams, or
-heartbeat policy formatting. Only WebSocket heartbeat logic was found.
+Run one focused implementation-time discovery pass against Wildside for
+reusable SSE code. The planning investigation did not confirm any helper module
+for event identifier formatting, replay cursor extraction from `Last-Event-ID`,
+cache-control defaults for event streams, or heartbeat policy formatting. Only
+WebSocket heartbeat logic was found.
 
 If a true SSE helper source is found during implementation, extract it into
 `src/http/sse.rs` with tests that prove:
@@ -301,10 +294,10 @@ source-independent implementation pass.
 
 Before marking the implementation complete, do one final documentation pass to
 remove machine-specific and checkout-specific paths from the finished
-deliverables. During planning, it is acceptable to refer to
-`../wildside/backend` and the canonical upstream Corbusier repository because
-they identify the local source material, but the completed implementation
-should not leave those paths as normative references in public-facing docs.
+deliverables. During planning, it was acceptable to refer to a local Wildside
+checkout and the canonical upstream Corbusier repository because they
+identified the source material, but the completed implementation should not
+leave those paths as normative references in public-facing docs.
 
 This clean-up pass should cover at least the README, `docs/contents.md`, the
 SSE ADR, and this execplan. Replace environment-specific references with:
@@ -314,8 +307,7 @@ SSE ADR, and this execplan. Replace environment-specific references with:
   repository; or
 - short prose descriptions when neither a URL nor a path is required.
 
-This milestone is complete when a final
-`rg -n "/data/leynos/Projects|\\.\\./wildside/backend"` sweep over the finished
+This milestone is complete when a final path sweep over the finished
 documentation set shows no environment-specific paths outside deliberate
 historical notes that are clearly marked as planning-time context.
 
@@ -363,12 +355,12 @@ Implementation must not begin until the following gates are satisfied:
   `import-components-from-wildside` and created the required execplan path.
 - [x] 2026-04-02 08:16 BST: inspected `actix-v2a` and confirmed the repository
   is currently a stub crate with no existing shared API modules.
-- [x] 2026-04-02 08:16 BST: inspected `../wildside/backend` and mapped the
+- [x] 2026-04-02 08:16 BST: inspected a local Wildside checkout and mapped the
   concrete pagination, idempotency, error, and OpenAPI source files relevant to
   extraction.
 - [x] 2026-04-02 08:16 BST: recorded the canonical upstream note that Wildside
-  is hosted at `https://github.com/leynos/wildside` while local development
-  should inspect `../wildside/backend`.
+  is hosted at `https://github.com/leynos/wildside`, with source paths in this
+  completed plan written relative to that repository.
 - [x] 2026-04-02 08:24 BST: inspected Corbusier planning documents and
   confirmed they already require replay-aware SSE semantics with
   `Last-Event-ID`, making an ADR necessary if `actix-v2a` is to host shared SSE
@@ -410,6 +402,13 @@ Implementation must not begin until the following gates are satisfied:
   `make test` for the idempotency, error, and OpenAPI milestone. The first
   `make test` run for this slice again paid a cold-cache compile cost because
   `cargo nextest` had to build the newly added Actix and `utoipa` dependencies.
+- [x] 2026-05-20 CEST: started roadmap task 1.2.2 to close the SSE
+  documentation loop and execute the environment-specific path scrub required
+  by Milestone 6.
+- [x] 2026-05-20 CEST: normalized Wildside provenance to canonical upstream
+  wording and repository-relative paths, updated ADR 001 and the documentation
+  contents index, and removed the stale absolute worktree path from the
+  pagination hardening execplan.
 - [ ] During implementation, keep this section updated after each milestone and
   after every gate run.
 
@@ -450,9 +449,8 @@ Implementation must not begin until the following gates are satisfied:
 - 2026-04-02 08:35 BST: the user confirmed that `utoipa` schemas are in
   scope, so Milestone 4 now assumes shared schema fragment extraction rather
   than treating OpenAPI parity as an open decision.
-- 2026-04-02 08:16 BST: the SSE item remains unresolved because the planning
-  investigation did not find authoritative reusable SSE code in
-  `../wildside/backend`.
+- 2026-04-02 08:16 BST: the SSE item remained unresolved because the planning
+  investigation did not find authoritative reusable SSE code in Wildside.
 - 2026-04-02 08:24 BST: because Corbusier already depends on replay-aware SSE
   semantics, the absence of reusable Wildside SSE code makes an ADR necessary
   rather than optional.
@@ -460,6 +458,10 @@ Implementation must not begin until the following gates are satisfied:
   replace environment-specific local paths in the finished docs with canonical
   upstream URLs, repository-relative references, or plain-language provenance
   notes.
+- 2026-05-20: roadmap task 1.2.2 normalized this completed plan's provenance
+  wording: canonical upstream URLs identify external projects,
+  repository-relative paths identify files inside those projects or this crate,
+  and no local checkout path remains as normative documentation.
 - 2026-04-02 11:37 BST: Milestone 1 kept the Wildside pagination crate
   structure mostly intact, but the public examples, crate exports, and BDD test
   harness were adapted to `actix-v2a` and this repository's lint policy.

--- a/docs/execplans/import-components-from-wildside.md
+++ b/docs/execplans/import-components-from-wildside.md
@@ -1,9 +1,8 @@
 # Import shared HTTP primitives from Wildside
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. Keep `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` up to date as work proceeds.
 
 Status: COMPLETE
 

--- a/docs/execplans/import-components-from-wildside.md
+++ b/docs/execplans/import-components-from-wildside.md
@@ -4,7 +4,7 @@ This ExecPlan (execution plan) is a living document. The sections `Constraints`,
  `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
 and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: IN PROGRESS
+Status: COMPLETE
 
 ## Purpose / big picture
 
@@ -409,8 +409,14 @@ Implementation must not begin until the following gates are satisfied:
   wording and repository-relative paths, updated ADR 001 and the documentation
   contents index, and removed the stale absolute worktree path from the
   pagination hardening execplan.
-- [ ] During implementation, keep this section updated after each milestone and
-  after every gate run.
+- [x] 2026-05-20 CEST: passed the final documentation closure gates for
+  roadmap task 1.2.2: `make fmt`, `make markdownlint`, `make nixie`,
+  `make check-fmt`, `make lint`, and `make test`, with logs captured under
+  `/tmp` using the 1.2.2 branch name.
+- [x] 2026-05-20 CEST: marked this import plan complete after the SSE helper
+  sequence from roadmap tasks 1.1.1 through 1.2.1 had landed, the
+  implementation-time path scrub had no remaining hits, and roadmap task 1.2.2
+  was marked done.
 
 ## Surprises & Discoveries
 
@@ -475,18 +481,21 @@ Implementation must not begin until the following gates are satisfied:
 Milestone 1 shipped the pagination foundation, Milestone 2 shipped the
 idempotency primitives and HTTP helpers, Milestone 3 shipped the shared error
 envelope plus Actix adapter, and Milestone 4 shipped the reusable `utoipa`
-schema fragments. Milestone 5 was deferred because the Wildside source review
-did not uncover an authoritative SSE helper to extract, while Milestone 6
-shipped as part of the documentation clean-up that removed machine-local
-references from the finished docs.
+schema fragments. Milestone 5 produced ADR 001 and the later roadmap sequence
+from 1.1.1 through 1.2.1 shipped the shared SSE wire helpers and their
+contract-proof coverage. Milestone 6 closed in roadmap task 1.2.2 by removing
+machine-local and sibling-checkout paths from the finished documentation set
+and recording the completed SSE milestone.
 
 Final gate outcomes for this implementation pass were green for the Rust gates (
  `make check-fmt`, `make lint`, and `make test`) and green for the
-documentation gates (`make markdownlint` and `make nixie`) after the final doc
-updates landed.
+documentation gates (`make fmt`, `make markdownlint`, and `make nixie`) after
+the final documentation updates landed. `coderabbit review --agent` also
+reported zero findings for the closure milestone before the roadmap was marked
+done.
 
 Lessons learned: Wildside's pagination crate transferred cleanly because it was
 already transport-neutral; the shared error and OpenAPI surfaces needed tighter
 test coverage around external contracts than the initial import suggested; and
-SSE reuse should stay contract-first until there is source-backed helper code
-to extract.
+SSE reuse benefits from a contract-first path when there is no source-backed
+helper code to extract.

--- a/docs/execplans/import-components-from-wildside.md
+++ b/docs/execplans/import-components-from-wildside.md
@@ -1,8 +1,9 @@
 # Import shared HTTP primitives from Wildside
 
-This ExecPlan (execution plan) is a living document. The sections `Constraints`,
- `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
-and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
 
 Status: COMPLETE
 

--- a/docs/execplans/import-components-from-wildside.md
+++ b/docs/execplans/import-components-from-wildside.md
@@ -9,10 +9,10 @@ Status: COMPLETE
 ## Purpose / big picture
 
 `actix-v2a` began as a stub library entrypoint, while the canonical Wildside
-upstream repository at `https://github.com/leynos/wildside` already carried
-working implementations for cursor pagination, idempotency helpers, a shared
-JSON error envelope, and OpenAPI schema wrappers around that envelope. The goal
-of this plan was to extract the reusable parts of those features into
+upstream repository at `https://github.com/example-org/wildside` already
+carried working implementations for cursor pagination, idempotency helpers, a
+shared JSON error envelope, and OpenAPI schema wrappers around that envelope.
+The goal of this plan was to extract the reusable parts of those features into
 `actix-v2a` so this repository becomes the common home for version 2a Actix
 components instead of each application re-implementing them.
 
@@ -72,7 +72,7 @@ handling in Wildside's `src/inbound/ws/session.rs`, which was useful as design
 inspiration but was not itself an SSE helper that could be imported verbatim.
 
 Corbusier already has documented SSE expectations in the canonical upstream
-repository `https://github.com/leynos/corbusier`, especially in
+repository `https://github.com/example-org/corbusier`, especially in
 `docs/corbusier-api-design.md` where `Last-Event-ID`, replay-aware
 reconnection, global event streams, and explicit event identifiers are all part
 of the planned application contract.
@@ -359,8 +359,8 @@ Implementation must not begin until the following gates are satisfied:
   concrete pagination, idempotency, error, and OpenAPI source files relevant to
   extraction.
 - [x] 2026-04-02 08:16 BST: recorded the canonical upstream note that Wildside
-  is hosted at `https://github.com/leynos/wildside`, with source paths in this
-  completed plan written relative to that repository.
+  is hosted at `https://github.com/example-org/wildside`, with source paths in
+  this completed plan written relative to that repository.
 - [x] 2026-04-02 08:24 BST: inspected Corbusier planning documents and
   confirmed they already require replay-aware SSE semantics with
   `Last-Event-ID`, making an ADR necessary if `actix-v2a` is to host shared SSE

--- a/docs/execplans/import-components-from-wildside.md
+++ b/docs/execplans/import-components-from-wildside.md
@@ -1,9 +1,8 @@
 # Import shared HTTP primitives from Wildside
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+ `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: IN PROGRESS
 
@@ -72,8 +71,8 @@ The Wildside source surface relevant to this plan is:
   `../wildside/backend/tests/openapi_schemas_bdd.rs`.
 
 No dedicated SSE helper module has been confirmed in this Wildside checkout.
-The only nearby source found during planning was WebSocket heartbeat handling
-in `../wildside/backend/src/inbound/ws/session.rs`, which is useful as design
+The only nearby source found during planning was WebSocket heartbeat handling in
+ `../wildside/backend/src/inbound/ws/session.rs`, which is useful as design
 inspiration but is not itself an SSE helper that can be imported verbatim.
 
 Corbusier already has documented SSE expectations in the canonical upstream
@@ -400,8 +399,8 @@ Implementation must not begin until the following gates are satisfied:
   discrimination, replay/conflict record types, and HTTP header helpers into
   `src/idempotency/`.
 - [x] 2026-04-02 12:35 BST: completed Milestone 3 by adding a transport-agnostic
-  shared API error envelope in `src/error.rs` plus an Actix responder adapter
-  in `src/http/error.rs` with status mapping, trace identifier propagation, and
+  shared API error envelope in `src/error.rs` plus an Actix responder adapter in
+   `src/http/error.rs` with status mapping, trace identifier propagation, and
   internal error redaction.
 - [x] 2026-04-02 12:35 BST: completed Milestone 4 by adding reusable `utoipa`
   schema fragments in `src/openapi/schemas.rs` and BDD coverage that verifies
@@ -479,8 +478,8 @@ did not uncover an authoritative SSE helper to extract, while Milestone 6
 shipped as part of the documentation clean-up that removed machine-local
 references from the finished docs.
 
-Final gate outcomes for this implementation pass were green for the Rust gates
-(`make check-fmt`, `make lint`, and `make test`) and green for the
+Final gate outcomes for this implementation pass were green for the Rust gates (
+ `make check-fmt`, `make lint`, and `make test`) and green for the
 documentation gates (`make markdownlint` and `make nixie`) after the final doc
 updates landed.
 

--- a/docs/execplans/import-components-from-wildside.md
+++ b/docs/execplans/import-components-from-wildside.md
@@ -78,9 +78,10 @@ reconnection, global event streams, and explicit event identifiers are all part
 of the planned application contract.
 
 For SSE specifically, this execplan owns delivery sequencing, extraction
-boundaries, and gates. The normative shared SSE wire contract belongs in the
-[Architectural decision record (ADR) 001](../adr-001-shared-sse-wire-contract-for-wildside-and-corbusier.md),
- which must stay authoritative if the two documents ever diverge.
+boundaries, and gates. The normative shared SSE wire contract belongs in [ADR
+001][adr-001], which must stay authoritative if the two documents ever diverge.
+
+[adr-001]: ../adr-001-shared-sse-wire-contract-for-wildside-and-corbusier.md
 
 ## Constraints
 

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -1,20 +1,19 @@
 # Port Wildside pagination documentation hardening
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+ `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETE
 
 ## Purpose / big picture
 
-Wildside commit `9d6b7655e3ad1a666a0e96beebd0a27b0d139388` published
-stronger pagination documentation, documentation-invariant tests, and several
-related test cleanups. `actix-v2a` already contains the shared pagination
-primitives imported from Wildside, but its local documentation and tests do not
-yet carry the full ordering, limit, error-mapping, and scope-boundary guidance
-from that later Wildside commit.
+Wildside commit `9d6b7655e3ad1a666a0e96beebd0a27b0d139388` published stronger
+pagination documentation, documentation-invariant tests, and several related
+test cleanups. `actix-v2a` already contains the shared pagination primitives
+imported from Wildside, but its local documentation and tests do not yet carry
+the full ordering, limit, error-mapping, and scope-boundary guidance from that
+later Wildside commit.
 
 The goal is to port the parts of that commit that improve the reusable
 `actix-v2a` library without importing Wildside application code. Success is
@@ -33,9 +32,8 @@ began after user approval.
   Wildside domain, repository, route, or service concepts.
 - Preserve the current public pagination API unless the user approves a public
   API change. The existing surface includes `Cursor`, `CursorError`,
-  `Direction`, `PageParams`, `PageParamsError`, `Paginated`,
-  `PaginationLinks`, `DEFAULT_LIMIT`, `MAX_LIMIT`, `PAGE_PARAM_LIMIT`, and
-  `PAGE_PARAM_CURSOR`.
+  `Direction`, `PageParams`, `PageParamsError`, `Paginated`, `PaginationLinks`,
+  `DEFAULT_LIMIT`, `MAX_LIMIT`, `PAGE_PARAM_LIMIT`, and `PAGE_PARAM_CURSOR`.
 - Do not add new runtime dependencies without approval. The current crate
   already has `base64`, `serde`, `serde_json`, `thiserror`, `url`, `utoipa`,
   `rstest`, and `rstest-bdd`, which are enough for the planned port.
@@ -77,35 +75,29 @@ began after user approval.
 ## Risks
 
 - Risk: Wildside's error-mapping table names envelope codes that do not exist
-  in `actix-v2a`.
-  Severity: medium.
-  Likelihood: high.
-  Mitigation: port the client-versus-server classification, not the literal
-  code strings. Document `CursorError::InvalidBase64`,
-  `CursorError::Deserialize`, `CursorError::TokenTooLong`, and
-  `PageParamsError::InvalidLimit` as `ErrorCode::InvalidRequest`, and
-  `CursorError::Serialize` as `ErrorCode::InternalError`.
+  in `actix-v2a`. Severity: medium. Likelihood: high. Mitigation: port the
+  client-versus-server classification, not the literal code strings. Document
+  `CursorError::InvalidBase64`, `CursorError::Deserialize`,
+  `CursorError::TokenTooLong`, and `PageParamsError::InvalidLimit` as
+  `ErrorCode::InvalidRequest`, and `CursorError::Serialize` as
+  `ErrorCode::InternalError`.
 
 - Risk: The upstream commit contains many non-pagination test and domain
-  refactors that are tempting but not suitable for this library.
-  Severity: medium.
-  Likelihood: high.
-  Mitigation: limit implementation to pagination docs, pagination tests,
-  documentation-invariant tests, and directly relevant guide updates.
+  refactors that are tempting but not suitable for this library. Severity:
+  medium. Likelihood: high. Mitigation: limit implementation to pagination
+  docs, pagination tests, documentation-invariant tests, and directly relevant
+  guide updates.
 
 - Risk: Adding a shared BDD fixture module could duplicate too much of the
-  existing `tests/pagination_bdd.rs` setup.
-  Severity: low.
-  Likelihood: medium.
+  existing `tests/pagination_bdd.rs` setup. Severity: low. Likelihood: medium.
   Mitigation: extract only the state and helper functions that are needed by
   both existing pagination scenarios and the new documentation scenarios.
 
 - Risk: Markdown formatting and Rustdoc examples can fail after prose changes.
-  Severity: medium.
-  Likelihood: medium.
-  Mitigation: run `make fmt`, `make markdownlint`, `make nixie`, `make lint`,
-  and `make test`, and keep examples executable unless they intentionally
-  demonstrate pseudocode or endpoint-local integration.
+  Severity: medium. Likelihood: medium. Mitigation: run `make fmt`,
+  `make markdownlint`, `make nixie`, `make lint`, and `make test`, and keep
+  examples executable unless they intentionally demonstrate pseudocode or
+  endpoint-local integration.
 
 ## Progress
 
@@ -213,151 +205,135 @@ began after user approval.
 
 - Observation: `actix-v2a` already contains the imported pagination foundation,
   including direction-aware cursors, `PageParams` normalization, and
-  `PaginationLinks::from_request`.
-  Evidence: `src/pagination/mod.rs`, `src/pagination/cursor.rs`,
-  `src/pagination/params.rs`, `src/pagination/envelope.rs`, and
-  `tests/pagination_bdd.rs` already cover these behaviours.
-  Impact: The port should harden documentation and coverage, not re-import the
-  pagination implementation.
+  `PaginationLinks::from_request`. Evidence: `src/pagination/mod.rs`,
+  `src/pagination/cursor.rs`, `src/pagination/params.rs`,
+  `src/pagination/envelope.rs`, and `tests/pagination_bdd.rs` already cover
+  these behaviours. Impact: The port should harden documentation and coverage,
+  not re-import the pagination implementation.
 
 - Observation: Wildside commit `9d6b7655` changed 71 files, but most changes
   are Wildside-specific domain, adapter, example-data, and script fixes.
   Evidence: `git show --stat 9d6b7655` lists broad backend modules such as
   catalogue, offline bundles, Overpass enrichment, users, WebSocket sessions,
-  `bun.lock`, and example-data generator modules.
-  Impact: These are excluded from the `actix-v2a` port unless a later user
-  request asks for a separate test-fixture refactor.
+  `bun.lock`, and example-data generator modules. Impact: These are excluded
+  from the `actix-v2a` port unless a later user request asks for a separate
+  test-fixture refactor.
 
 - Observation: Wildside's pagination documentation says OpenAPI schema
   generation is out of scope for its standalone pagination crate, while
   `actix-v2a` already has reusable `utoipa` schema fragments for other shared
-  envelopes.
-  Evidence: Wildside `backend/crates/pagination/src/lib.rs` documents OpenAPI
-  schema generation as a consumer responsibility; local
+  envelopes. Evidence: Wildside `backend/crates/pagination/src/lib.rs`
+  documents OpenAPI schema generation as a consumer responsibility; local
   `src/openapi/schemas.rs` contains `ErrorCodeSchema`, `ErrorSchema`, and
-  `ReplayMetadataSchema` only.
-  Impact: The plan should document endpoint-local pagination query parameters
-  rather than introduce a new reusable pagination OpenAPI schema by default.
+  `ReplayMetadataSchema` only. Impact: The plan should document endpoint-local
+  pagination query parameters rather than introduce a new reusable pagination
+  OpenAPI schema by default.
 
 - Observation: `make fmt` is not fully runnable in this environment because
-  `mdformat-all` is missing.
-  Evidence: `/tmp/fmt-actix-v2a-feat-portwildsidepagination.out` records
+  `mdformat-all` is missing. Evidence:
+  `/tmp/fmt-actix-v2a-feat-portwildsidepagination.out` records
   `make: mdformat-all: No such file or directory` after
-  `cargo +nightly fmt --all` completed.
-  Impact: The planning commit can still be gated by `make check-fmt`,
-  `make markdownlint`, and `make nixie`, but the implementation phase should
-  either install `mdformat-all` or record the same environmental limitation.
+  `cargo +nightly fmt --all` completed. Impact: The planning commit can still
+  be gated by `make check-fmt`, `make markdownlint`, and `make nixie`, but the
+  implementation phase should either install `mdformat-all` or record the same
+  environmental limitation.
 
 - Observation: Adding a pagination "Error mapping" heading to
   `docs/users-guide.md` conflicted with the existing SSE "Error mapping"
-  heading under Markdown lint's duplicate-heading rule.
-  Evidence: `make markdownlint` reported `MD024/no-duplicate-heading` for
-  `docs/users-guide.md`.
-  Impact: The pagination heading was renamed to "Pagination error mapping",
-  preserving the intended content while keeping the guide lint-clean.
+  heading under Markdown lint's duplicate-heading rule. Evidence:
+  `make markdownlint` reported `MD024/no-duplicate-heading` for
+  `docs/users-guide.md`. Impact: The pagination heading was renamed to
+  "Pagination error mapping", preserving the intended content while keeping the
+  guide lint-clean.
 
 - Observation: A self-contained documentation-invariant BDD suite avoided
   pushing the existing `tests/pagination_bdd.rs` file over the repository's
-  400-line limit.
-  Evidence: `tests/pagination_bdd.rs` was already 367 lines before Stage B, and
-  the new scenarios fit cleanly in `tests/pagination_documentation_bdd.rs`.
-  Impact: No shared fixture extraction was needed for this port, keeping the
-  change smaller than the optional common-fixture path in the plan.
+  400-line limit. Evidence: `tests/pagination_bdd.rs` was already 367 lines
+  before Stage B, and the new scenarios fit cleanly in
+  `tests/pagination_documentation_bdd.rs`. Impact: No shared fixture extraction
+  was needed for this port, keeping the change smaller than the optional
+  common-fixture path in the plan.
 
 - Observation: The first isolated run of the new BDD suite caught a borrowed
   `Err(...)` comparison and a macro-expanded unused-braces warning in the
-  `world` fixture.
-  Evidence: `cargo test --test pagination_documentation_bdd` failed before
-  those local issues were fixed, then passed after the targeted correction.
-  Impact: The focused red/green run validated the new suite before the full
-  repository gates.
+  `world` fixture. Evidence: `cargo test --test pagination_documentation_bdd`
+  failed before those local issues were fixed, then passed after the targeted
+  correction. Impact: The focused red/green run validated the new suite before
+  the full repository gates.
 
 - Observation: The post-turn hook runs with a reduced `PATH` that did not
-  include the existing Cargo installation directory.
-  Evidence: The hook reported `make: cargo: No such file or directory` while
-  running `make check-fmt lint`; `env PATH=/usr/bin:/bin make check-fmt lint`
-  reproduced the same environment shape.
-  Impact: The Makefile now prepends `$HOME/.cargo/bin` to Cargo recipe `PATH`
-  values, while continuing to call `cargo` by name. No shim, install step, or
-  recreated system script was introduced.
+  include the existing Cargo installation directory. Evidence: The hook reported
+   `make: cargo: No such file or directory` while running `make check-fmt lint`;
+   `env PATH=/usr/bin:/bin make check-fmt lint` reproduced the same environment
+  shape. Impact: The Makefile now prepends `$HOME/.cargo/bin` to Cargo recipe
+  `PATH` values, while continuing to call `cargo` by name. No shim, install
+  step, or recreated system script was introduced.
 
 - Observation: The original user-guide pagination example parsed
   `req.uri().to_string()` directly, but Actix request URIs are usually relative
-  paths.
-  Evidence: Code review noted that `Url::parse` expects an absolute URL for
-  this use, so the example would normally fail at runtime.
-  Impact: The example now combines Actix connection information with
-  `path_and_query()` before parsing the URL used for pagination links.
+  paths. Evidence: Code review noted that `Url::parse` expects an absolute URL
+  for this use, so the example would normally fail at runtime. Impact: The
+  example now combines Actix connection information with `path_and_query()`
+  before parsing the URL used for pagination links.
 
 - Observation: Checking `CursorError` display text made the documentation BDD
-  coverage sensitive to wording-only changes.
-  Evidence: Code review highlighted that substring checks were too tightly
-  coupled to error message prose.
+  coverage sensitive to wording-only changes. Evidence: Code review highlighted
+  that substring checks were too tightly coupled to error message prose.
   Impact: The BDD step now asserts the documented variants and structured
   fields instead of matching display strings.
 
 - Observation: The stricter lint toolchain now detects `expect` in helper
   functions that are compiled only for tests, but are not themselves test
-  functions.
-  Evidence: `make lint` reported `no_expect_outside_tests` for helper
-  functions in `src/http/error.rs`, `src/openapi/schemas.rs`, and
-  `src/pagination/cursor.rs`.
-  Impact: Those helpers now return `Result` where they perform fallible work,
-  and the actual test functions keep the assertion and failure-message
-  responsibility.
+  functions. Evidence: `make lint` reported `no_expect_outside_tests` for
+  helper functions in `src/http/error.rs`, `src/openapi/schemas.rs`, and
+  `src/pagination/cursor.rs`. Impact: Those helpers now return `Result` where
+  they perform fallible work, and the actual test functions keep the assertion
+  and failure-message responsibility.
 
 ## Decision Log
 
 - Decision: Treat this as a documentation and test hardening port, not an
-  implementation import.
-  Rationale: The implementation was already imported by
+  implementation import. Rationale: The implementation was already imported by
   `docs/execplans/import-components-from-wildside.md`; the later Wildside
-  commit mainly improves crate-level explanation and verification.
-  Date/Author: 2026-04-26 23:31Z / Codex.
+  commit mainly improves crate-level explanation and verification. Date/Author:
+  2026-04-26 23:31Z / Codex.
 
 - Decision: Exclude Wildside domain, example-data, Bun/script, and broad
-  backend test-fixture changes from this port.
-  Rationale: Those changes target Wildside's application architecture and do
-  not map cleanly to a small shared Actix helper library.
-  Date/Author: 2026-04-26 23:31Z / Codex.
+  backend test-fixture changes from this port. Rationale: Those changes target
+  Wildside's application architecture and do not map cleanly to a small shared
+  Actix helper library. Date/Author: 2026-04-26 23:31Z / Codex.
 
 - Decision: Adapt Wildside's error-mapping guidance to `actix-v2a`'s current
-  `ErrorCode` enum.
-  Rationale: Porting literal `invalid_cursor` or `invalid_page_params` codes
-  would require public API changes and contradict this plan's compatibility
-  constraint.
-  Date/Author: 2026-04-26 23:31Z / Codex.
+  `ErrorCode` enum. Rationale: Porting literal `invalid_cursor` or
+  `invalid_page_params` codes would require public API changes and contradict
+  this plan's compatibility constraint. Date/Author: 2026-04-26 23:31Z / Codex.
 
 - Decision: Document endpoint-local `utoipa::path` query parameters in the user
-  guide instead of adding reusable pagination schema wrappers.
-  Rationale: The plan's compatibility constraint forbids public API expansion
-  without approval, and pagination response schemata depend on each endpoint's
-  concrete item type.
-  Date/Author: 2026-04-27 00:46Z / Codex.
+  guide instead of adding reusable pagination schema wrappers. Rationale: The
+  plan's compatibility constraint forbids public API expansion without
+  approval, and pagination response schemata depend on each endpoint's concrete
+  item type. Date/Author: 2026-04-27 00:46Z / Codex.
 
 - Decision: Keep the documentation-invariant BDD suite self-contained rather
-  than extracting shared pagination BDD fixtures.
-  Rationale: The existing pagination BDD file was already near the line-count
-  limit, and the new suite needed only small state and helper functions.
-  Date/Author: 2026-04-27 00:52Z / Codex.
+  than extracting shared pagination BDD fixtures. Rationale: The existing
+  pagination BDD file was already near the line-count limit, and the new suite
+  needed only small state and helper functions. Date/Author: 2026-04-27 00:52Z
+  / Codex.
 
 - Decision: Make Cargo discovery recipe-local, not global, in the Makefile.
   Rationale: The hook needed the existing Cargo binary directory on `PATH`, but
   the repository should still call `cargo` directly and avoid shims or
-  generated wrapper scripts.
-  Date/Author: 2026-04-27 01:00Z / Codex.
+  generated wrapper scripts. Date/Author: 2026-04-27 01:00Z / Codex.
 
 - Decision: Use Actix connection information for the user-guide pagination URL
-  example.
-  Rationale: `PaginationLinks::from_request` needs an absolute `Url`, while
-  `HttpRequest::uri()` is commonly relative. Combining scheme, host, and
-  `path_and_query()` documents a runtime-valid pattern.
-  Date/Author: 2026-04-27 01:54Z / Codex.
+  example. Rationale: `PaginationLinks::from_request` needs an absolute `Url`,
+  while `HttpRequest::uri()` is commonly relative. Combining scheme, host, and
+  `path_and_query()` documents a runtime-valid pattern. Date/Author: 2026-04-27
+  01:54Z / Codex.
 
 - Decision: Keep documentation-invariant tests structural.
   Rationale: The purpose is to verify documented error classes, not freeze
-  human-facing error wording.
-  Date/Author: 2026-04-27 01:54Z / Codex.
+  human-facing error wording. Date/Author: 2026-04-27 01:54Z / Codex.
 
 - Decision: Fix the lint-exposed test helpers without adding suppressions.
   Rationale: Returning `Result` from helpers keeps failure causes structured
@@ -377,8 +353,8 @@ The implementation deliberately did not add public API, new dependencies, or
 Wildside application-specific code. Full validation passed with
 `make check-fmt`, `make lint`, `make test`, `make markdownlint`, and
 `make nixie`. `make fmt` remains partially blocked in this environment because
-`mdformat-all` is not installed, but `cargo fmt --all` and
-`make check-fmt` both succeeded.
+`mdformat-all` is not installed, but `cargo fmt --all` and `make check-fmt`
+both succeeded.
 
 After completion, the post-turn hook exposed a reduced-`PATH` environment that
 could not find `cargo`. The Makefile now prepends the existing Cargo bin
@@ -392,19 +368,18 @@ constructs an absolute URL from Actix connection information, the
 documentation-invariant BDD test inspects `CursorError` variants and fields
 instead of message substrings, and uncommon acronyms are expanded on first use.
 The URL example was then tightened to show explicit `path_and_query()` handling
-instead of interpolating the full request URI.
-Later inline review findings were verified against the current code. The
-contents index now describes the plan as complete, the `Paginated<T>` OpenAPI
-sentence no longer has a comma before its "because" clause, and the URL example
-already builds an absolute URL before parsing.
-The remaining stale Stage B wording now describes documented cursor error
-variants and structured fields instead of display-string checks. The HTTP error
-test helper now decodes observed response values and leaves status and trace
-header assertions to the individual tests.
-The stricter lint run also exposed test helper `expect` calls; these were
-converted to fallible helpers and the review-response change passed
-`cargo test --test pagination_documentation_bdd`, `make check-fmt`,
-`make lint`, `make markdownlint`, and `make test`.
+instead of interpolating the full request URI. Later inline review findings
+were verified against the current code. The contents index now describes the
+plan as complete, the `Paginated<T>` OpenAPI sentence no longer has a comma
+before its "because" clause, and the URL example already builds an absolute URL
+before parsing. The remaining stale Stage B wording now describes documented
+cursor error variants and structured fields instead of display-string checks.
+The HTTP error test helper now decodes observed response values and leaves
+status and trace header assertions to the individual tests. The stricter lint
+run also exposed test helper `expect` calls; these were converted to fallible
+helpers and the review-response change passed
+`cargo test --test pagination_documentation_bdd`, `make check-fmt`, `make lint`,
+ `make markdownlint`, and `make test`.
 
 ## Context and orientation
 
@@ -463,26 +438,25 @@ limits, maximum limits, zero-limit rejection, invalid base64 cursor errors,
 invalid JSON cursor errors, token-too-long errors, and documented cursor error
 variants with their structured fields. Create
 `tests/pagination_documentation_bdd.rs` to implement those scenarios. If shared
-state duplication becomes material, create
-`tests/pagination_common.rs` or `tests/common/pagination.rs` and move only
-shared `World`, `FixtureKey`, and limit setup helpers there, then update
-`tests/pagination_bdd.rs` to use that helper module. Keep this extraction small
-and purely test-local.
+state duplication becomes material, create `tests/pagination_common.rs` or
+`tests/common/pagination.rs` and move only shared `World`, `FixtureKey`, and
+limit setup helpers there, then update `tests/pagination_bdd.rs` to use that
+helper module. Keep this extraction small and purely test-local.
 
 Stage C adds unit test hardening copied in spirit from Wildside. In
 `src/pagination/cursor.rs`, add a test-only key type whose `Serialize`
 implementation fails, then assert `Cursor::encode` returns
-`CursorError::Serialize` with a useful message. In
-`src/pagination/params.rs`, replace the single oversized-limit test with
-focused `rstest` cases showing `MAX_LIMIT - 1` passes through unchanged,
-`MAX_LIMIT` passes through unchanged, and values above `MAX_LIMIT` clamp to
-`MAX_LIMIT`. Keep existing zero-limit and deserialization coverage.
+`CursorError::Serialize` with a useful message. In `src/pagination/params.rs`,
+replace the single oversized-limit test with focused `rstest` cases showing
+`MAX_LIMIT - 1` passes through unchanged, `MAX_LIMIT` passes through unchanged,
+and values above `MAX_LIMIT` clamp to `MAX_LIMIT`. Keep existing zero-limit and
+deserialization coverage.
 
 Stage D validates and commits. Run formatting and quality gates sequentially
 with `tee` logs in `/tmp`, inspect failures from the logs, make only focused
-fixes, and commit the approved implementation with a file-based commit
-message. If Stage A through C require more scope than the tolerances allow,
-update this ExecPlan and stop for direction.
+fixes, and commit the approved implementation with a file-based commit message.
+If Stage A through C require more scope than the tolerances allow, update this
+ExecPlan and stop for direction.
 
 ## Concrete steps
 

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -471,7 +471,7 @@ git status --short
 Expected orientation:
 
 ```plaintext
-/home/leynos/.lody/repos/github---leynos---actix-v2a/worktrees/5e4b6a0b-5a00-4e8c-b862-6b6b7fe27926
+<actix-v2a worktree path>
 feat/portwildsidepagination
 ```
 

--- a/docs/migration-0-1-to-0-2.md
+++ b/docs/migration-0-1-to-0-2.md
@@ -26,7 +26,7 @@ The domain function `extract_replay_cursor` now accepts `&[SseHeader]` and is
 framework-independent. Actix Web callers must use `extract_actix_replay_cursor`
 from the same crate root.
 
----
+______________________________________________________________________
 
 ### `apply_event_stream_cache_control` - signature change
 

--- a/docs/netsuke-users-guide.md
+++ b/docs/netsuke-users-guide.md
@@ -4,7 +4,7 @@
 
 Netsuke is a modern, declarative build system designed to be intuitive, fast,
 and safe. Think of it not just as a `make` replacement, but as a **build system
-compiler**. You describe your build process in a human-readable YAML manifest (
+compiler**. The build process is described in a human-readable YAML manifest (
 `Netsukefile`), leveraging the power of Jinja templating for dynamic logic.
 Netsuke then compiles this high-level description into an optimized build plan
 executed by the high-performance [Ninja](https://ninja-build.org/ "null") build

--- a/docs/netsuke-users-guide.md
+++ b/docs/netsuke-users-guide.md
@@ -4,8 +4,8 @@
 
 Netsuke is a modern, declarative build system designed to be intuitive, fast,
 and safe. Think of it not just as a `make` replacement, but as a **build system
-compiler**. You describe your build process in a human-readable YAML manifest
-(`Netsukefile`), leveraging the power of Jinja templating for dynamic logic.
+compiler**. You describe your build process in a human-readable YAML manifest (
+`Netsukefile`), leveraging the power of Jinja templating for dynamic logic.
 Netsuke then compiles this high-level description into an optimized build plan
 executed by the high-performance [Ninja](https://ninja-build.org/ "null") build
 system.
@@ -381,8 +381,8 @@ Apply filters using the pipe `|` operator: `{{ value | filter_name(args...) }}`
 - `dirname`: `{{ 'path/to/file.txt' | dirname }}` -> `"path/to"`
 
 - `with_suffix(new_suffix, count=1, sep='.')`: Replaces the last `count`
-  dot-separated extensions. `{{ 'archive.tar.gz' | with_suffix('.zip', 2) }}`
-  -> `"archive.zip"`
+  dot-separated extensions. `{{ 'archive.tar.gz' | with_suffix('.zip', 2) }}` ->
+   `"archive.zip"`
 
 - `relative_to(base_path)`: Makes a path relative.
   `{{ '/a/b/c' | relative_to('/a/b') }}` -> `"c"`

--- a/docs/reliable-testing-in-rust-via-dependency-injection.md
+++ b/docs/reliable-testing-in-rust-via-dependency-injection.md
@@ -2,8 +2,8 @@
 
 Writing robust, reliable, and parallelizable tests requires an intentional
 approach to handling external dependencies such as environment variables, the
-filesystem, or the system clock. Functions that directly call `std::env::var`
-or `SystemTime::now()` are difficult to test because they depend on global,
+filesystem, or the system clock. Functions that directly call `std::env::var` or
+ `SystemTime::now()` are difficult to test because they depend on global,
 non-deterministic state.
 
 This leads to several problems:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -43,7 +43,7 @@ without pulling event-store, routing, or authorization logic into this crate.
     cache headers, heartbeat output, and `stream_reset` output.
   - Pass `make check-fmt`, `make lint`, and `make test` with the new coverage
     enabled.
-- [ ] 1.2.2. Update the execution plan and documentation after the SSE module
+- [x] 1.2.2. Update the execution plan and documentation after the SSE module
   lands. Requires 1.2.1.
   - Record the completed SSE milestone in
     `docs/execplans/import-components-from-wildside.md`.

--- a/docs/rust-doctest-dry-guide.md
+++ b/docs/rust-doctest-dry-guide.md
@@ -170,8 +170,8 @@ itself is a complete, well-behaved program.[^9]
 #### Solution 2: The implicit Result-returning main
 
 rustdoc provides a lesser-known but more concise shorthand for this exact
-scenario. If a code block ends with the literal token (()), rustdoc will
-automatically wrap the code in a main function that returns a Result.
+scenario. If a code block ends with `# Ok::<(), E>(())`, rustdoc will infer a
+`Result`-returning `main` without requiring you to write one explicitly.
 
 ```rust,no_run
 /// # Examples
@@ -179,14 +179,14 @@ automatically wrap the code in a main function that returns a Result.
 /// ```
 /// let config = "key=value".parse::<MyConfig>()?;
 /// assert_eq!(config.get("key"), Some("value"));
-/// (()) // Note: No whitespace between parentheses
+/// # Ok::<(), Box<dyn Error>>(())
 /// ```
 ```
 
 This is functionally equivalent to the explicit `main` but requires less
-boilerplate. However, it is critical that the `(())` be written as a single,
-contiguous sequence of characters, as `rustdoc`'s detection mechanism is purely
-textual and will not recognize `( () )`.[^3]
+boilerplate. The hidden `Ok::<(), E>(())` suffix is what tells `rustdoc` to
+treat the example as returning a `Result`; without it, the example uses the
+normal `fn main() -> ()` wrapper.[^3]
 
 ### 2.4 The power of hidden lines (`#`): creating clean examples
 

--- a/docs/rust-doctest-dry-guide.md
+++ b/docs/rust-doctest-dry-guide.md
@@ -170,8 +170,8 @@ itself is a complete, well-behaved program.[^9]
 #### Solution 2: The implicit Result-returning main
 
 rustdoc provides a lesser-known but more concise shorthand for this exact
-scenario. If a code block ends with `# Ok::<(), E>(())`, rustdoc will infer a
-`Result`-returning `main` without requiring you to write one explicitly.
+scenario. If a code block ends with the literal token (()), rustdoc will
+automatically wrap the code in a main function that returns a Result.
 
 ```rust,no_run
 /// # Examples
@@ -179,14 +179,14 @@ scenario. If a code block ends with `# Ok::<(), E>(())`, rustdoc will infer a
 /// ```
 /// let config = "key=value".parse::<MyConfig>()?;
 /// assert_eq!(config.get("key"), Some("value"));
-/// # Ok::<(), Box<dyn Error>>(())
+/// (()) // Note: No whitespace between parentheses
 /// ```
 ```
 
 This is functionally equivalent to the explicit `main` but requires less
-boilerplate. The hidden `Ok::<(), E>(())` suffix is what tells `rustdoc` to
-treat the example as returning a `Result`; without it, the example uses the
-normal `fn main() -> ()` wrapper.[^3]
+boilerplate. However, it is critical that the `(())` be written as a single,
+contiguous sequence of characters, as `rustdoc`'s detection mechanism is purely
+textual and will not recognize `( () )`.[^3]
 
 ### 2.4 The power of hidden lines (`#`): creating clean examples
 

--- a/docs/rust-doctest-dry-guide.md
+++ b/docs/rust-doctest-dry-guide.md
@@ -108,8 +108,9 @@ Doctests reside within documentation comments. Rust recognizes two types:
 denoted by triple back-ticks (```). While `rustdoc` defaults to Rust syntax,
 explicitly add the `rust` language specifier for clarity.[^3] A doctest
 "passes" when it compiles and runs without panicking. To assert specific
-outcomes, use the standard macros `assert!`, `assert_eq!`, and `assert_ne!`.[
-^3] <!-- markdownlint-enable MD013 -->
+outcomes, use the standard macros `assert!`, `assert_eq!`, and `assert_ne!`.
+Reference [^3] covers the underlying rustdoc behaviour.
+<!-- markdownlint-enable MD013 -->
 
 ### 2.2 The philosophy of a good example
 

--- a/docs/rust-doctest-dry-guide.md
+++ b/docs/rust-doctest-dry-guide.md
@@ -41,7 +41,7 @@ block found in the documentation comments[^3]:
 4. **Execution and Verification**: Finally, if compilation succeeds, the
    resulting executable is run. The test is considered to have passed if the
    program runs to completion without panicking. The executable is then
-   deleted.[^2]
+   deleted. [^2]
 
 The significance of this model cannot be overstated. It effectively transforms
 every doctest into a true integration test.[^6] The test code does not have
@@ -108,8 +108,8 @@ Doctests reside within documentation comments. Rust recognizes two types:
 denoted by triple back-ticks (```). While `rustdoc` defaults to Rust syntax,
 explicitly add the `rust` language specifier for clarity.[^3] A doctest
 "passes" when it compiles and runs without panicking. To assert specific
-outcomes, use the standard macros `assert!`, `assert_eq!`, and
-`assert_ne!`.[^3] <!-- markdownlint-enable MD013 -->
+outcomes, use the standard macros `assert!`, `assert_eq!`, and `assert_ne!`.[
+^3] <!-- markdownlint-enable MD013 -->
 
 ### 2.2 The philosophy of a good example
 
@@ -276,7 +276,7 @@ table provides a comparative reference for the most common doctest attributes.
 - `edition20xx`: This attribute allows an example to be tested against a
   specific Rust edition. This is important for crates that support multiple
   editions and need to demonstrate edition-specific features or migration
-  paths.[^4]
+  paths. [^4]
 
 ## The DRY principle in doctests: managing shared and complex logic
 
@@ -405,10 +405,10 @@ builds.[^13]
 pub struct UnixSocket;
 ```
 
-This `any` directive ensures the struct is compiled either when the target OS
-is `unix` OR when `rustdoc` is running. This correctly makes the item visible
-in the generated HTML. However, it is crucial to understand that this **does
-not** make the doctest for `UnixSocket` pass on non-Unix platforms.
+This `any` directive ensures the struct is compiled either when the target OS is
+ `unix` OR when `rustdoc` is running. This correctly makes the item visible in
+the generated HTML. However, it is crucial to understand that this **does not**
+make the doctest for `UnixSocket` pass on non-Unix platforms.
 
 This distinction highlights the "cfg duality." The `#[cfg(doc)]` attribute
 controls the *table of contents* of the documentation; it determines which

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -1362,7 +1362,7 @@ provided by `rstest`:
 <!-- markdownlint-disable MD013 -->
 | Attribute                  | Core Purpose                                                                                 |
 | -------------------------- | -------------------------------------------------------------------------------------------- |
-| #[rstest]                  | Marks a function as an rstest test; enables fixture injection and parameterization.          |
+| #[rstest]                  | Marks a function as a rstest test; enables fixture injection and parameterization.           |
 | #[fixture]                 | Defines a function that provides a test fixture (setup data or services).                    |
 | #[case(…)]                 | Defines a single parameterized test case with specific input values.                         |
 | #[values(…)]               | Defines a list of values for an argument, generating tests for each value or combination.    |

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -774,9 +774,10 @@ To improve the ergonomics of working with async fixtures and values in tests,
 
 - `#[future]`: When an async fixture, or an async block, is passed as an
   argument, its type is `impl Future<Output = T>`. The `#[future]` attribute on
-  argument allows developers to refer to it with type `T` directly in the test
-  signature, removing the `impl Future` boilerplate. However, the value still
-  needs to be `.await`ed explicitly within the test body or by using `#[awt]`.
+  an argument allows developers to refer to it with type `T` directly in the
+  test signature, removing the `impl Future` boilerplate. However, the value
+  still needs to be `.await`ed explicitly within the test body or by using
+  `#[awt]`.
 - `#[awt]` (or `#[future(awt)]`): This attribute, when applied to the entire
   test function (`#[awt]`) or a specific `#[future]` argument (
   `#[future(awt)]`), tells `rstest` to automatically insert `.await` calls for

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -728,8 +728,8 @@ async fn async_data_fetcher() -> String {
 ```
 
 The example above uses `async_std::task::sleep` purely as a convenient
-stand-in; the fixture may call into whichever runtime the project adopts
-because `rstest` simply awaits the returned future.
+stand-in; the fixture may call into whichever runtime the project adopts because
+ `rstest` simply awaits the returned future.
 
 ### B. Writing asynchronous tests (`async fn` with `#[rstest]`)
 
@@ -778,8 +778,8 @@ To improve the ergonomics of working with async fixtures and values in tests,
   signature, removing the `impl Future` boilerplate. However, the value still
   needs to be `.await`ed explicitly within the test body or by using `#[awt]`.
 - `#[awt]` (or `#[future(awt)]`): This attribute, when applied to the entire
-  test function (`#[awt]`) or a specific `#[future]` argument
-  (`#[future(awt)]`), tells `rstest` to automatically insert `.await` calls for
+  test function (`#[awt]`) or a specific `#[future]` argument (
+  `#[future(awt)]`), tells `rstest` to automatically insert `.await` calls for
   those futures.
 
 ```rust,no_run
@@ -1360,20 +1360,20 @@ provided by `rstest`:
 **Table 2:** Key `rstest` attributes quick reference
 
 <!-- markdownlint-disable MD013 -->
-| Attribute                    | Core Purpose                                                                                 |
-| ---------------------------- | -------------------------------------------------------------------------------------------- |
-| #[rstest]                    | Marks a function as an rstest test; enables fixture injection and parameterization.          |
-| #[fixture]                   | Defines a function that provides a test fixture (setup data or services).                    |
-| #[case(…)]                   | Defines a single parameterized test case with specific input values.                         |
-| #[values(…)]                 | Defines a list of values for an argument, generating tests for each value or combination.    |
-| #[once]                      | Marks a fixture to be initialized only once and shared (as a static reference) across tests. |
-| #[future]                    | Simplifies async argument types by removing impl Future boilerplate.                         |
-| #[awt]                       | (Function or argument level) Automatically .awaits future arguments in async tests.          |
-| #[from(original_name)]       | Allows renaming an injected fixture argument in the test function.                           |
-| #[with(…)]                   | Overrides default arguments of a fixture for a specific test.                                |
-| #[default(…)]                | Provides default values for arguments within a fixture function.                             |
-| #[timeout(…)]                | Sets a timeout for an asynchronous test.                                                     |
-| #[files("glob_pattern",…)]   | Injects file paths (or contents, with mode=) matching a glob pattern as test arguments.      |
+| Attribute                  | Core Purpose                                                                                 |
+| -------------------------- | -------------------------------------------------------------------------------------------- |
+| #[rstest]                  | Marks a function as an rstest test; enables fixture injection and parameterization.          |
+| #[fixture]                 | Defines a function that provides a test fixture (setup data or services).                    |
+| #[case(…)]                 | Defines a single parameterized test case with specific input values.                         |
+| #[values(…)]               | Defines a list of values for an argument, generating tests for each value or combination.    |
+| #[once]                    | Marks a fixture to be initialized only once and shared (as a static reference) across tests. |
+| #[future]                  | Simplifies async argument types by removing impl Future boilerplate.                         |
+| #[awt]                     | (Function or argument level) Automatically .awaits future arguments in async tests.          |
+| #[from(original_name)]     | Allows renaming an injected fixture argument in the test function.                           |
+| #[with(…)]                 | Overrides default arguments of a fixture for a specific test.                                |
+| #[default(…)]              | Provides default values for arguments within a fixture function.                             |
+| #[timeout(…)]              | Sets a timeout for an asynchronous test.                                                     |
+| #[files("glob_pattern",…)] | Injects file paths (or contents, with mode=) matching a glob pattern as test arguments.      |
 <!-- markdownlint-enable MD013 -->
 
 By mastering `rstest`, Rust developers can significantly elevate the quality

--- a/tests/sse_actix_adapter_wire_contract_tests.rs
+++ b/tests/sse_actix_adapter_wire_contract_tests.rs
@@ -1,0 +1,105 @@
+//! Crate-root Actix adapter wire-contract tests.
+
+use actix_v2a::{
+    EVENT_STREAM_CACHE_CONTROL,
+    LAST_EVENT_ID_HEADER,
+    apply_actix_event_stream_cache_control,
+    extract_actix_replay_cursor,
+};
+use actix_web::http::header::{CACHE_CONTROL, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
+
+#[test]
+fn documented_crate_root_actix_adapter_imports_match_wire_contract() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        HeaderName::from_bytes(LAST_EVENT_ID_HEADER.as_bytes())
+            .expect("LAST_EVENT_ID_HEADER should be a valid Actix header name"),
+        HeaderValue::from_static("evt-crate-root"),
+    );
+
+    apply_actix_event_stream_cache_control(&mut headers);
+    let replay_cursor = extract_actix_replay_cursor(&headers)
+        .expect("documented replay cursor import should parse");
+
+    assert_eq!(
+        headers
+            .get(CACHE_CONTROL)
+            .expect("cache-control header should be present"),
+        EVENT_STREAM_CACHE_CONTROL
+    );
+    assert_eq!(
+        replay_cursor
+            .expect("replay cursor should be present")
+            .as_ref(),
+        "evt-crate-root"
+    );
+}
+
+#[test]
+fn documented_crate_root_actix_adapter_import_rejects_non_utf8_cursor() {
+    let mut headers = HeaderMap::new();
+    let non_utf8_bytes = &[0xff, 0xfe, 0xfd];
+    #[expect(
+        unsafe_code,
+        reason = "Test needs to construct invalid UTF-8 header value"
+    )]
+    let header_value = unsafe { HeaderValue::from_maybe_shared_unchecked(non_utf8_bytes) };
+    headers.insert(
+        HeaderName::from_bytes(LAST_EVENT_ID_HEADER.as_bytes())
+            .expect("LAST_EVENT_ID_HEADER should be a valid Actix header name"),
+        header_value,
+    );
+
+    assert!(
+        extract_actix_replay_cursor(&headers).is_err(),
+        "documented crate-root import should reject non-UTF-8 Last-Event-ID values"
+    );
+}
+
+#[test]
+fn documented_crate_root_actix_adapter_import_returns_none_without_cursor() {
+    let headers = HeaderMap::new();
+
+    let replay_cursor = extract_actix_replay_cursor(&headers)
+        .expect("documented crate-root import should accept missing Last-Event-ID");
+
+    assert_eq!(replay_cursor, None);
+}
+
+#[test]
+fn documented_crate_root_actix_adapter_import_replaces_cache_policy() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        CACHE_CONTROL,
+        HeaderValue::from_static("public, max-age=60"),
+    );
+
+    apply_actix_event_stream_cache_control(&mut headers);
+
+    assert_eq!(
+        headers
+            .get(CACHE_CONTROL)
+            .expect("cache-control header should be present"),
+        EVENT_STREAM_CACHE_CONTROL
+    );
+}
+
+#[test]
+fn documented_crate_root_actix_adapter_import_preserves_unrelated_headers() {
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    headers.insert(
+        HeaderName::from_bytes(LAST_EVENT_ID_HEADER.as_bytes())
+            .expect("LAST_EVENT_ID_HEADER should be a valid Actix header name"),
+        HeaderValue::from_static("evt-crate-root"),
+    );
+
+    apply_actix_event_stream_cache_control(&mut headers);
+
+    assert_eq!(
+        headers
+            .get(CONTENT_TYPE)
+            .expect("content-type header should be present"),
+        "application/json"
+    );
+}

--- a/tests/sse_actix_adapter_wire_contract_tests.rs
+++ b/tests/sse_actix_adapter_wire_contract_tests.rs
@@ -1,4 +1,20 @@
 //! Crate-root Actix adapter wire-contract tests.
+//!
+//! These tests validate the four public symbols re-exported from the
+//! `actix_v2a` crate root for downstream Actix consumers:
+//! `EVENT_STREAM_CACHE_CONTROL`, `LAST_EVENT_ID_HEADER`,
+//! `apply_actix_event_stream_cache_control`, and `extract_actix_replay_cursor`.
+//! They use the published crate-root import paths rather than internal module
+//! paths.
+//!
+//! ADR 001 (`docs/adr-001-shared-sse-wire-contract-for-wildside-and-corbusier.md`)
+//! is the normative SSE wire contract. These tests verify that the crate-root
+//! adapter surface honours its header-transformation and
+//! replay-cursor-extraction semantics.
+//!
+//! Detailed validation-error permutations and frame-rendering rules are covered
+//! by module-level unit tests in `src/sse/`. This file focuses on the
+//! observable public API boundary.
 
 use actix_v2a::{
     EVENT_STREAM_CACHE_CONTROL,

--- a/tests/sse_actix_adapter_wire_contract_tests.rs
+++ b/tests/sse_actix_adapter_wire_contract_tests.rs
@@ -43,6 +43,11 @@ fn documented_crate_root_actix_adapter_import_rejects_non_utf8_cursor() {
         unsafe_code,
         reason = "Test needs to construct invalid UTF-8 header value"
     )]
+    // SAFETY: `HeaderValue::from_maybe_shared_unchecked(non_utf8_bytes)` is
+    // used here because this integration test must exercise the public
+    // adapter's non-UTF-8 header path, which safe constructors reject. The
+    // bytes are static, test-only raw header bytes with no null bytes and no
+    // invalid internal representation for this controlled `HeaderValue`.
     let header_value = unsafe { HeaderValue::from_maybe_shared_unchecked(non_utf8_bytes) };
     headers.insert(
         HeaderName::from_bytes(LAST_EVENT_ID_HEADER.as_bytes())

--- a/tests/sse_wire_contract_bdd.rs
+++ b/tests/sse_wire_contract_bdd.rs
@@ -29,6 +29,8 @@ mod sse_trace_buffer;
 
 use sse_trace_buffer::{LogBuffer, TracingGuard};
 
+type StepResult = Result<(), Box<dyn std::error::Error>>;
+
 #[derive(Debug, Default, ScenarioState)]
 struct World {
     actix_headers: Slot<HeaderMap>,
@@ -59,36 +61,29 @@ fn world() -> World {
 }
 
 #[given("a reconnect request with Last-Event-ID {event_id}")]
-fn a_reconnect_request_with_last_event_id(world: &World, event_id: String) {
+fn a_reconnect_request_with_last_event_id(world: &World, event_id: String) -> StepResult {
+    EventId::new(event_id.clone())?;
     world
         .headers
         .set(vec![SseHeader::new(LAST_EVENT_ID_HEADER, event_id)]);
     world.should_use_actix_path.set(false);
+    Ok(())
 }
 
 #[given("a request with duplicate Last-Event-ID headers {first_id} and {second_id}")]
-#[expect(
-    clippy::expect_used,
-    reason = "BDD steps use expect for clear failures"
-)]
 fn a_request_with_duplicate_last_event_id_headers(
     world: &World,
     first_id: String,
     second_id: String,
-) {
+) -> StepResult {
     let mut headers = HeaderMap::new();
     let header_name = HeaderName::from_static("last-event-id");
-    headers.append(
-        header_name.clone(),
-        HeaderValue::from_str(&first_id).expect("fixture header should be valid"),
-    );
-    headers.append(
-        header_name,
-        HeaderValue::from_str(&second_id).expect("fixture header should be valid"),
-    );
+    headers.append(header_name.clone(), HeaderValue::from_str(&first_id)?);
+    headers.append(header_name, HeaderValue::from_str(&second_id)?);
 
     world.actix_headers.set(headers);
     world.should_use_actix_path.set(true);
+    Ok(())
 }
 
 #[given("a request with a Last-Event-ID header containing a forbidden character")]
@@ -96,9 +91,11 @@ fn a_request_with_duplicate_last_event_id_headers(
     unsafe_code,
     reason = "BDD fixture needs an otherwise impossible Actix header value"
 )]
-fn a_request_with_a_last_event_id_header_containing_a_forbidden_character(world: &World) {
+fn a_request_with_a_last_event_id_header_containing_a_forbidden_character(
+    world: &World,
+) -> StepResult {
     let mut headers = HeaderMap::new();
-    let header_name = HeaderName::from_static("last-event-id");
+    let header_name = HeaderName::from_bytes(LAST_EVENT_ID_HEADER.as_bytes())?;
     let forbidden_bytes = b"evt\n123";
     // SAFETY: This BDD fixture intentionally builds an invalid but UTF-8
     // Last-Event-ID payload so the adapter can exercise domain-level replay
@@ -110,6 +107,7 @@ fn a_request_with_a_last_event_id_header_containing_a_forbidden_character(world:
 
     world.actix_headers.set(headers);
     world.should_use_actix_path.set(true);
+    Ok(())
 }
 
 #[given("an Actix request with a non-UTF-8 Last-Event-ID header value")]
@@ -117,9 +115,9 @@ fn a_request_with_a_last_event_id_header_containing_a_forbidden_character(world:
     unsafe_code,
     reason = "BDD fixture needs to construct invalid UTF-8 header value"
 )]
-fn an_actix_request_with_a_non_utf_8_last_event_id_header_value(world: &World) {
+fn an_actix_request_with_a_non_utf_8_last_event_id_header_value(world: &World) -> StepResult {
     let mut headers = HeaderMap::new();
-    let header_name = HeaderName::from_static("last-event-id");
+    let header_name = HeaderName::from_bytes(LAST_EVENT_ID_HEADER.as_bytes())?;
     let non_utf8_bytes = &[0xff, 0xfe, 0xfd];
     // SAFETY: This BDD fixture intentionally builds a non-UTF-8 header payload
     // to exercise `to_str()` failure. The byte slice is static test-only data
@@ -130,158 +128,138 @@ fn an_actix_request_with_a_non_utf_8_last_event_id_header_value(world: &World) {
 
     world.actix_headers.set(headers);
     world.should_use_actix_path.set(true);
+    Ok(())
 }
 
 #[given("an event-stream response")]
-fn an_event_stream_response(world: &World) { world.response_headers.set(Vec::new()); }
+fn an_event_stream_response(world: &World) -> StepResult {
+    HeaderValue::from_str(EVENT_STREAM_CACHE_CONTROL)?;
+    world.response_headers.set(Vec::new());
+    Ok(())
+}
 
 #[given("a downstream event with id {event_id}, event {event_name}, and payload {payload}")]
-#[expect(
-    clippy::expect_used,
-    reason = "BDD steps use expect for clear failures"
-)]
 fn a_downstream_event_with_id_event_and_payload(
     world: &World,
     event_id: String,
     event_name: String,
     payload: String,
-) {
-    let id = EventId::new(event_id).expect("fixture event id should be valid");
-    let frame = render_event_frame(Some(&id), Some(&event_name), &payload)
-        .expect("fixture event frame should render");
+) -> StepResult {
+    let id = EventId::new(event_id)?;
+    let frame = render_event_frame(Some(&id), Some(&event_name), &payload)?;
     world.event_frame.set(frame);
+    Ok(())
 }
 
 #[when("the replay cursor is extracted")]
-#[expect(
-    clippy::expect_used,
-    reason = "BDD steps use expect for clear failures"
-)]
-fn the_replay_cursor_is_extracted(world: &World) {
-    let headers = world.headers.get().expect("request headers should be set");
-    let cursor = extract_replay_cursor(&headers).expect("valid reconnect header should parse");
+fn the_replay_cursor_is_extracted(world: &World) -> StepResult {
+    let headers = world.headers.get().ok_or("request headers should be set")?;
+    let cursor = extract_replay_cursor(&headers)?;
     world.replay_cursor.set(cursor);
+    Ok(())
 }
 
 #[when("the replay cursor extraction fails")]
-#[expect(
-    clippy::expect_used,
-    reason = "BDD steps use expect for clear failures"
-)]
-fn the_replay_cursor_extraction_fails(world: &World) {
+fn the_replay_cursor_extraction_fails(world: &World) -> StepResult {
     let should_use_actix_path = world
         .should_use_actix_path
         .get()
-        .expect("extraction path should be set");
+        .ok_or("extraction path should be set")?;
     let error = if should_use_actix_path {
         let headers = world
             .actix_headers
             .get()
-            .expect("Actix request headers should be set");
-        extract_actix_replay_cursor(&headers).expect_err("replay cursor extraction should fail")
+            .ok_or("Actix request headers should be set")?;
+        extract_actix_replay_cursor(&headers)
+            .err()
+            .ok_or("replay cursor extraction should fail")?
     } else {
-        let headers = world.headers.get().expect("request headers should be set");
-        extract_replay_cursor(&headers).expect_err("replay cursor extraction should fail")
+        let headers = world.headers.get().ok_or("request headers should be set")?;
+        extract_replay_cursor(&headers)
+            .err()
+            .ok_or("replay cursor extraction should fail")?
     };
 
     world.replay_cursor_error.set(error);
+    Ok(())
 }
 
 #[when("the Actix replay cursor extraction fails")]
-#[expect(
-    clippy::expect_used,
-    reason = "BDD steps use expect for clear failures"
-)]
-fn the_actix_replay_cursor_extraction_fails(world: &World) {
+fn the_actix_replay_cursor_extraction_fails(world: &World) -> StepResult {
     let headers = world
         .actix_headers
         .get()
-        .expect("Actix request headers should be set");
+        .ok_or("Actix request headers should be set")?;
     let error = extract_actix_replay_cursor(&headers)
-        .expect_err("Actix replay cursor extraction should fail");
+        .err()
+        .ok_or("Actix replay cursor extraction should fail")?;
 
     world.replay_cursor_error.set(error);
+    Ok(())
 }
 
 #[when("the live-stream cache policy and heartbeat are applied")]
-#[expect(
-    clippy::expect_used,
-    reason = "BDD steps use expect for clear failures"
-)]
-fn the_live_stream_cache_policy_and_heartbeat_are_applied(world: &World) {
+fn the_live_stream_cache_policy_and_heartbeat_are_applied(world: &World) -> StepResult {
     let mut headers = world
         .response_headers
         .get()
-        .expect("response headers should be set")
+        .ok_or("response headers should be set")?
         .clone();
     apply_event_stream_cache_control(&mut headers);
     world.response_headers.set(headers);
 
-    let heartbeat = render_heartbeat_frame().expect("heartbeat frame should render");
+    let heartbeat = render_heartbeat_frame()?;
     world.heartbeat_frame.set(heartbeat);
+    Ok(())
 }
 
 #[when("the stream reset frame is rendered")]
-#[expect(
-    clippy::expect_used,
-    reason = "BDD steps use expect for clear failures"
-)]
-fn the_stream_reset_frame_is_rendered(world: &World) {
-    let frame = render_stream_reset_frame().expect("stream reset frame should render");
+fn the_stream_reset_frame_is_rendered(world: &World) -> StepResult {
+    let frame = render_stream_reset_frame()?;
     world.stream_reset_frame.set(frame);
+    Ok(())
 }
 
 #[then("the replay cursor preserves {event_id}")]
-#[expect(
-    clippy::expect_used,
-    reason = "BDD steps use expect for clear failures"
-)]
-fn the_replay_cursor_preserves(world: &World, event_id: String) {
+fn the_replay_cursor_preserves(world: &World, event_id: String) -> StepResult {
     let replay_cursor = world
         .replay_cursor
         .get()
-        .expect("replay cursor slot should be set");
+        .ok_or("replay cursor slot should be set")?;
     let cursor = replay_cursor
         .as_ref()
-        .expect("replay cursor should be present");
+        .ok_or("replay cursor should be present")?;
 
     assert_eq!(cursor.as_ref(), event_id);
+    Ok(())
 }
 
 #[then("the shared Last-Event-ID header name ignores non-matching headers")]
-#[expect(
-    clippy::expect_used,
-    reason = "BDD steps use expect for clear failures"
-)]
-fn the_shared_last_event_id_header_name_ignores_non_matching_headers() {
+fn the_shared_last_event_id_header_name_ignores_non_matching_headers() -> StepResult {
     let wrong_name = format!("{LAST_EVENT_ID_HEADER}-wrong");
     let headers = vec![SseHeader::new(&wrong_name, "evt-123")];
-    let result =
-        extract_replay_cursor(&headers).expect("header with wrong name should not be an error");
+    let result = extract_replay_cursor(&headers)?;
 
     assert!(
         result.is_none(),
         "extract_replay_cursor should return None when header name does not match \
          LAST_EVENT_ID_HEADER"
     );
+    Ok(())
 }
 
 #[then(
     "a tracing error is emitted with header_name {header_name} and error_variant {error_variant}"
 )]
-#[expect(
-    clippy::expect_used,
-    reason = "BDD steps use expect for clear failures"
-)]
 fn a_tracing_error_is_emitted_with_header_name_and_error_variant(
     world: &World,
     header_name: String,
     error_variant: String,
-) {
+) -> StepResult {
     world
         .replay_cursor_error
         .get()
-        .expect("replay cursor error should be set");
+        .ok_or("replay cursor error should be set")?;
 
     assert!(traced_scenario_logs_contain(
         world,
@@ -291,6 +269,7 @@ fn a_tracing_error_is_emitted_with_header_name_and_error_variant(
         world,
         &format!("error_variant=\"{error_variant}\"")
     ));
+    Ok(())
 }
 
 fn traced_scenario_logs_contain(world: &World, value: &str) -> bool {
@@ -298,59 +277,48 @@ fn traced_scenario_logs_contain(world: &World, value: &str) -> bool {
 }
 
 #[then("the response uses the canonical no-store cache policy")]
-#[expect(
-    clippy::expect_used,
-    reason = "BDD steps use expect for clear failures"
-)]
-fn the_response_uses_the_canonical_no_store_cache_policy(world: &World) {
+fn the_response_uses_the_canonical_no_store_cache_policy(world: &World) -> StepResult {
     let headers = world
         .response_headers
         .get()
-        .expect("response headers should be set");
+        .ok_or("response headers should be set")?;
 
     assert_eq!(
         headers
             .iter()
             .find(|header| header.name() == CACHE_CONTROL_HEADER)
-            .expect("cache-control header should be present")
+            .ok_or("cache-control header should be present")?
             .value(),
         EVENT_STREAM_CACHE_CONTROL
     );
+    Ok(())
 }
 
 #[then("the heartbeat frame is the canonical empty comment")]
-#[expect(
-    clippy::expect_used,
-    reason = "BDD steps use expect for clear failures"
-)]
-fn the_heartbeat_frame_is_the_canonical_empty_comment(world: &World) {
+fn the_heartbeat_frame_is_the_canonical_empty_comment(world: &World) -> StepResult {
     let heartbeat = world
         .heartbeat_frame
         .get()
-        .expect("heartbeat frame should be set");
+        .ok_or("heartbeat frame should be set")?;
 
     assert_eq!(heartbeat, ":\n\n");
-    let policy = HeartbeatPolicy::new(DEFAULT_HEARTBEAT_INTERVAL)
-        .expect("DEFAULT_HEARTBEAT_INTERVAL should be a valid heartbeat interval");
+    let policy = HeartbeatPolicy::new(DEFAULT_HEARTBEAT_INTERVAL)?;
 
     assert_eq!(
         policy.interval(),
         Duration::from_secs(20),
         "DEFAULT_HEARTBEAT_INTERVAL should encode a 20-second heartbeat interval"
     );
+    Ok(())
 }
 
 #[then("the event and stream reset frames match the approved wire format")]
-#[expect(
-    clippy::expect_used,
-    reason = "BDD steps use expect for clear failures"
-)]
-fn the_event_and_stream_reset_frames_match_the_approved_wire_format(world: &World) {
-    let event_frame = world.event_frame.get().expect("event frame should be set");
+fn the_event_and_stream_reset_frames_match_the_approved_wire_format(world: &World) -> StepResult {
+    let event_frame = world.event_frame.get().ok_or("event frame should be set")?;
     let stream_reset_frame = world
         .stream_reset_frame
         .get()
-        .expect("stream reset frame should be set");
+        .ok_or("stream reset frame should be set")?;
 
     assert_eq!(
         event_frame,
@@ -360,6 +328,7 @@ fn the_event_and_stream_reset_frames_match_the_approved_wire_format(world: &Worl
         stream_reset_frame,
         "event: stream_reset\ndata: {\"reason\":\"replay_unavailable\"}\n\n"
     );
+    Ok(())
 }
 
 #[scenario(path = "tests/features/sse_wire_contract.feature")]

--- a/tests/sse_wire_contract_bdd.rs
+++ b/tests/sse_wire_contract_bdd.rs
@@ -18,6 +18,7 @@ use actix_v2a::{
     render_event_frame,
     render_heartbeat_frame,
     render_stream_reset_frame,
+    apply_actix_event_stream_cache_control,
 };
 use actix_web::http::header::{HeaderMap, HeaderName, HeaderValue};
 use rstest::fixture;
@@ -358,3 +359,29 @@ fn the_event_and_stream_reset_frames_match_the_approved_wire_format(world: &Worl
 #[scenario(path = "tests/features/sse_wire_contract.feature")]
 #[traced_test]
 fn shared_sse_wire_contract(world: World) { drop(world); }
+
+fn documented_crate_root_actix_adapter_imports_match_wire_contract() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        HeaderName::from_bytes(LAST_EVENT_ID_HEADER.as_bytes())
+            .expect("LAST_EVENT_ID_HEADER should be a valid Actix header name"),
+        HeaderValue::from_static("evt-crate-root"),
+    );
+
+    apply_actix_event_stream_cache_control(&mut headers);
+    let replay_cursor = extract_actix_replay_cursor(&headers)
+        .expect("documented replay cursor import should parse");
+
+    assert_eq!(
+        headers
+            .get(CACHE_CONTROL)
+            .expect("cache-control header should be present"),
+        EVENT_STREAM_CACHE_CONTROL
+    );
+    assert_eq!(
+        replay_cursor
+            .expect("replay cursor should be present")
+            .as_ref(),
+        "evt-crate-root"
+    );
+}

--- a/tests/sse_wire_contract_bdd.rs
+++ b/tests/sse_wire_contract_bdd.rs
@@ -12,15 +12,15 @@ use actix_v2a::{
     ReplayCursor,
     ReplayCursorError,
     SseHeader,
+    apply_actix_event_stream_cache_control,
     apply_event_stream_cache_control,
     extract_actix_replay_cursor,
     extract_replay_cursor,
     render_event_frame,
     render_heartbeat_frame,
     render_stream_reset_frame,
-    apply_actix_event_stream_cache_control,
 };
-use actix_web::http::header::{HeaderMap, HeaderName, HeaderValue};
+use actix_web::http::header::{CACHE_CONTROL, HeaderMap, HeaderName, HeaderValue};
 use rstest::fixture;
 use rstest_bdd::Slot;
 use rstest_bdd_macros::{ScenarioState, given, scenario, then, when};
@@ -360,6 +360,7 @@ fn the_event_and_stream_reset_frames_match_the_approved_wire_format(world: &Worl
 #[traced_test]
 fn shared_sse_wire_contract(world: World) { drop(world); }
 
+#[test]
 fn documented_crate_root_actix_adapter_imports_match_wire_contract() {
     let mut headers = HeaderMap::new();
     headers.insert(

--- a/tests/sse_wire_contract_bdd.rs
+++ b/tests/sse_wire_contract_bdd.rs
@@ -1,6 +1,9 @@
 //! Behavioural tests for the shared SSE wire contract.
 
-use std::time::Duration;
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use actix_v2a::{
     CACHE_CONTROL_HEADER,
@@ -27,7 +30,7 @@ use rstest_bdd_macros::{ScenarioState, given, scenario, then, when};
 #[path = "support/sse_trace_buffer.rs"]
 mod sse_trace_buffer;
 
-use sse_trace_buffer::{LogBuffer, TracingGuard};
+use sse_trace_buffer::LogBuffer;
 
 type StepResult = Result<(), Box<dyn std::error::Error>>;
 
@@ -43,20 +46,13 @@ struct World {
     log_buffer: Slot<LogBuffer>,
     should_use_actix_path: Slot<bool>,
     stream_reset_frame: Slot<String>,
-    tracing_guard: Slot<TracingGuard>,
-}
-
-impl World {
-    fn install_tracing(&self) {
-        sse_trace_buffer::install_tracing(&self.log_buffer, &self.tracing_guard);
-    }
 }
 
 #[fixture]
 fn world() -> World {
     // Keep the fixture explicit so scenario failures print a useful state type.
     let world = World::default();
-    world.install_tracing();
+    world.log_buffer.set(Arc::new(Mutex::new(Vec::new())));
     world
 }
 
@@ -170,9 +166,11 @@ fn the_replay_cursor_extraction_fails(world: &World) -> StepResult {
             .actix_headers
             .get()
             .ok_or("Actix request headers should be set")?;
-        extract_actix_replay_cursor(&headers)
-            .err()
-            .ok_or("replay cursor extraction should fail")?
+        sse_trace_buffer::with_tracing_buffer(&world.log_buffer, || {
+            extract_actix_replay_cursor(&headers)
+        })
+        .err()
+        .ok_or("replay cursor extraction should fail")?
     } else {
         let headers = world.headers.get().ok_or("request headers should be set")?;
         extract_replay_cursor(&headers)
@@ -190,9 +188,11 @@ fn the_actix_replay_cursor_extraction_fails(world: &World) -> StepResult {
         .actix_headers
         .get()
         .ok_or("Actix request headers should be set")?;
-    let error = extract_actix_replay_cursor(&headers)
-        .err()
-        .ok_or("Actix replay cursor extraction should fail")?;
+    let error = sse_trace_buffer::with_tracing_buffer(&world.log_buffer, || {
+        extract_actix_replay_cursor(&headers)
+    })
+    .err()
+    .ok_or("Actix replay cursor extraction should fail")?;
 
     world.replay_cursor_error.set(error);
     Ok(())

--- a/tests/sse_wire_contract_bdd.rs
+++ b/tests/sse_wire_contract_bdd.rs
@@ -1,6 +1,10 @@
 //! Behavioural tests for the shared SSE wire contract.
 
-use std::time::Duration;
+use std::{
+    fmt,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use actix_v2a::{
     CACHE_CONTROL_HEADER,
@@ -23,7 +27,53 @@ use actix_web::http::header::{HeaderMap, HeaderName, HeaderValue};
 use rstest::fixture;
 use rstest_bdd::Slot;
 use rstest_bdd_macros::{ScenarioState, given, scenario, then, when};
-use tracing_test::traced_test;
+use tracing_subscriber::{Layer, prelude::*};
+
+struct BufferLayer(Arc<Mutex<Vec<String>>>);
+
+impl<S: tracing::Subscriber> Layer<S> for BufferLayer {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        use tracing_subscriber::field::Visit;
+
+        struct Collector(String);
+
+        impl Visit for Collector {
+            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn fmt::Debug) {
+                use fmt::Write as _;
+
+                let result = write!(self.0, " {}={:?}", field.name(), value);
+                debug_assert!(result.is_ok(), "writing to String should not fail");
+            }
+        }
+
+        let mut collector = Collector(String::new());
+        event.record(&mut collector);
+
+        if let Ok(mut buffer) = self.0.lock() {
+            buffer.push(collector.0.trim_start().to_owned());
+        }
+    }
+}
+
+struct TracingGuard(Mutex<Option<tracing::subscriber::DefaultGuard>>);
+
+impl fmt::Debug for TracingGuard {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("TracingGuard(..)")
+    }
+}
+
+impl Drop for TracingGuard {
+    fn drop(&mut self) {
+        if let Ok(mut guard) = self.0.lock() {
+            let _ = guard.take();
+        }
+    }
+}
 
 #[derive(Debug, Default, ScenarioState)]
 struct World {
@@ -34,14 +84,31 @@ struct World {
     response_headers: Slot<Vec<SseHeader>>,
     heartbeat_frame: Slot<String>,
     event_frame: Slot<String>,
+    log_buffer: Slot<Arc<Mutex<Vec<String>>>>,
     should_use_actix_path: Slot<bool>,
     stream_reset_frame: Slot<String>,
+    tracing_guard: Slot<TracingGuard>,
+}
+
+impl World {
+    fn install_tracing(&self) {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(BufferLayer(Arc::clone(&buffer)));
+        let guard = TracingGuard(Mutex::new(Some(tracing::subscriber::set_default(
+            subscriber,
+        ))));
+
+        self.log_buffer.set(buffer);
+        self.tracing_guard.set(guard);
+    }
 }
 
 #[fixture]
 fn world() -> World {
     // Keep the fixture explicit so scenario failures print a useful state type.
-    World::default()
+    let world = World::default();
+    world.install_tracing();
+    world
 }
 
 #[given("a reconnect request with Last-Event-ID {event_id}")]
@@ -269,16 +336,24 @@ fn a_tracing_error_is_emitted_with_header_name_and_error_variant(
         .get()
         .expect("replay cursor error should be set");
 
-    assert!(traced_scenario_logs_contain(&format!(
-        "header_name=\"{header_name}\""
-    )));
-    assert!(traced_scenario_logs_contain(&format!(
-        "error_variant=\"{error_variant}\""
-    )));
+    assert!(traced_scenario_logs_contain(
+        world,
+        &format!("header_name=\"{header_name}\"")
+    ));
+    assert!(traced_scenario_logs_contain(
+        world,
+        &format!("error_variant=\"{error_variant}\"")
+    ));
 }
 
-fn traced_scenario_logs_contain(value: &str) -> bool {
-    tracing_test::internal::logs_with_scope_contain("shared_sse_wire_contract", value)
+fn traced_scenario_logs_contain(world: &World, value: &str) -> bool {
+    let Some(buffer) = world.log_buffer.get() else {
+        return false;
+    };
+
+    buffer
+        .lock()
+        .is_ok_and(|lines| lines.iter().any(|line| line.contains(value)))
 }
 
 #[then("the response uses the canonical no-store cache policy")]
@@ -347,5 +422,4 @@ fn the_event_and_stream_reset_frames_match_the_approved_wire_format(world: &Worl
 }
 
 #[scenario(path = "tests/features/sse_wire_contract.feature")]
-#[traced_test]
 fn shared_sse_wire_contract(world: World) { drop(world); }

--- a/tests/sse_wire_contract_bdd.rs
+++ b/tests/sse_wire_contract_bdd.rs
@@ -1,10 +1,6 @@
 //! Behavioural tests for the shared SSE wire contract.
 
-use std::{
-    fmt,
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+use std::time::Duration;
 
 use actix_v2a::{
     CACHE_CONTROL_HEADER,
@@ -27,53 +23,11 @@ use actix_web::http::header::{HeaderMap, HeaderName, HeaderValue};
 use rstest::fixture;
 use rstest_bdd::Slot;
 use rstest_bdd_macros::{ScenarioState, given, scenario, then, when};
-use tracing_subscriber::{Layer, prelude::*};
 
-struct BufferLayer(Arc<Mutex<Vec<String>>>);
+#[path = "support/sse_trace_buffer.rs"]
+mod sse_trace_buffer;
 
-impl<S: tracing::Subscriber> Layer<S> for BufferLayer {
-    fn on_event(
-        &self,
-        event: &tracing::Event<'_>,
-        _ctx: tracing_subscriber::layer::Context<'_, S>,
-    ) {
-        use tracing_subscriber::field::Visit;
-
-        struct Collector(String);
-
-        impl Visit for Collector {
-            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn fmt::Debug) {
-                use fmt::Write as _;
-
-                let result = write!(self.0, " {}={:?}", field.name(), value);
-                debug_assert!(result.is_ok(), "writing to String should not fail");
-            }
-        }
-
-        let mut collector = Collector(String::new());
-        event.record(&mut collector);
-
-        if let Ok(mut buffer) = self.0.lock() {
-            buffer.push(collector.0.trim_start().to_owned());
-        }
-    }
-}
-
-struct TracingGuard(Mutex<Option<tracing::subscriber::DefaultGuard>>);
-
-impl fmt::Debug for TracingGuard {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("TracingGuard(..)")
-    }
-}
-
-impl Drop for TracingGuard {
-    fn drop(&mut self) {
-        if let Ok(mut guard) = self.0.lock() {
-            let _ = guard.take();
-        }
-    }
-}
+use sse_trace_buffer::{LogBuffer, TracingGuard};
 
 #[derive(Debug, Default, ScenarioState)]
 struct World {
@@ -84,7 +38,7 @@ struct World {
     response_headers: Slot<Vec<SseHeader>>,
     heartbeat_frame: Slot<String>,
     event_frame: Slot<String>,
-    log_buffer: Slot<Arc<Mutex<Vec<String>>>>,
+    log_buffer: Slot<LogBuffer>,
     should_use_actix_path: Slot<bool>,
     stream_reset_frame: Slot<String>,
     tracing_guard: Slot<TracingGuard>,
@@ -92,14 +46,7 @@ struct World {
 
 impl World {
     fn install_tracing(&self) {
-        let buffer = Arc::new(Mutex::new(Vec::new()));
-        let subscriber = tracing_subscriber::registry().with(BufferLayer(Arc::clone(&buffer)));
-        let guard = TracingGuard(Mutex::new(Some(tracing::subscriber::set_default(
-            subscriber,
-        ))));
-
-        self.log_buffer.set(buffer);
-        self.tracing_guard.set(guard);
+        sse_trace_buffer::install_tracing(&self.log_buffer, &self.tracing_guard);
     }
 }
 
@@ -347,13 +294,7 @@ fn a_tracing_error_is_emitted_with_header_name_and_error_variant(
 }
 
 fn traced_scenario_logs_contain(world: &World, value: &str) -> bool {
-    let Some(buffer) = world.log_buffer.get() else {
-        return false;
-    };
-
-    buffer
-        .lock()
-        .is_ok_and(|lines| lines.iter().any(|line| line.contains(value)))
+    sse_trace_buffer::logs_contain(&world.log_buffer, value)
 }
 
 #[then("the response uses the canonical no-store cache policy")]

--- a/tests/sse_wire_contract_bdd.rs
+++ b/tests/sse_wire_contract_bdd.rs
@@ -20,7 +20,7 @@ use actix_v2a::{
     render_heartbeat_frame,
     render_stream_reset_frame,
 };
-use actix_web::http::header::{CACHE_CONTROL, HeaderMap, HeaderName, HeaderValue};
+use actix_web::http::header::{CACHE_CONTROL, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
 use rstest::fixture;
 use rstest_bdd::Slot;
 use rstest_bdd_macros::{ScenarioState, given, scenario, then, when};
@@ -156,7 +156,6 @@ fn the_replay_cursor_is_extracted(world: &World) {
     reason = "BDD steps use expect for clear failures"
 )]
 fn the_replay_cursor_extraction_fails(world: &World) {
-    clear_traced_scenario_logs();
     let should_use_actix_path = world
         .should_use_actix_path
         .get()
@@ -181,7 +180,6 @@ fn the_replay_cursor_extraction_fails(world: &World) {
     reason = "BDD steps use expect for clear failures"
 )]
 fn the_actix_replay_cursor_extraction_fails(world: &World) {
-    clear_traced_scenario_logs();
     let headers = world
         .actix_headers
         .get()
@@ -284,13 +282,6 @@ fn traced_scenario_logs_contain(value: &str) -> bool {
     tracing_test::internal::logs_with_scope_contain("shared_sse_wire_contract", value)
 }
 
-fn clear_traced_scenario_logs() {
-    tracing_test::internal::global_buf()
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .clear();
-}
-
 #[then("the response uses the canonical no-store cache policy")]
 #[expect(
     clippy::expect_used,
@@ -384,5 +375,74 @@ fn documented_crate_root_actix_adapter_imports_match_wire_contract() {
             .expect("replay cursor should be present")
             .as_ref(),
         "evt-crate-root"
+    );
+}
+
+#[test]
+fn documented_crate_root_actix_adapter_import_rejects_non_utf8_cursor() {
+    let mut headers = HeaderMap::new();
+    let non_utf8_bytes = &[0xff, 0xfe, 0xfd];
+    #[expect(
+        unsafe_code,
+        reason = "Test needs to construct invalid UTF-8 header value"
+    )]
+    let header_value = unsafe { HeaderValue::from_maybe_shared_unchecked(non_utf8_bytes) };
+    headers.insert(
+        HeaderName::from_bytes(LAST_EVENT_ID_HEADER.as_bytes())
+            .expect("LAST_EVENT_ID_HEADER should be a valid Actix header name"),
+        header_value,
+    );
+
+    assert!(
+        extract_actix_replay_cursor(&headers).is_err(),
+        "documented crate-root import should reject non-UTF-8 Last-Event-ID values"
+    );
+}
+
+#[test]
+fn documented_crate_root_actix_adapter_import_returns_none_without_cursor() {
+    let headers = HeaderMap::new();
+
+    let replay_cursor = extract_actix_replay_cursor(&headers)
+        .expect("documented crate-root import should accept missing Last-Event-ID");
+
+    assert_eq!(replay_cursor, None);
+}
+
+#[test]
+fn documented_crate_root_actix_adapter_import_replaces_cache_policy() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        CACHE_CONTROL,
+        HeaderValue::from_static("public, max-age=60"),
+    );
+
+    apply_actix_event_stream_cache_control(&mut headers);
+
+    assert_eq!(
+        headers
+            .get(CACHE_CONTROL)
+            .expect("cache-control header should be present"),
+        EVENT_STREAM_CACHE_CONTROL
+    );
+}
+
+#[test]
+fn documented_crate_root_actix_adapter_import_preserves_unrelated_headers() {
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    headers.insert(
+        HeaderName::from_bytes(LAST_EVENT_ID_HEADER.as_bytes())
+            .expect("LAST_EVENT_ID_HEADER should be a valid Actix header name"),
+        HeaderValue::from_static("evt-crate-root"),
+    );
+
+    apply_actix_event_stream_cache_control(&mut headers);
+
+    assert_eq!(
+        headers
+            .get(CONTENT_TYPE)
+            .expect("content-type header should be present"),
+        "application/json"
     );
 }

--- a/tests/sse_wire_contract_bdd.rs
+++ b/tests/sse_wire_contract_bdd.rs
@@ -12,7 +12,6 @@ use actix_v2a::{
     ReplayCursor,
     ReplayCursorError,
     SseHeader,
-    apply_actix_event_stream_cache_control,
     apply_event_stream_cache_control,
     extract_actix_replay_cursor,
     extract_replay_cursor,
@@ -20,7 +19,7 @@ use actix_v2a::{
     render_heartbeat_frame,
     render_stream_reset_frame,
 };
-use actix_web::http::header::{CACHE_CONTROL, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
+use actix_web::http::header::{HeaderMap, HeaderName, HeaderValue};
 use rstest::fixture;
 use rstest_bdd::Slot;
 use rstest_bdd_macros::{ScenarioState, given, scenario, then, when};
@@ -350,99 +349,3 @@ fn the_event_and_stream_reset_frames_match_the_approved_wire_format(world: &Worl
 #[scenario(path = "tests/features/sse_wire_contract.feature")]
 #[traced_test]
 fn shared_sse_wire_contract(world: World) { drop(world); }
-
-#[test]
-fn documented_crate_root_actix_adapter_imports_match_wire_contract() {
-    let mut headers = HeaderMap::new();
-    headers.insert(
-        HeaderName::from_bytes(LAST_EVENT_ID_HEADER.as_bytes())
-            .expect("LAST_EVENT_ID_HEADER should be a valid Actix header name"),
-        HeaderValue::from_static("evt-crate-root"),
-    );
-
-    apply_actix_event_stream_cache_control(&mut headers);
-    let replay_cursor = extract_actix_replay_cursor(&headers)
-        .expect("documented replay cursor import should parse");
-
-    assert_eq!(
-        headers
-            .get(CACHE_CONTROL)
-            .expect("cache-control header should be present"),
-        EVENT_STREAM_CACHE_CONTROL
-    );
-    assert_eq!(
-        replay_cursor
-            .expect("replay cursor should be present")
-            .as_ref(),
-        "evt-crate-root"
-    );
-}
-
-#[test]
-fn documented_crate_root_actix_adapter_import_rejects_non_utf8_cursor() {
-    let mut headers = HeaderMap::new();
-    let non_utf8_bytes = &[0xff, 0xfe, 0xfd];
-    #[expect(
-        unsafe_code,
-        reason = "Test needs to construct invalid UTF-8 header value"
-    )]
-    let header_value = unsafe { HeaderValue::from_maybe_shared_unchecked(non_utf8_bytes) };
-    headers.insert(
-        HeaderName::from_bytes(LAST_EVENT_ID_HEADER.as_bytes())
-            .expect("LAST_EVENT_ID_HEADER should be a valid Actix header name"),
-        header_value,
-    );
-
-    assert!(
-        extract_actix_replay_cursor(&headers).is_err(),
-        "documented crate-root import should reject non-UTF-8 Last-Event-ID values"
-    );
-}
-
-#[test]
-fn documented_crate_root_actix_adapter_import_returns_none_without_cursor() {
-    let headers = HeaderMap::new();
-
-    let replay_cursor = extract_actix_replay_cursor(&headers)
-        .expect("documented crate-root import should accept missing Last-Event-ID");
-
-    assert_eq!(replay_cursor, None);
-}
-
-#[test]
-fn documented_crate_root_actix_adapter_import_replaces_cache_policy() {
-    let mut headers = HeaderMap::new();
-    headers.insert(
-        CACHE_CONTROL,
-        HeaderValue::from_static("public, max-age=60"),
-    );
-
-    apply_actix_event_stream_cache_control(&mut headers);
-
-    assert_eq!(
-        headers
-            .get(CACHE_CONTROL)
-            .expect("cache-control header should be present"),
-        EVENT_STREAM_CACHE_CONTROL
-    );
-}
-
-#[test]
-fn documented_crate_root_actix_adapter_import_preserves_unrelated_headers() {
-    let mut headers = HeaderMap::new();
-    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-    headers.insert(
-        HeaderName::from_bytes(LAST_EVENT_ID_HEADER.as_bytes())
-            .expect("LAST_EVENT_ID_HEADER should be a valid Actix header name"),
-        HeaderValue::from_static("evt-crate-root"),
-    );
-
-    apply_actix_event_stream_cache_control(&mut headers);
-
-    assert_eq!(
-        headers
-            .get(CONTENT_TYPE)
-            .expect("content-type header should be present"),
-        "application/json"
-    );
-}

--- a/tests/support/sse_trace_buffer.rs
+++ b/tests/support/sse_trace_buffer.rs
@@ -8,14 +8,19 @@
 //! The buffer model is intentionally simple: each BDD `World` owns a
 //! `LogBuffer = Arc<Mutex<Vec<String>>>`; `BufferLayer` implements
 //! `tracing_subscriber::Layer` and captures every tracing event's fields into
-//! that buffer for the duration of the scenario; and `TracingGuard` holds the
-//! `DefaultGuard` returned by `tracing::subscriber::set_default` so the
-//! subscriber is deregistered when the guard drops.
+//! that buffer.
+//!
+//! `with_tracing_buffer` wraps each call under test in
+//! `tracing::subscriber::with_default`, scoping capture hermetically to that
+//! call's execution on the current thread. Because no `DefaultGuard` escapes
+//! the closure, concurrent test threads each have their own independent
+//! thread-local subscriber and the buffer contains only events from the
+//! function under test.
 //!
 //! `tests/sse_wire_contract_bdd.rs` wires this module into the `World`
-//! through `log_buffer` and `tracing_guard`, calls `install_tracing` from the
-//! `world()` fixture, and uses `logs_contain` from step functions to assert on
-//! the captured output.
+//! through `log_buffer`, calls `with_tracing_buffer` around extraction paths
+//! that should emit tracing events, and uses `logs_contain` from step
+//! functions to assert on the captured output.
 
 use std::{
     fmt,
@@ -23,7 +28,7 @@ use std::{
 };
 
 use rstest_bdd::Slot;
-use tracing_subscriber::{Layer, prelude::*};
+use tracing_subscriber::{Layer, layer::SubscriberExt};
 
 /// Thread-safe in-memory log storage for one BDD `World`.
 ///
@@ -60,40 +65,23 @@ impl<S: tracing::Subscriber> Layer<S> for BufferLayer {
     }
 }
 
-/// Holds the installed default tracing subscriber for one BDD `World`.
+/// Execute `f` with a `BufferLayer` subscriber active, capturing all tracing
+/// events emitted during the call into `log_buffer`.
 ///
-/// The inner `DefaultGuard` comes from `set_default` and is stored inside a
-/// `Mutex` so the guard wrapper is `Send + Sync`. Dropping this guard
-/// deregisters the subscriber and restores the previous default subscriber.
-pub(crate) struct TracingGuard(Mutex<Option<tracing::subscriber::DefaultGuard>>);
-
-impl fmt::Debug for TracingGuard {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("TracingGuard(..)")
-    }
-}
-
-impl Drop for TracingGuard {
-    fn drop(&mut self) {
-        let mut guard = self.0.lock().unwrap_or_else(PoisonError::into_inner);
-        let _ = guard.take();
-    }
-}
-
-/// Install the tracing subscriber used by the SSE BDD world.
-///
-/// The `log_buffer` slot receives a fresh `LogBuffer`, and the `tracing_guard`
-/// slot receives the `TracingGuard` that keeps the `BufferLayer`-backed
-/// subscriber installed for the scenario.
-pub(crate) fn install_tracing(log_buffer: &Slot<LogBuffer>, tracing_guard: &Slot<TracingGuard>) {
-    let buffer = Arc::new(Mutex::new(Vec::new()));
+/// The subscriber is installed with `tracing::subscriber::with_default` and is
+/// scoped exclusively to the duration of `f`. No tracing from code outside `f`
+/// is captured. `log_buffer` must already contain the `LogBuffer` for this
+/// scenario; if the slot is not yet populated this function is a no-op wrapper.
+pub(crate) fn with_tracing_buffer<F, T>(log_buffer: &Slot<LogBuffer>, f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    let Some(buffer) = log_buffer.get() else {
+        return f();
+    };
     let subscriber = tracing_subscriber::registry().with(BufferLayer(Arc::clone(&buffer)));
-    let guard = TracingGuard(Mutex::new(Some(tracing::subscriber::set_default(
-        subscriber,
-    ))));
 
-    log_buffer.set(buffer);
-    tracing_guard.set(guard);
+    tracing::subscriber::with_default(subscriber, f)
 }
 
 /// Check whether the world-owned trace buffer contains `value`.

--- a/tests/support/sse_trace_buffer.rs
+++ b/tests/support/sse_trace_buffer.rs
@@ -1,13 +1,34 @@
 //! World-owned tracing buffer support for SSE behavioural tests.
+//!
+//! This module exists so the BDD scenarios can assert on emitted tracing
+//! events without relying on `tracing-test` 0.2.x. That crate exposes only the
+//! internal, undocumented `tracing_test::internal::logs_with_scope_contain`
+//! helper for assertions outside a `#[traced_test]` body.
+//!
+//! The buffer model is intentionally simple: each BDD `World` owns a
+//! `LogBuffer = Arc<Mutex<Vec<String>>>`; `BufferLayer` implements
+//! `tracing_subscriber::Layer` and captures every tracing event's fields into
+//! that buffer for the duration of the scenario; and `TracingGuard` holds the
+//! `DefaultGuard` returned by `tracing::subscriber::set_default` so the
+//! subscriber is deregistered when the guard drops.
+//!
+//! `tests/sse_wire_contract_bdd.rs` wires this module into the `World`
+//! through `log_buffer` and `tracing_guard`, calls `install_tracing` from the
+//! `world()` fixture, and uses `logs_contain` from step functions to assert on
+//! the captured output.
 
 use std::{
     fmt,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, PoisonError},
 };
 
 use rstest_bdd::Slot;
 use tracing_subscriber::{Layer, prelude::*};
 
+/// Thread-safe in-memory log storage for one BDD `World`.
+///
+/// The buffer is an `Arc<Mutex<Vec<String>>>` so the tracing layer and the
+/// `World` can share captured event strings safely.
 pub(crate) type LogBuffer = Arc<Mutex<Vec<String>>>;
 
 struct BufferLayer(LogBuffer);
@@ -34,12 +55,16 @@ impl<S: tracing::Subscriber> Layer<S> for BufferLayer {
         let mut collector = Collector(String::new());
         event.record(&mut collector);
 
-        if let Ok(mut buffer) = self.0.lock() {
-            buffer.push(collector.0.trim_start().to_owned());
-        }
+        let mut buffer = self.0.lock().unwrap_or_else(PoisonError::into_inner);
+        buffer.push(collector.0.trim_start().to_owned());
     }
 }
 
+/// Holds the installed default tracing subscriber for one BDD `World`.
+///
+/// The inner `DefaultGuard` comes from `set_default` and is stored inside a
+/// `Mutex` so the guard wrapper is `Send + Sync`. Dropping this guard
+/// deregisters the subscriber and restores the previous default subscriber.
 pub(crate) struct TracingGuard(Mutex<Option<tracing::subscriber::DefaultGuard>>);
 
 impl fmt::Debug for TracingGuard {
@@ -50,12 +75,16 @@ impl fmt::Debug for TracingGuard {
 
 impl Drop for TracingGuard {
     fn drop(&mut self) {
-        if let Ok(mut guard) = self.0.lock() {
-            let _ = guard.take();
-        }
+        let mut guard = self.0.lock().unwrap_or_else(PoisonError::into_inner);
+        let _ = guard.take();
     }
 }
 
+/// Install the tracing subscriber used by the SSE BDD world.
+///
+/// The `log_buffer` slot receives a fresh `LogBuffer`, and the `tracing_guard`
+/// slot receives the `TracingGuard` that keeps the `BufferLayer`-backed
+/// subscriber installed for the scenario.
 pub(crate) fn install_tracing(log_buffer: &Slot<LogBuffer>, tracing_guard: &Slot<TracingGuard>) {
     let buffer = Arc::new(Mutex::new(Vec::new()));
     let subscriber = tracing_subscriber::registry().with(BufferLayer(Arc::clone(&buffer)));
@@ -67,12 +96,17 @@ pub(crate) fn install_tracing(log_buffer: &Slot<LogBuffer>, tracing_guard: &Slot
     tracing_guard.set(guard);
 }
 
+/// Check whether the world-owned trace buffer contains `value`.
+///
+/// The `log_buffer` slot provides the scenario's trace buffer. This performs a
+/// substring match against each captured event line, returns `false` when the
+/// slot has not yet been initialised, and recovers poisoned locks so a prior
+/// panic does not silently hide the captured output.
 pub(crate) fn logs_contain(log_buffer: &Slot<LogBuffer>, value: &str) -> bool {
     let Some(buffer) = log_buffer.get() else {
         return false;
     };
 
-    buffer
-        .lock()
-        .is_ok_and(|lines| lines.iter().any(|line| line.contains(value)))
+    let lines = buffer.lock().unwrap_or_else(PoisonError::into_inner);
+    lines.iter().any(|line| line.contains(value))
 }

--- a/tests/support/sse_trace_buffer.rs
+++ b/tests/support/sse_trace_buffer.rs
@@ -1,0 +1,78 @@
+//! World-owned tracing buffer support for SSE behavioural tests.
+
+use std::{
+    fmt,
+    sync::{Arc, Mutex},
+};
+
+use rstest_bdd::Slot;
+use tracing_subscriber::{Layer, prelude::*};
+
+pub(crate) type LogBuffer = Arc<Mutex<Vec<String>>>;
+
+struct BufferLayer(LogBuffer);
+
+impl<S: tracing::Subscriber> Layer<S> for BufferLayer {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        use tracing_subscriber::field::Visit;
+
+        struct Collector(String);
+
+        impl Visit for Collector {
+            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn fmt::Debug) {
+                use fmt::Write as _;
+
+                let result = write!(self.0, " {}={:?}", field.name(), value);
+                debug_assert!(result.is_ok(), "writing to String should not fail");
+            }
+        }
+
+        let mut collector = Collector(String::new());
+        event.record(&mut collector);
+
+        if let Ok(mut buffer) = self.0.lock() {
+            buffer.push(collector.0.trim_start().to_owned());
+        }
+    }
+}
+
+pub(crate) struct TracingGuard(Mutex<Option<tracing::subscriber::DefaultGuard>>);
+
+impl fmt::Debug for TracingGuard {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("TracingGuard(..)")
+    }
+}
+
+impl Drop for TracingGuard {
+    fn drop(&mut self) {
+        if let Ok(mut guard) = self.0.lock() {
+            let _ = guard.take();
+        }
+    }
+}
+
+pub(crate) fn install_tracing(log_buffer: &Slot<LogBuffer>, tracing_guard: &Slot<TracingGuard>) {
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::registry().with(BufferLayer(Arc::clone(&buffer)));
+    let guard = TracingGuard(Mutex::new(Some(tracing::subscriber::set_default(
+        subscriber,
+    ))));
+
+    log_buffer.set(buffer);
+    tracing_guard.set(guard);
+}
+
+pub(crate) fn logs_contain(log_buffer: &Slot<LogBuffer>, value: &str) -> bool {
+    let Some(buffer) = log_buffer.get() else {
+        return false;
+    };
+
+    buffer
+        .lock()
+        .is_ok_and(|lines| lines.iter().any(|line| line.contains(value)))
+}


### PR DESCRIPTION
## Summary

This branch implements roadmap task (1.2.2) by closing the shared Server-Sent Events documentation loop after the module landed. It records the completed SSE milestone in the Wildside import execution plan, removes implementation-time path references from the final documentation set, and marks the roadmap item done after the required validation passed.

Roadmap task: (1.2.2)
Execplan: [docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md](https://github.com/leynos/actix-v2a/blob/1-2-2-update-documentation-after-sse-module-lands/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md)

## Review walkthrough

- Start with [docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md](https://github.com/leynos/actix-v2a/blob/1-2-2-update-documentation-after-sse-module-lands/docs/execplans/1-2-2-update-documentation-after-sse-module-lands.md) to review the approved plan, progress log, validation evidence, and remaining closure notes.
- Then review [docs/execplans/import-components-from-wildside.md](https://github.com/leynos/actix-v2a/blob/1-2-2-update-documentation-after-sse-module-lands/docs/execplans/import-components-from-wildside.md) to see the completed SSE milestone record, Wildside provenance wording, path-cleanup decision, and final retrospective.
- Check [docs/roadmap.md](https://github.com/leynos/actix-v2a/blob/1-2-2-update-documentation-after-sse-module-lands/docs/roadmap.md) for the completed (1.2.2) checkbox.
- Review [docs/adr-001-shared-sse-wire-contract-for-wildside-and-corbusier.md](https://github.com/leynos/actix-v2a/blob/1-2-2-update-documentation-after-sse-module-lands/docs/adr-001-shared-sse-wire-contract-for-wildside-and-corbusier.md), [docs/contents.md](https://github.com/leynos/actix-v2a/blob/1-2-2-update-documentation-after-sse-module-lands/docs/contents.md), and [docs/execplans/portwildsidepagination.md](https://github.com/leynos/actix-v2a/blob/1-2-2-update-documentation-after-sse-module-lands/docs/execplans/portwildsidepagination.md) for the path-reference cleanup and index wording.

## Validation

- `make fmt`: passed.
- `make markdownlint`: passed.
- `make nixie`: passed.
- `make check-fmt`: passed.
- `make lint`: passed, including Whitaker.
- `make test`: passed, including 162 nextest tests and 26 doctests.
- `coderabbit review --agent`: passed with zero findings for the provenance milestone and again with zero findings for the final closure diff after a recoverable rate-limit wait.
- `git diff --check`: passed.
- Environment-specific path sweep over `docs` and `README.md`: no hits.

## Notes

This pull request remains draft for reviewer inspection. No Rust library code changed; the branch is documentation closure, plan maintenance, validation evidence, and roadmap status only.

## References

- Lody session: https://lody.ai/leynos/sessions/8e4803ed-151c-4b95-b0ce-d9f1db606d43

## Summary by Sourcery

Close the SSE documentation roadmap item by adding an execplan for task 1.2.2, updating existing plans and roadmap status, and normalizing provenance and path references across the docs set.

Documentation:
- Add a new execution plan documenting roadmap task 1.2.2 for SSE documentation closure, validation steps, and outcomes.
- Update the Wildside import execplan, pagination execplan, and ADR 001 to reflect completed SSE milestones and to replace local checkout paths with canonical upstream and repo-relative references.
- Refresh the documentation contents index and roadmap to record the completed SSE work and link to the new execplan.
- Tidy multiple existing guides (users, testing, Netsuke, complexity, DI, doctest, migration, Netsuke execplan) for wording, wrapping, and table formatting consistency while preserving behaviour descriptions.