### PR TITLE
Normalize Markdown formatting across documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,11 +248,10 @@ project:
 
 - **Mandate caret requirements for all dependencies.** All crate versions
   specified in `Cargo.toml` must use SemVer-compatible caret requirements (e.g.,
-   `some-crate = "1.2.3"` (equivalent to `^1.2.3`). This is Cargo's default and
-   allows for safe,
-  non-breaking updates to minor and patch versions while preventing breaking
-  changes from new major versions. This approach is critical for ensuring build
-  stability and reproducibility.
+  `some-crate = "1.2.3"` (equivalent to `^1.2.3`). This is Cargo's default and
+  allows for safe, non-breaking updates to minor and patch versions while
+  preventing breaking changes from new major versions. This approach is
+  critical for ensuring build stability and reproducibility.
 - **Prohibit unstable version specifiers.** The use of wildcard (`*`) or
   open-ended inequality (`>=`) version requirements is strictly forbidden, as
   they introduce unacceptable risk and unpredictability. Tilde requirements (
@@ -286,7 +285,7 @@ project:
 
 - Use `tracing` for logging and diagnostics. Prefer structured
   `tracing::{trace, debug, info, warn, error}` events and spans over `println!`,
-   `eprintln!`, or direct `log` macros. Add fields for identifiers, state, and
+  `eprintln!`, or direct `log` macros. Add fields for identifiers, state, and
   error context so downstream subscribers can filter and correlate events
   without parsing message text.
 - Use `#[tracing::instrument]` or explicit spans around request handling,

--- a/docs/complexity-antipatterns-and-refactoring-strategies.md
+++ b/docs/complexity-antipatterns-and-refactoring-strategies.md
@@ -40,7 +40,7 @@ of a program by counting decision points that can affect the execution flow.
 Reference [^4] covers that framing. This metric is computed using the
 control-flow graph of the program, where nodes represent indivisible groups of
 commands, and directed edges connect nodes if one command can immediately follow
- another.[^3]
+another.[^3]
 
 Cyclomatic Complexity is often expressed with the formula M=E−N+2P, where E is
 the number of edges, N is the number of nodes, and P is the number of connected
@@ -48,7 +48,7 @@ components (typically 1 for a single program or method).[^3] A simpler
 formulation applies to a single subroutine:
 
 M = number of decision points + 1, where decision points include constructs like
- `if` statements and conditional loops.[^3]
+`if` statements and conditional loops.[^3]
 
 Thresholds and Implications:
 
@@ -200,7 +200,7 @@ attention, much like a physical bumpy road slows down driving.[^9]
 
 The Bumpy Road antipattern, like many software antipatterns, often emerges from
 development practices that prioritize short-term speed over long-term structural
- integrity.[^2] Rushed development cycles, lack of clear design, or cutting
+integrity.[^2] Rushed development cycles, lack of clear design, or cutting
 corners on maintenance can lead to the gradual accumulation of conditional
 logic within a single function.[^2] As new requirements emerge alongside
 additional edge cases, developers might add conditional branches to an existing
@@ -395,7 +395,7 @@ maintainable systems.
 
 Separation of Concerns is a design principle that advocates for dividing a
 computer program into distinct sections, where each section addresses a separate
- concern.[^13] A "concern" is a set of information that affects the code of a
+concern.[^13] A "concern" is a set of information that affects the code of a
 computer program. Modularity is achieved by encapsulating information within a
 section of code that has a well-defined interface.[^13]
 
@@ -473,7 +473,7 @@ prevent the kind of tangled logic that forms Bumpy Roads. By isolating write
 operations (commands) from read operations (queries), and by encouraging
 task-based commands, the system naturally tends towards smaller, more cohesive
 units of behaviour, thus reducing overall cognitive complexity within individual
- components.[^14] The separation allows for independent optimization and
+components.[^14] The separation allows for independent optimization and
 scaling of read and write sides, but more importantly for this discussion, it
 enforces a structural discipline that discourages methods from accumulating
 diverse responsibilities.[^14]

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -547,7 +547,7 @@ Pagination tests are split by contract:
   normative specification for the SSE module
 - [ExecPlan: Implement SSE identifier and replay cursor
   helpers](execplans/1-1-1-implement-sse-identifier-and-replay-cursor-helpers.md)
-   — implementation plan for task 1.1.1
+  — implementation plan for task 1.1.1
 - [ExecPlan: Implement SSE frame and cache-header
   helpers](execplans/1-1-2-sse-frame-and-cache-header-helpers.md) —
   implementation plan for task 1.1.2

--- a/docs/execplans/1-1-1-implement-sse-identifier-and-replay-cursor-helpers.md
+++ b/docs/execplans/1-1-1-implement-sse-identifier-and-replay-cursor-helpers.md
@@ -1,7 +1,7 @@
 # Implement validated SSE event identifier and replay cursor helpers
 
 This ExecPlan (execution plan) is a living document. The sections `Constraints`,
- `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
 and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETE
@@ -252,7 +252,7 @@ SSE specification assigns special meaning to an empty identifier.
   1.1 "Build the shared wire-helper surface".
 - The
   [import-components-from-wildside execplan](import-components-from-wildside.md)
-   is the parent execution plan. Milestone 5 deferred SSE implementation
+  is the parent execution plan. Milestone 5 deferred SSE implementation
   because no authoritative source existed in Wildside; ADR 001 now provides the
   normative contract.
 

--- a/docs/execplans/1-1-2-sse-frame-and-cache-header-helpers.md
+++ b/docs/execplans/1-1-2-sse-frame-and-cache-header-helpers.md
@@ -1,7 +1,7 @@
 # Implement SSE frame and cache-header helpers
 
 This ExecPlan (execution plan) is a living document. The sections `Constraints`,
- `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
 and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETED
@@ -10,7 +10,7 @@ Status: COMPLETED
 
 `actix-v2a` already exposes the first slice of the shared Server-Sent Events
 (SSE) contract from [Architecture Decision Record (ADR) 001][adr-001]: validated
- `EventId` values and `Last-Event-ID` replay cursor parsing. Roadmap task 1.1.2
+`EventId` values and `Last-Event-ID` replay cursor parsing. Roadmap task 1.1.2
 is the next delivery unit in that contract. It adds the wire helpers that
 downstream applications need to emit browser-compatible SSE frames and to mark
 live event-stream responses as non-reusable by intermediaries.
@@ -66,7 +66,7 @@ Success is observable when:
   module file requires a module-level `//!` comment.
 - New code must satisfy the repository lint posture, including deny-level
   Clippy rules such as `expect_used`, `unwrap_used`, `cognitive_complexity`, and
-   `missing_const_for_fn`.
+  `missing_const_for_fn`.
 - File size must remain below the repository guidance of 400 lines per file.
 - Tests must use `rstest` fixtures and parameterized cases where they improve
   clarity. `rstest-bdd` should be used only where scenario structure adds real

--- a/docs/execplans/1-1-3-shared-heartbeat-and-stream-reset-helpers.md
+++ b/docs/execplans/1-1-3-shared-heartbeat-and-stream-reset-helpers.md
@@ -1,7 +1,7 @@
 # Implement shared heartbeat and stream_reset helpers
 
 This ExecPlan (execution plan) is a living document. The sections `Constraints`,
- `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
 and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETED
@@ -70,7 +70,7 @@ Success is observable when:
   module file requires a module-level `//!` comment.
 - New code must satisfy the repository lint posture, including deny-level
   Clippy rules such as `expect_used`, `unwrap_used`, `missing_const_for_fn`, and
-   `cognitive_complexity`.
+  `cognitive_complexity`.
 - File size must remain below the repository guidance of 400 lines per file.
 - Tests must use `rstest` fixtures and parameterized cases where they improve
   clarity. `rstest-bdd` should be used only where scenario structure adds real

--- a/docs/execplans/1-2-1-unit-and-integration-tests-for-the-shared-sse-module.md
+++ b/docs/execplans/1-2-1-unit-and-integration-tests-for-the-shared-sse-module.md
@@ -1,7 +1,7 @@
 # Add unit and integration tests for the shared SSE module
 
 This ExecPlan (execution plan) is a living document. The sections `Constraints`,
- `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
 and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETE
@@ -26,7 +26,7 @@ two forms of evidence:
 Success is observable when all roadmap-mandated behaviours are proven:
 identifier validation, `Last-Event-ID` parsing, frame formatting, cache
 headers, heartbeat output, and `stream_reset` output. It is also observable when
- `make check-fmt`, `make lint`, and `make test` pass with the new coverage, and
+`make check-fmt`, `make lint`, and `make test` pass with the new coverage, and
 when `docs/roadmap.md` marks task 1.2.1 done only after the implementation is
 complete.
 
@@ -81,9 +81,9 @@ This plan was approved before implementation began.
 
 Property-based testing (for example, `proptest`) for `EventId` byte-validation
 exhaustiveness and `apply_event_stream_cache_control` idempotence over arbitrary
- `Vec<SseHeader>` state is **out of scope for this plan**. The discrete
+`Vec<SseHeader>` state is **out of scope for this plan**. The discrete
 `rstest` parameterized cases cover the specified forbidden-byte set (`\n`, `\r`,
- `\0`) and the empty-string guard; idempotence is verified over hand-crafted
+`\0`) and the empty-string guard; idempotence is verified over hand-crafted
 initial states (empty, single pre-existing entry, multiple entries). Exhaustive
 property coverage is tracked in
 [issue `#18`](https://github.com/example-org/actix-v2a/issues/18) and deferred

--- a/docs/execplans/adopt-netsuke.md
+++ b/docs/execplans/adopt-netsuke.md
@@ -1,7 +1,7 @@
 # Adopt Netsuke as the Repository Build Driver
 
 This ExecPlan (execution plan) is a living document. The sections `Constraints`,
- `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
 and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETE
@@ -13,7 +13,7 @@ GitHub Actions workflow at `.github/workflows/ci.yml`. The goal is to pilot
 Netsuke as the primary build driver for this simple Rust repository while
 dogfooding Netsuke before package-manager distribution is available. After this
 change, a developer can run `netsuke build check-fmt`, `netsuke build lint`, and
- `netsuke build test` from the repository root and receive the same quality
+`netsuke build test` from the repository root and receive the same quality
 gate behaviour currently exposed by `make check-fmt`, `make lint`, and
 `make test`.
 
@@ -256,7 +256,7 @@ Actions.
 
 The stop hook at
 `https://github.com/example-org/agent-helper-scripts/blob/main/hooks/post-turn-quality-stop-hook.py`
- must become build-driver aware before repositories can retire Makefile shims.
+must become build-driver aware before repositories can retire Makefile shims.
 The current script assumes Make at the data-model, discovery, execution, and
 reporting layers:
 

--- a/docs/execplans/import-components-from-wildside.md
+++ b/docs/execplans/import-components-from-wildside.md
@@ -393,7 +393,7 @@ Implementation must not begin until the following gates are satisfied:
   `src/idempotency/`.
 - [x] 2026-04-02 12:35 BST: completed Milestone 3 by adding a transport-agnostic
   shared API error envelope in `src/error.rs` plus an Actix responder adapter in
-   `src/http/error.rs` with status mapping, trace identifier propagation, and
+  `src/http/error.rs` with status mapping, trace identifier propagation, and
   internal error redaction.
 - [x] 2026-04-02 12:35 BST: completed Milestone 4 by adding reusable `utoipa`
   schema fragments in `src/openapi/schemas.rs` and BDD coverage that verifies
@@ -489,7 +489,7 @@ machine-local and sibling-checkout paths from the finished documentation set
 and recording the completed SSE milestone.
 
 Final gate outcomes for this implementation pass were green for the Rust gates (
- `make check-fmt`, `make lint`, and `make test`) and green for the
+`make check-fmt`, `make lint`, and `make test`) and green for the
 documentation gates (`make fmt`, `make markdownlint`, and `make nixie`) after
 the final documentation updates landed. `coderabbit review --agent` also
 reported zero findings for the closure milestone before the roadmap was marked

--- a/docs/execplans/portwildsidepagination.md
+++ b/docs/execplans/portwildsidepagination.md
@@ -1,7 +1,7 @@
 # Port Wildside pagination documentation hardening
 
 This ExecPlan (execution plan) is a living document. The sections `Constraints`,
- `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
 and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETE
@@ -263,8 +263,8 @@ began after user approval.
 
 - Observation: The post-turn hook runs with a reduced `PATH` that did not
   include the existing Cargo installation directory. Evidence: The hook reported
-   `make: cargo: No such file or directory` while running `make check-fmt lint`;
-   `env PATH=/usr/bin:/bin make check-fmt lint` reproduced the same environment
+  `make: cargo: No such file or directory` while running `make check-fmt lint`;
+  `env PATH=/usr/bin:/bin make check-fmt lint` reproduced the same environment
   shape. Impact: The Makefile now prepends `$HOME/.cargo/bin` to Cargo recipe
   `PATH` values, while continuing to call `cargo` by name. No shim, install
   step, or recreated system script was introduced.
@@ -379,7 +379,7 @@ status and trace header assertions to the individual tests. The stricter lint
 run also exposed test helper `expect` calls; these were converted to fallible
 helpers and the review-response change passed
 `cargo test --test pagination_documentation_bdd`, `make check-fmt`, `make lint`,
- `make markdownlint`, and `make test`.
+`make markdownlint`, and `make test`.
 
 ## Context and orientation
 

--- a/docs/netsuke-users-guide.md
+++ b/docs/netsuke-users-guide.md
@@ -382,7 +382,7 @@ Apply filters using the pipe `|` operator: `{{ value | filter_name(args...) }}`
 
 - `with_suffix(new_suffix, count=1, sep='.')`: Replaces the last `count`
   dot-separated extensions. `{{ 'archive.tar.gz' | with_suffix('.zip', 2) }}` ->
-   `"archive.zip"`
+  `"archive.zip"`
 
 - `relative_to(base_path)`: Makes a path relative.
   `{{ '/a/b/c' | relative_to('/a/b') }}` -> `"c"`

--- a/docs/reliable-testing-in-rust-via-dependency-injection.md
+++ b/docs/reliable-testing-in-rust-via-dependency-injection.md
@@ -3,7 +3,7 @@
 Writing robust, reliable, and parallelizable tests requires an intentional
 approach to handling external dependencies such as environment variables, the
 filesystem, or the system clock. Functions that directly call `std::env::var` or
- `SystemTime::now()` are difficult to test because they depend on global,
+`SystemTime::now()` are difficult to test because they depend on global,
 non-deterministic state.
 
 This leads to several problems:

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -29,17 +29,17 @@ day-to-day contributors and omits generated or implementation-specific detail.
 
 Table: Top-level repository files and their responsibilities.
 
-| Path | Responsibility |
-| --- | --- |
-| `AGENTS.md` | Repository instructions for agents and maintainers. |
-| `Cargo.toml` | Workspace manifest and crate metadata. |
-| `Cargo.lock` | Locked dependency versions for reproducible builds. |
-| `Makefile` | Stable task entry points for build, lint, and formatting workflows. |
-| `Netsukefile` | Build-driver configuration consumed by `netsuke`. |
-| `README.md` | Public overview and first-stop entry point for new readers. |
-| `clippy.toml` | Clippy configuration and lint policy. |
-| `codecov.yml` | Coverage configuration. |
-| `rust-toolchain.toml` | Pinned Rust toolchain selection. |
+| Path                  | Responsibility                                                      |
+| --------------------- | ------------------------------------------------------------------- |
+| `AGENTS.md`           | Repository instructions for agents and maintainers.                 |
+| `Cargo.toml`          | Workspace manifest and crate metadata.                              |
+| `Cargo.lock`          | Locked dependency versions for reproducible builds.                 |
+| `Makefile`            | Stable task entry points for build, lint, and formatting workflows. |
+| `Netsukefile`         | Build-driver configuration consumed by `netsuke`.                   |
+| `README.md`           | Public overview and first-stop entry point for new readers.         |
+| `clippy.toml`         | Clippy configuration and lint policy.                               |
+| `codecov.yml`         | Coverage configuration.                                             |
+| `rust-toolchain.toml` | Pinned Rust toolchain selection.                                    |
 
 ## Source code
 
@@ -67,8 +67,8 @@ The `tests/` tree holds integration, BDD-style, and snapshot coverage:
 - `tests/snapshots/` contains checked-in snapshot expectations.
 - `tests/*_bdd.rs` and `tests/*_tests.rs` cover externally observable behaviour.
 
-Prefer adding tests beside the feature they exercise. Shared fixtures belong
-in `tests/support/` rather than in ad hoc helpers spread across suites.
+Prefer adding tests beside the feature they exercise. Shared fixtures belong in
+`tests/support/` rather than in ad hoc helpers spread across suites.
 
 ## Documentation
 
@@ -86,8 +86,8 @@ The `docs/` tree holds the long-lived project knowledge base:
 - `docs/execplans/` contains living execution plans and retrospectives.
 
 Keep design intent, decision records, and procedural guidance in the most
-specific document that can own it. Avoid duplicating repository layout
-guidance outside `docs/repository-layout.md`.
+specific document that can own it. Avoid duplicating repository layout guidance
+outside `docs/repository-layout.md`.
 
 ## Tooling and automation
 

--- a/docs/rust-doctest-dry-guide.md
+++ b/docs/rust-doctest-dry-guide.md
@@ -15,7 +15,7 @@ the power and the inherent limitations of doctests.
 
 At its heart, `rustdoc` treats each documentation test not as a snippet of code
 running within the library's own context, but as an entirely separate, temporary
- crate.[^1] When a developer executes
+crate.[^1] When a developer executes
 
 `cargo test --doc`, `rustdoc` initiates a multi-stage process for every code
 block found in the documentation comments[^3]:
@@ -276,8 +276,8 @@ table provides a comparative reference for the most common doctest attributes.
 
 - `edition20xx`: This attribute allows an example to be tested against a
   specific Rust edition. This is important for crates that support multiple
-  editions and need to demonstrate edition-specific features or migration paths.
-   [^4]
+  editions and need to demonstrate edition-specific features or migration
+  paths.[^4]
 
 ## The DRY principle in doctests: managing shared and complex logic
 
@@ -407,7 +407,7 @@ pub struct UnixSocket;
 ```
 
 This `any` directive ensures the struct is compiled either when the target OS is
- `unix` OR when `rustdoc` is running. This correctly makes the item visible in
+`unix` OR when `rustdoc` is running. This correctly makes the item visible in
 the generated HTML. However, it is crucial to understand that this **does not**
 make the doctest for `UnixSocket` pass on non-Unix platforms.
 
@@ -580,8 +580,8 @@ real-world challenges when working with doctests.
 
   `#[test]` function in a temporary file or test module. This allows the
   developer to leverage the full power of the IDE. Once the code is working
-  correctly, it can be copied into the doc comment, and the necessary
-  formatting (`///`, `#`, etc.) can be applied.[^15]
+  correctly, it can be copied into the doc comment, and the necessary formatting
+  (`///`, `#`, etc.) can be applied.[^15]
 
 ## Conclusion and recommendations
 
@@ -656,8 +656,8 @@ July 15, 2025, <https://doc.rust-lang.org/rustdoc/documentation-tests.html>
 [^14]: Stack Overflow — Conditionally executing a module-level doctest,
 accessed on July 15, 2025,
 <https://stackoverflow.com/questions/50312190/how-can-i-conditionally-execute-a-module-level-doctest-based-on-a-feature-flag>
- Stack Overflow — Conditional compilation with doctests, accessed on July 15,
-2025,
+Stack Overflow — Conditional compilation with doctests, accessed on
+July 15, 2025,
 <https://stackoverflow.com/questions/38292741/how-would-one-achieve-conditional-compilation-with-rust-projects-that-have-docte>
 [^15]: Reddit — Preferred approaches for doc tests, accessed on July 15,
 2025,

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -729,7 +729,7 @@ async fn async_data_fetcher() -> String {
 
 The example above uses `async_std::task::sleep` purely as a convenient
 stand-in; the fixture may call into whichever runtime the project adopts because
- `rstest` simply awaits the returned future.
+`rstest` simply awaits the returned future.
 
 ### B. Writing asynchronous tests (`async fn` with `#[rstest]`)
 


### PR DESCRIPTION
## Summary

This branch normalizes Markdown formatting across the documentation by
running `make fmt` (mdformat, mdtablefix, and `markdownlint-cli2 --fix`)
over the repository and committing the resulting churn in a single,
content-free change. Fifteen files gain paragraph rewraps at 80 columns,
padded table cells, and normalized footnote spacing. Landing this
separately keeps future documentation pull requests free of formatter
noise.

## Review walkthrough

The whole branch is one formatting-only commit
([`2e61dca`](https://github.com/leynos/actix-v2a/commit/2e61dca6cb8fb7b164f8ac2a50a37d155a5332d5)).
A word-level comparison (whitespace squeezed) confirms the prose is
unchanged apart from spacing.

- [docs/repository-layout.md](https://github.com/leynos/actix-v2a/blob/2e61dca6cb8fb7b164f8ac2a50a37d155a5332d5/docs/repository-layout.md)
  shows the table-padding normalization applied by mdtablefix.
- [docs/rust-doctest-dry-guide.md](https://github.com/leynos/actix-v2a/blob/2e61dca6cb8fb7b164f8ac2a50a37d155a5332d5/docs/rust-doctest-dry-guide.md)
  shows the footnote-spacing normalization (for example, `paths. [^4]`
  becomes `paths.[^4]`).
- The remaining files
  ([AGENTS.md](https://github.com/leynos/actix-v2a/blob/2e61dca6cb8fb7b164f8ac2a50a37d155a5332d5/AGENTS.md),
  the execplans under
  [docs/execplans/](https://github.com/leynos/actix-v2a/tree/2e61dca6cb8fb7b164f8ac2a50a37d155a5332d5/docs/execplans),
  and other guides under `docs/`) contain only 80-column paragraph
  rewraps.

## Validation

- `make fmt`: idempotent; a second run produces no further changes
- `make markdownlint`: `Summary: 0 error(s)` across 24 files
- `make nixie`: all Mermaid diagrams validated successfully
- Word-level diff check (whitespace squeezed): no prose content changes

## Notes

Two small rewrap hunks in `docs/developers-guide.md` and
`docs/netsuke-users-guide.md` also exist identically on the
`netsuke-bump-2026-07-08` branch; the identical content merges cleanly
in either order.
