### PR TITLE
Bump Netsuke to current main and adopt manifest-time action selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Netsuke
         run: >-
           cargo install --git https://github.com/leynos/netsuke.git
-          --rev 2fe314a58d7311758640b3daa086c401d79838cf
+          --rev bb1b6b66820f0088286272a25aa990a281602ab2
           netsuke --locked
       - name: Show Netsuke version
         run: netsuke --version

--- a/Netsukefile
+++ b/Netsukefile
@@ -8,7 +8,7 @@ vars:
 
 actions:
   - name: all
-    sources:
+    deps:
       - check-fmt
       - lint
       - test
@@ -29,30 +29,51 @@ actions:
       sh -e -c 'PATH="{{ prepend_path }}:$$PATH"
       "$${CARGO:-cargo}" clean'
 
+  # Tool availability is probed at manifest time with command_available, so
+  # invoke Netsuke with cargo and local tool directories on PATH (the
+  # Makefile targets do this) for optional tooling to be discovered.
   - name: test
+    when: command_available("cargo-nextest")
     command: >-
       sh -e -c 'PATH="{{ prepend_path }}:$$PATH";
-      RUSTFLAGS="{{ rust_flags }} $${RUST_FLAGS:-}";
-      if "$${CARGO:-cargo}" nextest --version >/dev/null 2>&1; then
       echo "[netsuke:test] cargo-nextest found; using nextest runner";
+      RUSTFLAGS="{{ rust_flags }} $${RUST_FLAGS:-}";
       RUSTFLAGS="$$RUSTFLAGS" "$${CARGO:-cargo}" nextest run {{ cargo_flags }} $${BUILD_JOBS:-};
-      RUSTFLAGS="$$RUSTFLAGS" "$${CARGO:-cargo}" test --doc --workspace --all-features;
-      else
-      echo "[netsuke:test] cargo-nextest not found; falling back to cargo test";
-      RUSTFLAGS="$$RUSTFLAGS" "$${CARGO:-cargo}" test {{ cargo_flags }} $${BUILD_JOBS:-};
-      fi'
+      RUSTFLAGS="$$RUSTFLAGS" "$${CARGO:-cargo}" test --doc --workspace --all-features'
 
-  - name: lint
+  - name: test
+    when: not command_available("cargo-nextest")
+    command: >-
+      sh -e -c 'PATH="{{ prepend_path }}:$$PATH";
+      echo "[netsuke:test] cargo-nextest not found; falling back to cargo test";
+      RUSTFLAGS="{{ rust_flags }} $${RUST_FLAGS:-}" "$${CARGO:-cargo}" test {{ cargo_flags }} $${BUILD_JOBS:-}'
+
+  - name: clippy-lint
     command: >-
       sh -e -c 'PATH="{{ prepend_path }}:$$PATH";
       RUSTDOCFLAGS="{{ rustdoc_flags }} $${RUSTDOC_FLAGS:-}" "$${CARGO:-cargo}" doc --no-deps;
-      "$${CARGO:-cargo}" clippy {{ cargo_flags }} -- {{ rust_flags }} $${RUST_FLAGS:-};
-      if command -v whitaker >/dev/null 2>&1; then
+      "$${CARGO:-cargo}" clippy {{ cargo_flags }} -- {{ rust_flags }} $${RUST_FLAGS:-}'
+
+  # Both variants depend on clippy-lint so lint work stays sequential and
+  # benefits from the shared build cache.
+  - name: whitaker-lint
+    when: command_available("whitaker")
+    deps: clippy-lint
+    command: >-
+      sh -e -c 'PATH="{{ prepend_path }}:$$PATH";
       echo "[netsuke:lint] whitaker found; running whitaker lint";
