### PR TITLE
Adopt the Whitaker Dylint suite in the lint gate and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
+      WHITAKER_INSTALLER_VERSION: '0.2.5'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: Setup Rust
@@ -60,6 +61,24 @@ jobs:
         run: >-
           set -o pipefail;
           netsuke --verbose build nixie 2>&1 | tee /tmp/netsuke-nixie-actix-v2a-adopt-netsuke-ci.out
+      - name: Cache Whitaker installer
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        with:
+          path: |
+            ~/.cargo/bin/whitaker-installer
+            ~/.cache/cargo-binstall
+          key: whitaker-installer-${{ runner.os }}-${{ runner.arch }}-${{ env.WHITAKER_INSTALLER_VERSION }}
+      - name: Install Whitaker Dylint suite
+        run: |
+          if ! command -v whitaker-installer >/dev/null 2>&1; then
+            if cargo binstall --version >/dev/null 2>&1; then
+              cargo binstall --no-confirm --locked "whitaker-installer@${WHITAKER_INSTALLER_VERSION}"
+            else
+              echo "cargo-binstall unavailable; building whitaker-installer from crates.io"
+              cargo install --locked whitaker-installer --version "${WHITAKER_INSTALLER_VERSION}"
+            fi
+          fi
+          whitaker-installer
       - name: Lint
         run: >-
           set -o pipefail;

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ clean: ## Remove build artefacts
 test: ## Run tests with warnings treated as errors
 	PATH="$(PREPEND_PATH):$(PATH)" $(NETSUKE) build test
 
-lint: ## Run Clippy with warnings denied
+lint: ## Run Clippy and the Whitaker Dylint suite with warnings denied
 	PATH="$(PREPEND_PATH):$(PATH)" $(NETSUKE) build lint
 
 typecheck: ## Type-check without building

--- a/Netsukefile
+++ b/Netsukefile
@@ -54,22 +54,14 @@ actions:
       RUSTDOCFLAGS="{{ rustdoc_flags }} $${RUSTDOC_FLAGS:-}" "$${CARGO:-cargo}" doc --no-deps;
       "$${CARGO:-cargo}" clippy {{ cargo_flags }} -- {{ rust_flags }} $${RUST_FLAGS:-}'
 
-  # Both variants depend on clippy-lint so lint work stays sequential and
-  # benefits from the shared build cache.
+  # Depends on clippy-lint so lint work stays sequential and benefits
+  # from the shared build cache. Whitaker is mandatory: the suite is a
+  # required gate, and $WHITAKER allows overriding the binary.
   - name: whitaker-lint
-    when: command_available("whitaker")
     deps: clippy-lint
     command: >-
       sh -e -c 'PATH="{{ prepend_path }}:$$PATH";
-      echo "[netsuke:lint] whitaker found; running whitaker lint";
-      RUSTFLAGS="{{ rust_flags }} $${RUST_FLAGS:-}" whitaker --all -- {{ cargo_flags }}'
-
-  - name: whitaker-lint
-    when: not command_available("whitaker")
-    deps: clippy-lint
-    command: >-
-      sh -e -c 'echo "[netsuke:lint] whitaker not found on PATH;
-      skipping whitaker lint. Install whitaker to run this check."'
+      RUSTFLAGS="{{ rust_flags }} $${RUST_FLAGS:-}" "$${WHITAKER:-whitaker}" --all -- {{ cargo_flags }}'
 
   - name: lint
     deps: whitaker-lint


### PR DESCRIPTION
## Summary

This pull request adopts the Whitaker Dylint suite as part of the estate-wide rollout (see leynos/netsuke#410 for the reference adoption). The Netsukefile's `lint` action previously ran the suite only when the wrapper happened to be on `PATH`, silently skipping it otherwise; it now runs the suite unconditionally after Clippy with warnings denied, so a missing installation fails the gate instead of passing quietly. The binary is overridable through the `WHITAKER` environment variable, matching the existing `CARGO` convention. CI installs the pinned `whitaker-installer` (0.2.5) before the lint step, preferring `cargo binstall` with a `cargo install --locked` fallback, and caches the installer binary keyed on its version.

The suite reported no findings on this codebase, so no code changes and no `dylint.toml` exclusions were required.

## Review walkthrough

- [`Netsukefile`](https://github.com/leynos/actix-v2a/blob/adopt-whitaker/Netsukefile) — mandatory Whitaker invocation in the `lint` action.
- [`Makefile`](https://github.com/leynos/actix-v2a/blob/adopt-whitaker/Makefile) — updated `lint` help text.
- [`.github/workflows/ci.yml`](https://github.com/leynos/actix-v2a/blob/adopt-whitaker/.github/workflows/ci.yml) — installer cache and hardened install step ahead of the Lint step.

## Validation

- `make check-fmt` — passed.
- `make lint` — passed (`cargo doc`, Clippy, and the Whitaker suite, warnings denied; zero findings).
- `make typecheck` — passed.
- `make test` — passed (nextest 168/168; doctests 26/26).
- `make markdownlint` — passed (24 files, no errors).
- `make nixie` — passed (all Mermaid diagrams validated).