-      RUSTFLAGS="{{ rust_flags }} $${RUST_FLAGS:-}" whitaker --all -- {{ cargo_flags }};
-      else
-      echo "[netsuke:lint] whitaker not found on PATH; skipping whitaker lint. Install whitaker to run this check.";
-      fi'
+      RUSTFLAGS="{{ rust_flags }} $${RUST_FLAGS:-}" whitaker --all -- {{ cargo_flags }}'
+
+  - name: whitaker-lint
+    when: not command_available("whitaker")
+    deps: clippy-lint
+    command: >-
+      sh -e -c 'echo "[netsuke:lint] whitaker not found on PATH;
+      skipping whitaker lint. Install whitaker to run this check."'
+
+  - name: lint
+    deps: whitaker-lint
+    command: "true"
 
   - name: typecheck
     command: >-

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -231,7 +231,7 @@ Netsuke before running repository gates:
 ```bash
 sudo dnf install ninja-build
 cargo install --git https://github.com/example-org/netsuke.git \
-  --rev 2fe314a58d7311758640b3daa086c401d79838cf \
+  --rev bb1b6b66820f0088286272a25aa990a281602ab2 \
   netsuke --locked
 ```
 
@@ -547,7 +547,7 @@ Pagination tests are split by contract:
   normative specification for the SSE module
 - [ExecPlan: Implement SSE identifier and replay cursor
   helpers](execplans/1-1-1-implement-sse-identifier-and-replay-cursor-helpers.md)
-   — implementation plan for task 1.1.1
+  — implementation plan for task 1.1.1
 - [ExecPlan: Implement SSE frame and cache-header
   helpers](execplans/1-1-2-sse-frame-and-cache-header-helpers.md) —
   implementation plan for task 1.1.2

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -251,16 +251,25 @@ Override Cargo by exporting `CARGO` before invoking Netsuke:
 CARGO=/path/to/cargo netsuke build test
 ```
 
-The `test` action detects `cargo-nextest` through Cargo. Install
-`cargo-nextest` to `$HOME/.cargo/bin` to enable `netsuke build test` to use
-nextest.
+Optional tooling is probed at manifest time. The `test` and `whitaker-lint`
+actions use the `command_available` predicate in `when` clauses to select
+between complementary action variants while Netsuke loads the manifest, so only
+the applicable variant reaches the generated Ninja file. Because the probe
+resolves executables against the PATH of the Netsuke process itself, invoke
+Netsuke with the Cargo and local tool directories on `PATH`; the Makefile
+targets already do this.
+
+Install `cargo-nextest` to `$HOME/.cargo/bin` to enable `netsuke build test` to
+use nextest:
 
 ```bash
 cargo install cargo-nextest
 ```
 
-If `cargo-nextest` is absent, `netsuke build test` falls back to `cargo test`
-and still runs doctests.
+If `cargo-nextest` is absent when the manifest loads, `netsuke build test`
+selects the `cargo test` fallback variant instead. Similarly,
+`netsuke build lint` runs `whitaker` after Clippy when it is available and
+prints a skip notice otherwise.
 
 Markdown linting uses `MDLINT`, resolved through the same scoped prepend. In
 the standard development environment, `markdownlint-cli2` resolves from

--- a/docs/netsuke-users-guide.md
+++ b/docs/netsuke-users-guide.md
@@ -238,14 +238,20 @@ targets:
 - `recipe`: How to build the target. Defined by one of `rule`, `command`, or
   `script` (mutually exclusive).
 
-- `sources`: Input file path(s) (`StringOrList`). If a source matches another
-  target's `name`, an implicit dependency is created.
+- `sources`: Input file path(s) (`StringOrList`). Sources are explicit recipe
+  inputs: they are passed to `$in` and `{{ ins }}` and trigger rebuilds when
+  changed.
 
-- `deps` (Optional): Explicit target dependencies (`StringOrList`). Changes
-  trigger rebuilds.
+- `deps` (Optional): Implicit target dependencies (`StringOrList`). Changes
+  trigger rebuilds, but these paths are not passed to `$in` or `{{ ins }}`.
+  Maps to Ninja `|`.
 
 - `order_only_deps` (Optional): Dependencies that must run first but whose
   changes don't trigger rebuilds (`StringOrList`). Maps to Ninja `||`.
+
+Cycle detection traverses `sources` and `deps`, because both classes affect the
+build graph and rebuild freshness. `order_only_deps` only enforce build
+ordering and do not participate in Netsuke's cycle detection.
 
 - `vars` (Optional): Target-specific variables that override global `vars`.
 
@@ -285,9 +291,12 @@ Netsuke processes the manifest in stages:
    `serde_json::Value`).
 
 2. Template Expansion (`foreach`, `when`): Evaluate `foreach` expressions to
-   generate multiple target definitions. The `item` (and optional `index`)
-   become available in the context. Evaluate `when` expressions to
-   conditionally include/exclude targets.
+   generate multiple target or action definitions. The `item` (and optional
+   `index`) become available in the context. Evaluate `when` expressions to
+   conditionally include/exclude entries (`when` can exclude both targets and
+   actions). This is a manifest-time selection step; skipped entries are
+   removed before Netsuke builds the typed manifest AST, creates its IR, emits
+   `build.ninja`, or runs Ninja.
 
 3. Deserialisation to AST: Convert the expanded intermediate structure into
    Netsuke's typed Rust structs (`NetsukeManifest`, `Target`, etc.).
@@ -298,7 +307,8 @@ Netsuke processes the manifest in stages:
 
 ### `foreach` and `when`
 
-These keys enable generating multiple similar targets programmatically.
+These keys enable generating multiple similar targets or actions
+programmatically.
 
 ```yaml
 targets:
@@ -315,11 +325,33 @@ targets:
 
 ```
 
+```yaml
+actions:
+  # Generate named test actions, skipping disabled suites.
+  - foreach:
+      - unit
+      - integration
+      - disabled
+    when: item != 'disabled'
+    name: "test-{{ item }}"
+    command: "cargo test --test {{ item }}"
+```
+
 - `foreach`: A Jinja expression evaluating to a list (or any iterable). A
-  target definition will be generated for each item.
+  target or action definition will be generated for each item.
 
 - `when` (Optional): A Jinja expression evaluating to a boolean. If false,
-  the target generated for the current `item` is skipped.
+  the target or action generated for the current `item` is skipped. `when` may
+  also appear without `foreach` to include or exclude a single entry.
+
+`foreach` and `when` do not create build-time branches. They decide which
+manifest entries exist while Netsuke loads the manifest. The generated Ninja
+file contains only the selected targets and actions, so a skipped entry cannot
+contribute rules, outputs, dependencies, defaults, or command text later in the
+build pipeline.
+
+When a decision must happen while a target is being built, put that branching
+inside the recipe command or script instead.
 
 ### User-defined Macros
 
@@ -382,7 +414,7 @@ Apply filters using the pipe `|` operator: `{{ value | filter_name(args...) }}`
 
 - `with_suffix(new_suffix, count=1, sep='.')`: Replaces the last `count`
   dot-separated extensions. `{{ 'archive.tar.gz' | with_suffix('.zip', 2) }}` ->
-   `"archive.zip"`
+  `"archive.zip"`
 
 - `relative_to(base_path)`: Makes a path relative.
   `{{ '/a/b/c' | relative_to('/a/b') }}` -> `"c"`
@@ -465,6 +497,31 @@ Apply filters using the pipe `|` operator: `{{ value | filter_name(args...) }}`
   `netsuke::jinja::which::not_found` along with a preview of the scanned
   `PATH`. Supplying unknown keyword arguments or invalid values raises
   `netsuke::jinja::which::args`.
+
+Use `command_available(name, **kwargs)` when absence should select another
+manifest-time branch instead of failing the render. It uses the same resolver
+and cache as `which`, accepts the same keyword arguments, returns `true` when
+at least one executable is found, and returns `false` for absent commands.
+Invalid arguments still raise `netsuke::jinja::which::args`.
+
+Use `command_available` in manifest-time `when` clauses when optional tooling
+selects between actions:
+
+```yaml
+actions:
+  - name: test-fast
+    command: cargo nextest run
+    when: command_available("cargo-nextest")
+  - name: test-fast
+    command: cargo test
+    when: not command_available("cargo-nextest")
+```
+
+Only the selected action reaches the typed manifest and generated Ninja file.
+Top-level actions selected this way still keep the normal implicit
+`phony: true` behaviour. The `which` filter remains the right choice when a
+missing tool should stop the manifest render; the predicate is for optional
+toolchains and complementary branches.
 
 **Impurity:** Filters like `shell` and functions like `fetch` interact with the
 outside world. Netsuke tracks this "impurity". Impure templates might affect


### PR DESCRIPTION
## Summary

This branch moves the pinned Netsuke revision from `2fe314a5` to
[`bb1b6b66`](https://github.com/leynos/netsuke/commit/bb1b6b66820f0088286272a25aa990a281602ab2),
the current head of `leynos/netsuke` `main` (30 commits ahead), and
refines the `Netsukefile` to use the actions-target improvements that
landed in that range:

- manifest-time `when` selection on top-level actions without `foreach`
  (roadmap 3.14.2 upstream);
- lowering of target- and action-level `deps:` into Ninja implicit
  dependency edges (3.14.3 upstream); and
- the non-throwing `command_available` executable probe for `when`
  clauses (3.14.4 upstream).

The shell-level `if command -v …` branching inside the `test` and
`lint` actions is replaced with complementary action variants selected
while Netsuke loads the manifest, so only the applicable variant
reaches the generated Ninja file. The dated revision references in the
adoption execplan's progress log are left untouched as historical
record.

## Review walkthrough

The branch is two commits: the version bump
([`4fa0880`](https://github.com/leynos/actix-v2a/commit/4fa0880))
followed by the manifest refinement
([`78d0dee`](https://github.com/leynos/actix-v2a/commit/78d0dee08d07bd438ea78579318e9dc6c04b934f)).

- Start with
  [Netsukefile](https://github.com/leynos/actix-v2a/blob/78d0dee08d07bd438ea78579318e9dc6c04b934f/Netsukefile)
  to see the new shape: two `test` variants gated on
  `command_available("cargo-nextest")`; `lint` decomposed into
  `clippy-lint` plus two `whitaker-lint` variants, chained with `deps:`
  so lint work stays sequential and benefits from the shared build
  cache; and the `all` aggregate declaring its prerequisites with
  `deps:` rather than `sources:`.
- Then review
  [.github/workflows/ci.yml](https://github.com/leynos/actix-v2a/blob/78d0dee08d07bd438ea78579318e9dc6c04b934f/.github/workflows/ci.yml)
  for the revision pin in the install step. CI installs no optional
  tooling, so the fallback variants (`cargo test`, whitaker skip
  notice) are selected there.
- [docs/developers-guide.md](https://github.com/leynos/actix-v2a/blob/78d0dee08d07bd438ea78579318e9dc6c04b934f/docs/developers-guide.md)
  documents the behavioural nuance: `command_available` resolves
  against the PATH of the Netsuke process itself rather than the
  recipe-level prepended PATH, so Netsuke should be invoked with the
  Cargo and local tool directories on PATH (the Makefile targets
  already do this).
- Finish with
  [docs/netsuke-users-guide.md](https://github.com/leynos/actix-v2a/blob/78d0dee08d07bd438ea78579318e9dc6c04b934f/docs/netsuke-users-guide.md),
  where the vendored guide excerpts covering `sources` versus `deps`
  semantics, `foreach`/`when` on actions, and `command_available` are
  updated to match the pinned revision.

## Validation

All gates ran at the new revision, installed locally via
`cargo install --git … --rev bb1b6b66 netsuke --locked`:

- `netsuke manifest -`: validates; with `cargo-nextest` and `whitaker`
  on PATH the nextest and whitaker variants are selected, and with a
  stripped PATH (`PATH=/usr/bin:/bin`) the fallback variants are
  selected
- `make check-fmt`: passes
- `make lint`: passes; Ninja runs the `clippy-lint` → `whitaker-lint`
  → `lint` chain sequentially
- `make test`: 95 tests plus 26 doctests pass via the
  manifest-selected nextest variant
- `make markdownlint`: `Summary: 0 error(s)`
- `make nixie`: all Mermaid diagrams validated successfully

## Notes

Two small formatter rewrap hunks in `docs/developers-guide.md` and
`docs/netsuke-users-guide.md` also exist identically on the
`markdown-formatting-2026-07-08` branch (#50); the identical content
merges cleanly in either order.
